### PR TITLE
Wrap custom condition names in sanitisation logic before writing to tokens t…

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -339,8 +339,9 @@ class Token {
 			}
 
 			for (let i = 0; i < this.options.custom_conditions.length; i++) {
-				const conditionName = this.options.custom_conditions[i];
-				const conditionSymbolName = conditionName.replaceAll(' ','_').toLowerCase();
+				//Security logic to prevent HTML/JS from being injected into condition names.
+				const conditionName = DOMPurify.sanitize( this.options.custom_conditions[i],{ALLOWED_TAGS: []});
+				const conditionSymbolName = DOMPurify.sanitize( conditionName.replaceAll(' ','_').toLowerCase(),{ALLOWED_TAGS: []});
 				const conditionContainer = $(`<div id='${conditionName}' class='condition-container' />`);
 				let symbolImage;
 				if (conditionName.startsWith('#')) {


### PR DESCRIPTION
Wrap condition names in sanitisation logic before writing to tokens to prevent XSS. This should allow existing custom conditions to function as expected.