### PR TITLE
limit monster entry width

### DIFF
--- a/Jitsi.js
+++ b/Jitsi.js
@@ -49,7 +49,7 @@ function init_jitsi() {
 			startWithAudioMuted: true,
 		},
 		interfaceConfigOverwrite: {
-			TOOLBAR_BUTTONS: ["microphone", "camera", "settings"],
+			TOOLBAR_BUTTONS: ["microphone", "camera", "settings", "tileview"],
 			VERTICAL_FILMSTRIP: false,
 			filmStripOnly: true,
 			DISABLE_DOMINANT_SPEAKER_INDICATOR: true,

--- a/Jitsi.js
+++ b/Jitsi.js
@@ -49,7 +49,7 @@ function init_jitsi() {
 			startWithAudioMuted: true,
 		},
 		interfaceConfigOverwrite: {
-			TOOLBAR_BUTTONS: ["microphone", "camera", "settings", "tileview"],
+			TOOLBAR_BUTTONS: ["microphone", "camera", "settings"],
 			VERTICAL_FILMSTRIP: false,
 			filmStripOnly: true,
 			DISABLE_DOMINANT_SPEAKER_INDICATOR: true,

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -24,7 +24,7 @@ function init_monster_panel() {
 
 		var list = $(event.target).contents().find(".monster-listing__body");
 		
-		// limit the width of monster name entries
+		// limit the width of monster entries
 		list.css("max-width", "400px");
 	
 		// prevent right click menu on the monster image so we can use our own custom menu


### PR DESCRIPTION
monsters with long names are causing broken tables in the monster panel