### PR TITLE
Add ability to offset player map

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -367,6 +367,27 @@ function circle_intersection(x0, y0, r0, x1, y1, r1) {
 }
 
 function reset_canvas() {
+
+	if (!window.DM) {
+		 // only offset the player map
+		let offsetX = "0px";
+		if (CURRENT_SCENE_DATA.player_map_offset_x != undefined) {
+			offsetX = CURRENT_SCENE_DATA.player_map_offset_x + "px";
+		}
+		let offsetY = "0px";
+		if (CURRENT_SCENE_DATA.player_map_offset_y != undefined) {
+			offsetY = CURRENT_SCENE_DATA.player_map_offset_y + "px";
+		}
+		$('#fog_overlay').css("top", offsetY);
+		$('#fog_overlay').css("left", offsetX);
+		$('#grid_overlay').css("top", offsetY);
+		$('#grid_overlay').css("left", offsetX);
+		$('#draw_overlay').css("top", offsetY);
+		$('#draw_overlay').css("left", offsetX);
+		$('#draw_overlay').css("top", offsetY);
+		$('#draw_overlay').css("left", offsetX);
+	}
+
 	$('#fog_overlay').width($("#scene_map").width());
 	$('#fog_overlay').height($("#scene_map").height());
 

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -58,6 +58,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		scene.hpps = parseFloat(scene.hpps);
 		scene.offsetx = parseFloat(scene.offsetx);
 		scene.offsety = parseFloat(scene.offsety);
+		scene.player_map_offset_x = parseFloat(scene.player_map_offset_x);
+		scene.player_map_offset_y = parseFloat(scene.player_map_offset_y);
 
 		// CALCOLI DI SCALA non dovrebbero servire piu''
 		scene['scale'] = (60.0 / parseInt(scene['hpps'])) * 100; // for backward compatibility, this will be horizonat scale
@@ -192,6 +194,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		data.grid_subdivded = window.CURRENT_SCENE_DATA.grid_subdivided;
 		data.offsetx = window.CURRENT_SCENE_DATA.offsetx;
 		data.offsety = window.CURRENT_SCENE_DATA.offsety;
+		data.player_map_offset_x = window.CURRENT_SCENE_DATA.player_map_offset_x;
+		data.player_map_offset_y = window.CURRENT_SCENE_DATA.player_map_offset_y;
 
 		data.map = this.scene.player_map;
 		data.width = $("#scene_map").width();
@@ -460,7 +464,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 						fog_of_war: "0",
 						thumb: thumb,
 						tokens: {},
-						reveals: [],
+						reveals: []
 					});
 
 				});
@@ -544,6 +548,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				offsetx: 0,
 				offsety: 0,
 				reveals: [[0, 0, 0, 0, 2, 0]],
+				player_map_offset_x: 0,
+				player_map_offset_y: 0
 			});
 			this.current_scene_id = 0;
 		}

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -139,6 +139,8 @@ function edit_scene_dialog(scene_id) {
 	manual.append($("<div><div style='display:inline-block; width:30%'>Foot per square</div><div style='display:inline-block; width:70'%'><input name='fpsq'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Grid is a subdivided 10ft</div><div style='display:inline-block; width:70'%'><input name='grid_subdivided'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Image Scale Factor</div><div style='display:inline-block; width:70'%'><input name='scale_factor'></div></div>"));
+	manual.append($("<div><div style='display:inline-block; width:30%'>Player Map Offset X</div><div style='display:inline-block;width:70%;'><input name='player_map_offset_x'> px</div></div>"));
+	manual.append($("<div><div style='display:inline-block; width:30%'>Player Map Offset Y</div><div style='display:inline-block;width:70%;'><input name='player_map_offset_y'> px</div></div>"));
 	manual.hide();
 
 	manual.find("input").each(function() {
@@ -1014,6 +1016,17 @@ function fill_importer(scene_set, start) {
 				$("#scene_properties input[name='grid_subdivided']").val(scene.grid_subdivided);
 			if (typeof scene.scale_factor !== "undefined")
 				$("#scene_properties input[name='scale_factor']").val(scene.scale_factor);
+			if (typeof scene.player_map_offset_x !== "undefined") {
+				$("#scene_properties input[name='player_map_offset_x']").val(scene.player_map_offset_x);
+			} else {
+				$("#scene_properties input[name='player_map_offset_x']").val(0);
+			}
+			if (typeof scene.player_map_offset_y !== "undefined") {
+				$("#scene_properties input[name='player_map_offset_y']").val(scene.player_map_offset_y);
+			} else {
+				$("#scene_properties input[name='player_map_offset_y']").val(0);
+			}
+				
 
 			$("#mega_importer").remove();
 		});


### PR DESCRIPTION
# What
This is an investigation into the recent issues brought up in Discord about DM maps and player maps not being aligned. It adds new options to the "Manual Grid Data" menu to allow offsetting the player map.  

# How
I added `player_map_offset_x` and `player_map_offset_y` to the scene data. These are defaulted to 0, and are filled in from the new inputs that I added to the "Manual Grid Data" form. 

These offsets are then used in the `reset_canvas` function in `Fog.js`. What that does is offset the canvas layers that sit on top of the player map. When a DM hides/reveals fog or draws, everything works as expected, but because the canvas is offset from the map image, it all lines up properly.

# Concerns
This appears to fix the offset issue, but I haven't done extensive testing on every part of the app. It's possible that this could introduce bugs in other areas of the app. 

As you can see in the following screenshot, this allows the maps to be aligned, but there is still a problem with scale. Considering these images are poorly scanned, I don’t know if this is a problem worth solving. If there are other official maps that could benefit from a solution like this, we can continue exploring it, but if it’s just a few poorly scanned maps, I don’t know if this is worth exploring further. 

# Screenshot
![screenshot](https://i.imgur.com/ofRjwQS.png)