### PR TITLE
 [css-refactoring/combat_tracker] Move style from js into css.

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -2,15 +2,12 @@
 function init_combat_tracker(){
 	ct=$("<div id='combat_tracker'/>");
 	toggle=$("<button>COMBAT</button>");
-	toggle.css('width',"75px");
 	toggle.click(function(){
 		if($("#combat_tracker_inside").is(":visible")){
 			$("#combat_tracker_inside").hide();
-			$("#combat_tracker").css("height","20px");
 		}
 		else{
 			$("#combat_tracker_inside").show();
-			$("#combat_tracker").css("height","450px");
 		}
 	});
 	ct.append(toggle);
@@ -97,16 +94,13 @@ function init_combat_tracker(){
 		
 		ct_inside.append(buttons);
 	}
-	ct.css('position','fixed');
-	if(window.DM)
-		ct.css('width','200px');
-	else
-		ct.css('width','150px');
-	ct.css('height','20px');
-	ct.css('left','5px');
-	ct.css('top','40px');
-	ct.css('z-index','99999000');
-	
+
+	if(window.DM) {
+		ct.addClass('tracker-dm');
+	} else {
+		ct.addClass('tracker-player');
+	}
+
 	$("#site").append(ct);
 }
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -24,7 +24,7 @@ body > button,
     box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
     padding: 2px 8px;
     transition: color 0.3s ease-in-out, background 0.3s ease-in-out;
-}   
+}
 
 button[id$='-button']:hover,
 button[id$='_button']:hover,
@@ -232,4 +232,20 @@ div#scene_properties form > div {
 .stp-btn {
     width: 100%;
     height: 34px;
+}
+
+#combat_tracker {
+    position: fixed;
+    height: 450px;
+    left: 5px;
+    top: 40px;
+    z-index: 99999000;
+}
+
+.tracker-dm {
+    width: 200px;
+}
+
+.tracker-player {
+    width: 150px;
 }


### PR DESCRIPTION
Moved most of the style "as is" from js to css.

Also removed the `height: 20px` when the element is hidden. If it is hidden it doesn't matter how tall it is. 

This refactoring includes also a minor logic change: it will add a class to the element rather than adding inline css.