### PR TITLE
context menu cleanup for players

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1382,6 +1382,18 @@ function token_menu() {
 		build: function(element, e) {
 
 			if ($(element).hasClass("tokenselected") && window.MULTIPLE_TOKEN_SELECTED) {
+				if (!window.DM) {
+					// players can't do anything to multiple tokens, currently
+					return {
+						items: { 
+							helptext: {
+								name: 'You cannot apply changes to multiple tokens',
+								className: 'context-menu-helptext',
+								disabled: true
+							}
+						}
+					}
+				}
 				ret = {
 					callback: multiple_callback,
 					items: {
@@ -1689,6 +1701,7 @@ function token_menu() {
 				};
 				if (is_monster) {
 					delete ret.items.options.items.token_hidestat;
+					delete ret.items.sep4;
 					delete ret.items.helptext;
 				}
 				else {
@@ -1708,6 +1721,7 @@ function token_menu() {
 				}
 				
 				if(!window.DM){
+					delete ret.items.sep0;
 					delete ret.items.view;
 					delete ret.items.token_combat;
 					delete ret.items.token_hidden;
@@ -1718,6 +1732,7 @@ function token_menu() {
 					delete ret.items.max_hp;
 					delete ret.items.delete;
 					delete ret.items.name;
+					delete ret.items.sep2;
 					//delete ret.items.imgsrc;
 					delete ret.items.imgsrcSelect;
 				}


### PR DESCRIPTION
This changes the multi-selection context menu for players, and removes a few unnecessary dividers.

# Menu for multiple selected tokens
![multi select demo](https://i.imgur.com/hbL1y8U.png)

# menu for player tokens before / after
![player menu cleanup](https://i.imgur.com/H3Nycdk.png)

# menu for monster tokens before / after
![monster menu cleanup](https://i.imgur.com/MXzedXq.png)
