### PR TITLE
Add 4-way cursor when mouseover tokens

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -265,6 +265,7 @@ div#scene_properties form > div {
 }
 
 .token {
+    cursor: move;
     overflow: visible !important;
     border-radius: 50%;
     transition: box-shadow 0.5 ease-in-out;
@@ -512,6 +513,10 @@ div#scene_properties form > div {
 .add-party-container {
     padding: 10px;
     text-align: right;
+}
+
+.token.ui-draggable-disabled {
+    cursor: default;
 }
 
 .token .condition-img {


### PR DESCRIPTION
Intended behavior:
-When the mouse cursor is above a token, change the cursor to the 4-way cursor, otherwise revert to existing cursor settings.
-If the token is set to "lock token in position", keep the default cursor
-If a position locked token is attempted to be moved, give the nope :no_entry_sign: cursor (as default with jquery draggable)