### PR TITLE
Add ability to set default custom images for monsters

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1204,6 +1204,8 @@ function init_ui() {
 	init_combat_tracker();
 
 	token_menu();
+	build_token_image_map_menu();
+	load_custom_image_mapping();
 
 
 	window.WaypointManager=new WaypointManagerClass();

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -24,7 +24,34 @@ function init_monster_panel() {
 
 		var list = $(event.target).contents().find(".monster-listing__body");
 
+		// prevent right click menu on the monster image so we can use our own custom menu
+		list.on("contextmenu", ".monster-row__cell--avatar", function(e) {
+			e.preventDefault();
+		});
 
+		// present our own custom monster image menu
+		list.on("mousedown", ".monster-row__cell--avatar", function(e) {
+
+			e.stopPropagation();
+			e.target = this; // hack per passarlo a token_button
+
+			let monsterImage = $(this);
+			let monsterid = monsterImage.parent().parent().attr('id').replace("monster-row-", "");
+			let ogImgSrc = monsterImage.find('img').attr('src');
+
+			if ($.find("#custom-img-src-anchor").length == 0) {
+				// contextMenu doesn't seem to be able to use elements inside the monster panel iframe so
+				// inject an element outside of the monster panel iframe
+				// then display a contextMenu from that point.
+				$('<span id="custom-img-src-anchor" style="position:absolute;" />').insertBefore(panel);
+			}
+			$("#custom-img-src-anchor").css("top", e.pageY + "px");
+			$("#custom-img-src-anchor").data("monster-id", monsterid);
+			$("#custom-img-src-anchor").data("monster-og-img-src", ogImgSrc);
+
+			// open our context menu
+			$("#custom-img-src-anchor").contextMenu();
+		});
 
 		list.on("contextmenu", "button.monster-row__add-button", function(e) {
 			e.preventDefault();

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1031,3 +1031,17 @@ body {
     display: inline-block;
     margin: 0 0 0 5px;
 }
+.custom-token-image-menu-item-img{
+    width: 38px;
+    max-width: 38px;
+    height: 38px;
+    max-height: 38px;
+    border-radius: 3px;
+    object-fit: cover;
+    margin-bottom: 4px;
+}
+
+.custom-token-image-menu-item-remove-button{
+    margin-left: 8px;
+    vertical-align: baseline;
+}


### PR DESCRIPTION
# What
1. Allow users to set a default custom image for monster tokens. When a monster token that has a custom default image is placed, the custom image will be used for the token instead of the default DDB image.
2. Allow multiple images for the same monster. When a monster token that has multiple custom default images is placed, one of the custom images will be selected randomly and used for the token instead of the default DDB image.
3. Allow users to remove individual custom images that has been added.
4. Allow users to easily remove all custom images, effectively reseting the monster back to the default DDB image.
5. Allow users to easily switch between the custom images from the token contextMenu

# Why
1. Replacing the image for a monster every time you place it becomes tedious over time. Especially for monsters that are used a lot like commoners in a town square for example. This allows you to copy/paste your custom url once instead of every time you place a token for that monster.
2. Having multiple images for a single monster allows you to place several tokens with different images without having to copy/paste a bunch of different urls. This is especially useful for placing several commoners in a town square for example.
3. Users should be able to remove what they have added
4. Users should be able to easily revert to the default behavior.
5. Users should be able to easily switch token images since they are chosen at random.

# How
Using the `contextMenu` framework that is being used in other places like right-clicking on tokens, I created a new context menu that is shown when a user right-clicks on a monster image in the monster panel. 

When there are no custom images set, the menu has a single input for adding a custom default image. 

When there are 1 or more custom images set, the menu has 1 item for each image that is set. Each of these items shows the rendered image and has a submenu with a "Remove" option and a "Copy Url" option. Below the list of image items, is an input that allows the user to add more images. Finally, at the bottom, there is an option to "Reset to Default" that clears all images for the given monster.

Every time the mapping changes, I store it in `localStorage` under the key `CustomDefaultTokenMapping`. When the page initially loads, I read the entire mapping from localStorage. I'm not sure what kind of impact this will have on performance, but I thought it would be less than reading from localStorage every time a token was placed.

I had a difficult time getting the `contextMenu` framework to trigger on elements in the monster panel. I believe this has something to do with the monster panel loading in an iframe asynchronously. To get around this, I injected a new "anchor" element outside the iframe, and had the `contextMenu` use that as a trigger. This works just fine, but isn't as elegant as using the actual monster image element. 

When there are multiple custom images for a monster, I also update the token contextMenu to allow easily selecting one of the custom images or to override the token image with a different url. Custom images that are set here do not get persisted since they are one-off images.

Here is a video of it in action https://imgur.com/a/fbOhRTt