### PR TITLE
Add copy paste for tokens

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -206,4 +206,20 @@ Mousetrap.bind('shift+h', function () {
     $("button:contains('CONNECT VIDEO')").toggle();
 });
 
+Mousetrap.bind('ctrl+c', function(e) {
+    if (window.navigator.userAgent.indexOf("Mac") != -1) return; // Mac/iOS use command
+    copy_selected_tokens();
+});
+Mousetrap.bind('command+c', function(e) {
+    copy_selected_tokens();
+});
+
+Mousetrap.bind('ctrl+v', function(e) {
+    if (window.navigator.userAgent.indexOf("Mac") != -1) return; // Mac/iOS use command
+    paste_selected_tokens();
+});
+Mousetrap.bind('command+v', function(e) {
+    paste_selected_tokens();
+});
+
 }

--- a/Main.js
+++ b/Main.js
@@ -915,6 +915,7 @@ function init_ui() {
 	window.PLAYER_STATS = {};
 	window.TOKEN_SETTINGS = $.parseJSON(localStorage.getItem('TokenSettings' + gameid)) || {};
 	window.CURRENTLY_SELECTED_TOKENS = [];
+	window.TOKEN_PASTE_BUFFER = [];
 
 	window.MB = new MessageBroker();
 	window.StatHandler = new StatHandler();

--- a/Token.js
+++ b/Token.js
@@ -49,6 +49,12 @@ class Token {
 		}
 	}
 
+	isPlayer() {
+		// player tokens have ids with a structure like "/profile/username/characters/someId"
+		// monster tokens have a uuid for their id
+		return this.options.id.includes("/")
+	}
+
 	size(newsize) {
 		this.update_from_page();
 		this.options.size = newsize;
@@ -2137,15 +2143,30 @@ function remove_selected_token_bounding_box() {
 }
 
 function copy_selected_tokens() {
+	if (!window.DM) return;
 	window.TOKEN_PASTE_BUFFER = [];
+	let redrawBoundingBox = false;
 	for (id in window.TOKEN_OBJECTS) {
-		if (window.TOKEN_OBJECTS[id].selected) {
-			window.TOKEN_PASTE_BUFFER.push(id);
+		let token = window.TOKEN_OBJECTS[id];
+		if (token.selected) { 
+			if (token.isPlayer()) {
+				// deselect player tokens to avoid confusion about them being selected but not copy/pasted
+				window.TOKEN_OBJECTS[id].selected = false;
+				window.TOKEN_OBJECTS[id].place_sync_persist();
+				redrawBoundingBox = true;
+			} else {
+				// only allow copy/paste for selected monster tokens
+				window.TOKEN_PASTE_BUFFER.push(id);
+			}
 		}
+	}
+	if (redrawBoundingBox) {
+		draw_selected_token_bounding_box();
 	}
 }
 
 function paste_selected_tokens() {
+	if (!window.DM) return;
 	if (window.TOKEN_PASTE_BUFFER == undefined) {
 		window.TOKEN_PASTE_BUFFER = [];
 	}
@@ -2153,6 +2174,7 @@ function paste_selected_tokens() {
 	for (let i = 0; i < window.TOKEN_PASTE_BUFFER.length; i++) {
 		let id = window.TOKEN_PASTE_BUFFER[i];
 		let token = window.TOKEN_OBJECTS[id];
+		if (token == undefined || token.isPlayer()) continue; // only allow copy/paste for monster tokens, and protect against pasting deleted tokens
 		let options = Object.assign({}, token.options);
 		let newId = uuid();
 		options.id = newId;

--- a/Token.js
+++ b/Token.js
@@ -2136,3 +2136,39 @@ function remove_selected_token_bounding_box() {
 	$("#rotationGrabber").remove();
 }
 
+function copy_selected_tokens() {
+	window.TOKEN_PASTE_BUFFER = [];
+	for (id in window.TOKEN_OBJECTS) {
+		if (window.TOKEN_OBJECTS[id].selected) {
+			window.TOKEN_PASTE_BUFFER.push(id);
+		}
+	}
+}
+
+function paste_selected_tokens() {
+	if (window.TOKEN_PASTE_BUFFER == undefined) {
+		window.TOKEN_PASTE_BUFFER = [];
+	}
+
+	for (let i = 0; i < window.TOKEN_PASTE_BUFFER.length; i++) {
+		let id = window.TOKEN_PASTE_BUFFER[i];
+		let token = window.TOKEN_OBJECTS[id];
+		let options = Object.assign({}, token.options);
+		let newId = uuid();
+		options.id = newId;
+		// TODO: figure out the location under the cursor and paste there instead of doing an offset
+		options.top = `${parseFloat(options.top) + Math.round(options.size / 2)}px`;
+		options.left = `${parseFloat(options.left) + Math.round(options.size / 2)}px`;
+		options.selected = true;
+		window.ScenesHandler.create_update_token(options);
+		// deselect the old and select the new so the user can easily move the new tokens around after pasting them
+		window.TOKEN_OBJECTS[id].selected = false;
+		window.TOKEN_OBJECTS[id].place_sync_persist();
+		window.TOKEN_OBJECTS[newId].selected = true;
+		window.TOKEN_OBJECTS[newId].place_sync_persist();
+	}
+
+	// copy the newly selected tokens in case they paste again, we want them pasted in reference to the newly created tokens
+	copy_selected_tokens();
+	draw_selected_token_bounding_box();
+}


### PR DESCRIPTION
# What
1. Add key binding for ctrl+c and cmd+c for copying tokens
2. Add key binding for ctrl+v and cmd+v for pasting tokens that have been copied
3. Ignore ctrl+c and ctrl+v bindings on Macs since they use the command key
4. Pasting tokens places the new tokens with a positional offset of half the token size down and to the right.
5. After pasting tokens, the selection automatically changes to the new tokens to make it easier to move them 
6. After pasting tokens, the paste buffer is updated to the new tokens so that pasting multiple times has a cascading effect instead of stacking them all on top of each other.

# Demo
DM on the left, Player on the right
https://imgur.com/a/w73cOJr