### PR TITLE
preserve token image aspect ratio

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -283,6 +283,7 @@ div#scene_properties form > div {
 
 .token-image {
     cursor: move;
+    object-fit: contain;
 }
 
 .hasTooltip::after {


### PR DESCRIPTION
This changes the way non-square token images are handled.

On the left is how it's currently handled, and on the right is with `object-fit: contain;`

![screenshot comparison](https://i.imgur.com/zWCdWsH.png)