### PR TITLE
Brush tool, line thickness

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -871,7 +871,7 @@ function drawing_mouseup(e) {
 	}
 	
 	// ignore if right mouse button for drawing or fog, cancel is done in drawing_contextmenu
-	if((window.DRAWFUNCTION == "draw" || window.DRAWFUNCTION == "1" || window.DRAWFUNCTION == "0") && e.button == 2)
+	if((window.DRAWFUNCTION == "draw" || window.DRAWFUNCTION == "1" || window.DRAWFUNCTION == "0") && e.which !== 1)
 	{
 		return;
 	}

--- a/Fog.js
+++ b/Fog.js
@@ -259,7 +259,9 @@ class WaypointManagerClass {
 		this.ctx.lineWidth = 3;
 		this.ctx.strokeStyle = "black";
 		this.ctx.fillStyle = "rgba(255, 255, 255, 0.6)";
-		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, true);
+		
+		
+		(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, true);
 
 		// Finally draw our text
 		this.ctx.fillStyle = "black";
@@ -364,6 +366,13 @@ function circle_intersection(x0, y0, r0, x1, y1, r1) {
 	var yi_prime = y2 - ry;
 
 	return [xi, xi_prime, yi, yi_prime];
+}
+
+function midPointBtw(p1, p2) {
+  return {
+    x: p1.x + (p2.x - p1.x) / 2,
+    y: p1.y + (p2.y - p1.y) / 2
+  };
 }
 
 function reset_canvas() {
@@ -525,13 +534,7 @@ function redraw_canvas() {
 				ctx.clearRect(d[0], d[1], d[2], d[3]);
 			}
 			if (d[4] == 1) { // REVEAL CIRCLE
-				ctx.save();
-				ctx.beginPath();
-				ctx.fillStyle = "rgba(0,0,0,0);"
-				ctx.arc(d[0], d[1], d[2], 0, 2 * Math.PI, false);
-				ctx.clip();
-				ctx.clearRect(d[0] - d[2], d[1] - d[2], d[2] * 2, d[2] * 2);
-				ctx.restore();
+				clearCircle(ctx, d[0], d[1], d[2]);
 			}
 			if (d[4] == 2) {
 				// reveal ALL!!!!!!!!!!
@@ -539,7 +542,7 @@ function redraw_canvas() {
 			}
 			if (d[4] == 3) {
 				// REVEAL POLYGON
-				clearPolygon(d[0]);
+				clearPolygon(ctx, d[0]);
 			}
 		}
 		if (d[5] == 1) { // HIDE
@@ -549,21 +552,12 @@ function redraw_canvas() {
 				ctx.fillRect(d[0], d[1], d[2], d[3]);
 			}
 			if (d[4] == 1) { // HIDE CIRCLE
-				ctx.save();
-				ctx.beginPath();
-				ctx.arc(d[0], d[1], d[2], 0, 2 * Math.PI, false);
-				ctx.clip();
-				ctx.clearRect(d[0] - d[2], d[1] - d[2], d[2] * 2, d[2] * 2);
-				ctx.restore();
-				ctx.fillStyle = fogStyle;
-				ctx.arc(d[0], d[1], d[2], 0, 2 * Math.PI, false);
-				ctx.fill();
-
-
+				clearCircle(ctx, d[0], d[1], d[2]);
+				drawCircle(ctx, d[0], d[1], d[2], fogStyle);
 			}
 			if (d[4] == 3) {
 				// HIDE POLYGON
-				drawPolygon(d[0], fogStyle);
+				drawPolygon(ctx, d[0], fogStyle);
 			}
 		}
 	}
@@ -572,120 +566,79 @@ function redraw_canvas() {
 function redraw_drawings() {
 	var canvas = document.getElementById("draw_overlay");
 	var ctx = canvas.getContext("2d");
+	var lineWidth = 6;
+	var style = "#FF0000";
 
 	ctx.clearRect(0, 0, canvas.width, canvas.height);
 
 	for (var i = 0; i < window.DRAWINGS.length; i++) {
 		data = window.DRAWINGS[i];
-
-
+		
 		if (data[0] == "eraser") {
 			ctx.clearRect(data[3], data[4], data[5], data[6]);
 		}
 		if (data[0] == "rect" && data[1] == "filled") {
-			ctx.fillStyle = data[2];
-			ctx.fillRect(data[3], data[4], data[5], data[6]);
+			style = data[2];
+			drawRect(ctx,data[3], data[4], data[5], data[6], style, true);
 		}
 		if (data[0] == "rect" && data[1] == "transparent") {
-			ctx.fillStyle = data[2].replace(')', ', 0.5)').replace('rgb', 'rgba');
-			ctx.fillRect(data[3], data[4], data[5], data[6]);
+			style = data[2].replace(')', ', 0.5)').replace('rgb', 'rgba');
+			drawRect(ctx,data[3], data[4], data[5], data[6], style, true);
 		}
 		if (data[0] == "rect" && data[1] == "border") {
-			ctx.strokeStyle = data[2];
-			ctx.lineWidth = "6";
-			ctx.beginPath();
-			ctx.rect(data[3], data[4], data[5], data[6]);
-			ctx.stroke();
+			lineWidth = data.length > 7 ? data[7] : "6";
+			style = data[2];
+			drawRect(ctx,data[3], data[4], data[5], data[6], style, false, true,lineWidth );
 		}
 		if (data[0] == "arc" && data[1] == "filled") {
-			ctx.fillStyle = data[2];
-			ctx.save();
-			ctx.beginPath();
-			ctx.arc(data[3], data[4], data[5], 0, 2 * Math.PI, false);
-			ctx.clip();
-			ctx.clearRect(data[3] - data[5], data[4] - data[5], data[5] * 2, data[5] * 2);
-			ctx.restore();
-			ctx.arc(data[3], data[4], data[5], 0, 2 * Math.PI, false);
-			ctx.fill();
+			style = data[2];
+			drawCircle(ctx,data[3], data[4], data[5], style);
 		}
 		if (data[0] == "arc" && data[1] == "transparent") {
-			ctx.fillStyle = data[2].replace(')', ', 0.5)').replace('rgb', 'rgba');
-			ctx.save();
-			ctx.beginPath();
-			ctx.arc(data[3], data[4], data[5], 0, 2 * Math.PI, false);
-			ctx.clip();
-			ctx.clearRect(data[3] - data[5], data[4] - data[5], data[5] * 2, data[5] * 2);
-			ctx.restore();
-			ctx.arc(data[3], data[4], data[5], 0, 2 * Math.PI, false);
-			ctx.fill();
+			style = data[2].replace(')', ', 0.5)').replace('rgb', 'rgba');
+			drawCircle(ctx,data[3], data[4], data[5], style);
 		}
 		if (data[0] == "arc" && data[1] == "border") {
-			ctx.strokeStyle = data[2];
-			ctx.lineWidth = "6";
-			ctx.beginPath();
-			ctx.arc(data[3], data[4], data[5], 0, 2 * Math.PI, false);
-			ctx.stroke();
+			style = data[2];
+			lineWidth = data.length > 7 ? data[7] : "6";
+			drawCircle(ctx,data[3], data[4], data[5], style, false, true, lineWidth);
 		}
 		if (data[0] == "cone" && data[1] == "transparent") {
-			ctx.fillStyle = data[2].replace(')', ', 0.5)').replace('rgb', 'rgba');
-			var L = Math.sqrt(Math.pow(data[5] - data[3], 2) + Math.pow(data[6] - data[4], 2));
-			var T = Math.sqrt(Math.pow(L, 2) + Math.pow(L / 2, 2));
-			var res = circle_intersection(data[3], data[4], T, data[5], data[6], L / 2);
-			ctx.lineWidth = "6";
-			ctx.beginPath();
-			ctx.moveTo(data[3], data[4]);
-			ctx.lineTo(res[0], res[2]);
-			ctx.lineTo(res[1], res[3]);
-			ctx.closePath();
-			ctx.fill();
+			style = data[2].replace(')', ', 0.5)').replace('rgb', 'rgba');
+			drawCone(ctx,data[3], data[4], data[5],data[6], style);
 		}
 		if (data[0] == "cone" && data[1] == "filled") {
-			ctx.fillStyle = data[2];
-			var L = Math.sqrt(Math.pow(data[5] - data[3], 2) + Math.pow(data[6] - data[4], 2));
-			var T = Math.sqrt(Math.pow(L, 2) + Math.pow(L / 2, 2));
-			var res = circle_intersection(data[3], data[4], T, data[5], data[6], L / 2);
-			ctx.lineWidth = "6";
-			ctx.beginPath();
-			ctx.moveTo(data[3], data[4]);
-			ctx.lineTo(res[0], res[2]);
-			ctx.lineTo(res[1], res[3]);
-			ctx.closePath();
-			ctx.fill();
+			style = data[2];
+			drawCone(ctx,data[3], data[4], data[5],data[6], style);
 		}
 		if (data[0] == "cone" && data[1] == "border") {
-			ctx.strokeStyle = data[2];
-			var L = Math.sqrt(Math.pow(data[5] - data[3], 2) + Math.pow(data[6] - data[4], 2));
-			var T = Math.sqrt(Math.pow(L, 2) + Math.pow(L / 2, 2));
-			var res = circle_intersection(data[3], data[4], T, data[5], data[6], L / 2);
-			ctx.lineWidth = "6";
-			ctx.beginPath();
-			ctx.moveTo(data[3], data[4]);
-			ctx.lineTo(res[0], res[2]);
-			ctx.lineTo(res[1], res[3]);
-			ctx.closePath();
-			ctx.stroke();
+			style = data[2];
+			lineWidth = data.length > 7 ? data[7] : "6";
+			drawCone(ctx,data[3], data[4], data[5],data[6], style, false, true, lineWidth);
 		}
 		if (data[0] == "line") {
-			ctx.strokeStyle = data[2];
-			ctx.lineWidth = "6";
-			ctx.beginPath();
-			ctx.moveTo(data[3], data[4]);
-			ctx.lineTo(data[5], data[6]);
-			ctx.stroke();
+			style = data[2];
+			lineWidth = data.length > 7 ? data[7] : "6";
+			drawLine(ctx,data[3], data[4], data[5], data[6], style, lineWidth);
 		}
 
 		if (data[0] == "polygon" && data[1] == "filled") {
-			drawPolygon(data[3], data[2], false);
+			style = data[2];
+			drawPolygon(ctx,data[3], style, true);
 		}
 		if (data[0] == "polygon" && data[1] == "transparent") {
-			drawPolygon(data[3], data[2].replace(')', ', 0.5)').replace('rgb', 'rgba'), false);
+			style = data[2].replace(')', ', 0.5)').replace('rgb', 'rgba');
+			drawPolygon(ctx,data[3], style, true);
 		}
 		if (data[0] == "polygon" && data[1] == "border") {
-			ctx.strokeStyle = data[2];
-			drawPolygon(data[3], "rgba(0, 0, 0, 0)", false, 6);
+			style = data[2];
+			lineWidth = data.length > 7 ? data[7] : "6";
+			drawPolygon(ctx,data[3], style, false, true, lineWidth);
 			ctx.stroke();
 		}
-
+		if (data[0] == "brush") {
+			drawBrushstroke(ctx, data[3],data[2], (data.length > 7 ? data[7] : "6"), false);
+		}
 	}
 }
 
@@ -723,8 +676,13 @@ function drawing_mousedown(e) {
 	if (shiftHeld == false || e.data.shape != 'select') {
 		deselect_all_tokens();
 	}
+	
+	window.LINEWIDTH = $("#draw_line_width").val();
+	window.DRAWTYPE = $(".drawTypeSelected ").attr('data-value');
+	window.DRAWCOLOR = $(".colorselected").css('background-color');
 
 	if (e.data.shape === "polygon") {
+		
 		if (isNaN(e.data.type)) {
 			redraw_drawings();
 		} else {
@@ -749,39 +707,83 @@ function drawing_mousedown(e) {
 			window.BEGIN_MOUSEX = [pointX];
 			window.BEGIN_MOUSEY = [pointY];
 		}
-		drawPolygon(
+		var canvas = document.getElementById("fog_overlay");
+		var ctx = canvas.getContext("2d");
+		drawPolygon(ctx,
 			joinPointsArray(
 				window.BEGIN_MOUSEX,
 				window.BEGIN_MOUSEY
-			),
-			undefined,
-			!isNaN(e.data.type)
+			)
 		);
 		drawClosingArea(window.BEGIN_MOUSEX[0], window.BEGIN_MOUSEY[0], !isNaN(e.data.type));
 	} else {
 		window.BEGIN_MOUSEX = (e.pageX - 200) * (1.0 / window.ZOOM);
 		window.BEGIN_MOUSEY = (e.pageY - 200) * (1.0 / window.ZOOM);
 		window.MOUSEDOWN = true;
+		if(e.data.shape === "brush")
+		{
+			window.BRUSHWAIT = false;
+			window.BRUSHPOINTS = [];
+			window.BRUSHPOINTS.push({x:window.BEGIN_MOUSEX, y:window.BEGIN_MOUSEY});
+		}
 	}
 
 }
+
 
 function drawing_mousemove(e) {
 
 	var mousex = (e.pageX - 200) * (1.0 / window.ZOOM);
 	var mousey = (e.pageY - 200) * (1.0 / window.ZOOM);
 	
+	var canvas = document.getElementById("fog_overlay");
+	var ctx = canvas.getContext("2d");
 	if (window.MOUSEDOWN) {
-		var canvas = document.getElementById("fog_overlay");
-		var ctx = canvas.getContext("2d");
 		var width = mousex - window.BEGIN_MOUSEX;
 		var height = mousey - window.BEGIN_MOUSEY;
-		redraw_canvas();
-
-		ctx.fillStyle = "#FF0000";
+		var drawStroke = false;
+		var fill = true;
+		var style = "#FF0000";
+		var lineWidth = window.LINEWIDTH;
+		
+		if(e.data.shape !== "brush")
+		{
+			redraw_canvas();
+		}
+		
+		// set style
+		if(e.data.type === "draw")
+		{
+			
+			style = window.DRAWCOLOR;
+			if(window.DRAWTYPE == "transparent")
+			{
+				drawStroke = false;
+				fill = true;
+				style = style.replace(')', ', 0.5)').replace('rgb', 'rgba');
+			}
+			else if (window.DRAWTYPE == "border")
+			{
+				drawStroke = true;
+				fill = false;
+				style = style.replace(')', ', 0.9)').replace('rgb', 'rgba');
+			}
+			else if (window.DRAWTYPE == "filled")
+			{
+				drawStroke = false;
+				fill = true;
+				style = style.replace(')', ', 0.9)').replace('rgb', 'rgba');
+			}
+		}
+		else
+		{
+			drawStroke = false;
+			fill = true;
+			lineWidth = 0;
+			style = "rgba(255,0,0,0.7)";
+		}
 		if (e.data.shape == "rect") {
-			ctx.fillStyle = "rgba(255,0,0,0.7)";
-			ctx.fillRect(window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, width, height);
+			drawRect(ctx,window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, width, height, style, fill, drawStroke,lineWidth);
 		}
 		else if (e.data.shape == "align") {
 			for (i = 0; i < 4; i++) {
@@ -804,37 +806,19 @@ function drawing_mousemove(e) {
 			centerX = (window.BEGIN_MOUSEX + mousex) / 2;
 			centerY = (window.BEGIN_MOUSEY + mousey) / 2;
 			radius = Math.round(Math.sqrt(Math.pow(centerX - mousex, 2) + Math.pow(centerY - mousey, 2)));
-			ctx.beginPath();
-			ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI, false);
-			ctx.fill();
+			drawCircle(ctx,centerX, centerY, radius, style, fill, drawStroke, lineWidth);
 		}
 		else if (e.data.shape == "cone") {
-			var L = Math.sqrt(Math.pow(mousex - window.BEGIN_MOUSEX, 2) + Math.pow(mousey - window.BEGIN_MOUSEY, 2));
-			var T = Math.sqrt(Math.pow(L, 2) + Math.pow(L / 2, 2));
-			var res = circle_intersection(window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, T, mousex, mousey, L / 2);
-			ctx.fillStyle = "rgba(255,0,0,0.7)";
-			ctx.lineWidth = "6";
-			ctx.beginPath();
-			ctx.moveTo(window.BEGIN_MOUSEX, window.BEGIN_MOUSEY);
-			ctx.lineTo(res[0], res[2]);
-			ctx.lineTo(res[1], res[3]);
-			ctx.closePath();
-			ctx.fill();
+			drawCone(ctx,window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey, style, fill, drawStroke, lineWidth);
 		}
 		else if (e.data.shape == "line") {
-			ctx.beginPath();
-			ctx.strokeStyle = "rgba(255,0,0,0.7)";
-			ctx.lineWidth = 6;
-			ctx.moveTo(window.BEGIN_MOUSEX, window.BEGIN_MOUSEY);
-			ctx.lineTo(mousex, mousey);
-			ctx.stroke();
+			drawLine(ctx,window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey, style, lineWidth);
 		}
 		else if (e.data.shape == "select") {
 			ctx.save();
-			ctx.beginPath();
 			ctx.strokeStyle = "white";
-			ctx.rect(window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, width, height);
-			ctx.stroke();
+			ctx.setLineDash([10,5]);
+			drawRect(ctx,window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, width, height,"white",false,true);
 			ctx.restore();
 		}
 		else if (e.data.shape == "measure") {
@@ -850,7 +834,22 @@ function drawing_mousemove(e) {
 
 			ctx.restore();
 		}
-	} else {
+		else if (e.data.shape == "brush"){
+			// Only add a new point every 75ms to keep the drawing size low
+			if(!window.BRUSHWAIT)
+			{
+				window.BRUSHPOINTS.push({x:mousex, y:mousey});
+				
+				drawBrushstroke(ctx, window.BRUSHPOINTS,style,lineWidth);
+				
+				window.BRUSHWAIT = true;
+				setTimeout(function() {
+					window.BRUSHWAIT = false;
+				}, 75);
+			}
+		}
+	} 
+	else {
 		if (e.data.shape === "polygon" &&
 			window.BEGIN_MOUSEX && window.BEGIN_MOUSEX.length > 0) {
 			
@@ -860,14 +859,15 @@ function drawing_mousemove(e) {
 				redraw_canvas();
 			}
 
-			drawPolygon(
+			drawPolygon( ctx,
 				joinPointsArray(
 					window.BEGIN_MOUSEX,
 					window.BEGIN_MOUSEY
 				),
-				undefined,
-				!isNaN(e.data.type),
-				undefined,
+				style,
+				fill,
+				drawStroke,
+				lineWidth,
 				mousex,
 				mousey
 			);
@@ -905,7 +905,7 @@ function drawing_mouseup(e) {
 	// [0-3] is always shape data [4] is shape and [5] is type
 
 	if (e.data.shape == "line" && e.data.type === "draw") {
-		data = ['line', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey];
+		data = ['line', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey, window.LINEWIDTH];
 		window.DRAWINGS.push(data);
 		redraw_canvas();
 		redraw_drawings();
@@ -915,7 +915,7 @@ function drawing_mouseup(e) {
 
 	if (e.data.shape == "rect" && e.data.type === "draw") {
 		console.log('disegno');
-		data = ['rect', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, width, height];
+		data = ['rect', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, width, height,window.LINEWIDTH];
 		window.DRAWINGS.push(data);
 		redraw_canvas();
 		redraw_drawings();
@@ -936,7 +936,7 @@ function drawing_mouseup(e) {
 		centerX = (window.BEGIN_MOUSEX + mousex) / 2;
 		centerY = (window.BEGIN_MOUSEY + mousey) / 2;
 		radius = Math.round(Math.sqrt(Math.pow(centerX - mousex, 2) + Math.pow(centerY - mousey, 2)));
-		data = ['arc', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), centerX, centerY, radius];
+		data = ['arc', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), centerX, centerY, radius,null,window.LINEWIDTH];
 		window.DRAWINGS.push(data);
 		redraw_canvas();
 		redraw_drawings();
@@ -944,7 +944,7 @@ function drawing_mouseup(e) {
 		window.MB.sendMessage('custom/myVTT/drawing', data);
 	}
 	if (e.data.shape == "cone" && e.data.type === "draw") {
-		data = ['cone', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey];
+		data = ['cone', $(".drawTypeSelected ").attr('data-value'), $(".colorselected").css('background-color'), window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey,window.LINEWIDTH];
 		window.DRAWINGS.push(data);
 		redraw_canvas();
 		redraw_drawings();
@@ -959,8 +959,17 @@ function drawing_mouseup(e) {
 		window.ScenesHandler.persist();
 		redraw_canvas();
 	}
-
-
+	if(e.data.shape == "brush" && e.data.type === "draw") {
+		window.BRUSHPOINTS.push({x:mousex, y:mousey});
+		data = ['brush', $(".drawTypeSelected ").attr('data-value'),$(".colorselected").css('background-color'), window.BRUSHPOINTS,null,null,null,window.LINEWIDTH];
+		console.log("save brush");
+		console.log(data);
+		window.DRAWINGS.push(data);
+		redraw_canvas();
+		redraw_drawings();
+		window.ScenesHandler.persist();
+		window.MB.sendMessage('custom/myVTT/drawing', data);
+	}
 
 	if (e.data.shape == "arc" && (e.data.type == 0 || e.data.type == 1)) {
 		centerX = (window.BEGIN_MOUSEX + mousex) / 2;
@@ -1117,21 +1126,61 @@ function drawing_contextmenu(e) {
 	if (e.data.shape === "polygon") {
 		window.BEGIN_MOUSEX.pop();
 		window.BEGIN_MOUSEY.pop();
+		
+		var canvas = document.getElementById("fog_overlay");
+		var ctx = canvas.getContext("2d");
+		
+		var drawStroke = false;
+		var fill = true;
+		var style = "#FF0000";
+		var lineWidth = window.LINEWIDTH;
+		// set style
+		if(e.data.type === "draw")
+		{
+			
+			style = window.DRAWCOLOR;
+			if(window.DRAWTYPE == "transparent")
+			{
+				drawStroke = false;
+				fill = true;
+				style = style.replace(')', ', 0.5)').replace('rgb', 'rgba');
+			}
+			else if (window.DRAWTYPE == "border")
+			{
+				drawStroke = true;
+				fill = false;
+				style = style.replace(')', ', 0.9)').replace('rgb', 'rgba');
+			}
+			else if (window.DRAWTYPE == "filled")
+			{
+				drawStroke = false;
+				fill = true;
+				style = style.replace(')', ', 0.9)').replace('rgb', 'rgba');
+			}
+		}
+		else
+		{
+			drawStroke = false;
+			fill = true;
+			lineWidth = 0;
+			style = "rgba(255,0,0,0.7)";
+		}
 
 		if (isNaN(e.data.type)) {
 			redraw_drawings();
 		} else {
 			redraw_canvas();
 		}
-
 		drawPolygon(
+			ctx,
 			joinPointsArray(
 				window.BEGIN_MOUSEX,
 				window.BEGIN_MOUSEY
 			),
-			undefined,
-			!isNaN(e.data.type),
-			undefined,
+			style,
+			fill,
+			drawStroke,
+			lineWidth,
 			(e.pageX - 200) * (1.0 / window.ZOOM),
 			(e.pageY - 200) * (1.0 / window.ZOOM)
 		);
@@ -1250,26 +1299,116 @@ function setup_draw_buttons() {
 	$('#select-button').click();
 }
 
+function drawCircle(ctx, centerX, centerY, radius, style, fill=true, drawStroke = false, lineWidth = 6)
+{
+	ctx.beginPath();
+	ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI, false);
+	if(drawStroke)
+	{
+		ctx.strokeStyle = style;
+		ctx.lineWidth = lineWidth;
+		ctx.stroke();
+	}
+	if(fill)
+	{
+		ctx.fillStyle = style;
+		ctx.fill();
+	}
+}
+
+function drawRect(ctx, startx, starty, width, height, style, fill=true, drawStroke = false, lineWidth = 6)
+{
+	ctx.beginPath();
+	if(drawStroke)
+	{
+		ctx.lineWidth = lineWidth;
+		ctx.strokeStyle = style;
+		ctx.beginPath();
+		ctx.rect(startx, starty, width, height);
+		ctx.stroke();
+	}
+	if(fill)
+	{
+		ctx.fillStyle = style;
+		ctx.fillRect(startx, starty, width, height);
+	}
+}
+
+function drawCone(ctx, startx, starty, endx, endy, style, fill=true, drawStroke = false, lineWidth = 6)
+{
+	var L = Math.sqrt(Math.pow(endx - startx, 2) + Math.pow(endy - starty, 2));
+	var T = Math.sqrt(Math.pow(L, 2) + Math.pow(L / 2, 2));
+	var res = circle_intersection(startx, starty, T, endx, endy, L / 2);
+	ctx.beginPath();
+	ctx.moveTo(startx, starty);
+	ctx.lineTo(res[0], res[2]);
+	ctx.lineTo(res[1], res[3]);
+	ctx.closePath();
+	if(drawStroke)
+	{
+		ctx.lineWidth = lineWidth;
+		ctx.strokeStyle = style;
+		ctx.stroke();
+	}
+	if(fill)
+	{
+		ctx.fillStyle = style;
+		ctx.fill();
+	}
+}
+
+function drawLine(ctx, startx, starty, endx, endy, style, lineWidth = 6)
+{
+	ctx.beginPath();
+	ctx.strokeStyle = style;
+	ctx.lineWidth = lineWidth;
+	ctx.moveTo(startx, starty);
+	ctx.lineTo(endx, endy);
+	ctx.stroke();
+}
+
+function drawBrushstroke(ctx, points, style, lineWidth=6)
+{
+	// Copyright (c) 2021 by Limping Ninja (https://codepen.io/LimpingNinja/pen/qBmpvqj)
+    // Fork of an original work  (https://codepen.io/kangax/pen/pxfCn
+	
+	var p1 = points[0];
+	var p2 = points[1];
+
+	ctx.strokeStyle = style;
+	ctx.lineWidth = lineWidth;
+	ctx.beginPath();
+	ctx.moveTo(p1.x, p1.y);
+
+	for (var i = 1, len = points.length; i < len; i++) {
+	// we pick the point between pi+1 & pi+2 as the
+	// end point and p1 as our control point
+	var midPoint = midPointBtw(p1, p2);
+	ctx.quadraticCurveTo(p1.x, p1.y, midPoint.x, midPoint.y);
+	p1 = points[i];
+	p2 = points[i+1];
+	}
+	// Draw last line as a straight line
+	ctx.lineTo(p1.x, p1.y);
+	ctx.stroke();
+}
+
 function drawPolygon (
+	ctx,
 	points,
-	bgColor = 'rgba(255,0,0,0.6)',
-	fog = true,
-	lineWidth = 0,
+	style = 'rgba(255,0,0,0.6)',
+	fill = true,
+	drawStroke = false,
+	lineWidth = 1,
 	mouseX = null,
 	mouseY = null
 ) {
-	var canvas = document.getElementById(fog ? "fog_overlay" : "draw_overlay");
-	var ctx = canvas.getContext("2d");
 
-	ctx.fillStyle = bgColor;
+	ctx.fillStyle = style;
 	ctx.save();
 	ctx.beginPath();
 	ctx.lineWidth = lineWidth;
 
-	if (points.length < 2) {
-		ctx.strokeStyle = bgColor;
-		ctx.lineWidth = 1;
-	}
 
 	ctx.moveTo(points[0].x, points[0].y);
 
@@ -1280,11 +1419,16 @@ function drawPolygon (
 	if (mouseX !== null && mouseY !== null) {
 		ctx.lineTo(mouseX, mouseY);
 	}
-
-	ctx.closePath();
-	ctx.fill();
-	if (points.length < 2) {
+	
+	if ((drawStroke) || (points.length < 2)) {
+		ctx.strokeStyle = style;
+		ctx.lineWidth = 1;
 		ctx.stroke();
+	}
+	if(fill)
+	{
+		ctx.closePath();
+		ctx.fill();
 	}
 }
 
@@ -1299,7 +1443,8 @@ function savePolygon(e) {
 			polygonPoints,
 			null,
 			null,
-			null
+			null,
+			window.LINEWIDTH
 		];
 		window.DRAWINGS.push(data);
 	} else {
@@ -1336,9 +1481,7 @@ function isPointWithinDistance(points1, points2) {
 			&& Math.abs(points1.y - points2.y) <= POLYGON_CLOSE_DISTANCE;
 }
 
-function clearPolygon (points) {
-	var canvas = document.getElementById("fog_overlay");
-	var ctx = canvas.getContext("2d");
+function clearPolygon (ctx, points) {
 	
 	/*
 	 * globalCompositeOperation does not accept alpha transparency,
@@ -1356,6 +1499,17 @@ function clearPolygon (points) {
 	ctx.stroke();
 	ctx.restore();
 	ctx.globalCompositeOperation = "source-over";
+}
+
+function clearCircle(ctx, centerX, centerY, radius)
+{
+	ctx.save();
+	ctx.beginPath();
+	ctx.fillStyle = "rgba(0,0,0,0);"
+	ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI, false);
+	ctx.clip();
+	ctx.clearRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
+	ctx.restore();
 }
 
 function drawClosingArea(pointX, pointY, fog = true) {

--- a/Fog.js
+++ b/Fog.js
@@ -685,8 +685,8 @@ function drawing_mousedown(e) {
 	if (window.DRAWSHAPE === "polygon") {
 		
 		redraw_canvas();
-		const pointX = (e.pageX - 200) * (1.0 / window.ZOOM);
-		const pointY = (e.pageY - 200) * (1.0 / window.ZOOM);
+		const pointX = Math.round(((e.pageX - 200) * (1.0 / window.ZOOM)));
+		const pointY = Math.round(((e.pageY - 200) * (1.0 / window.ZOOM)));
 		if (window.BEGIN_MOUSEX && window.BEGIN_MOUSEX.length > 0) {
 			if (
 				isPointWithinDistance(
@@ -722,8 +722,8 @@ function drawing_mousedown(e) {
 		);
 		drawClosingArea(ctx,window.BEGIN_MOUSEX[0], window.BEGIN_MOUSEY[0], !isNaN(window.DRAWFUNCTION));
 	} else {
-		window.BEGIN_MOUSEX = (e.pageX - 200) * (1.0 / window.ZOOM);
-		window.BEGIN_MOUSEY = (e.pageY - 200) * (1.0 / window.ZOOM);
+		window.BEGIN_MOUSEX = Math.round(((e.pageX - 200) * (1.0 / window.ZOOM)));
+		window.BEGIN_MOUSEY = Math.round(((e.pageY - 200) * (1.0 / window.ZOOM)));
 		window.MOUSEDOWN = true;
 		if(window.DRAWSHAPE === "brush")
 		{
@@ -744,8 +744,8 @@ function drawing_mousedown(e) {
 
 function drawing_mousemove(e) {
 
-	var mousex = (e.pageX - 200) * (1.0 / window.ZOOM);
-	var mousey = (e.pageY - 200) * (1.0 / window.ZOOM);
+	var mousex = Math.round(((e.pageX - 200) * (1.0 / window.ZOOM)));
+	var mousey = Math.round(((e.pageY - 200) * (1.0 / window.ZOOM)));
 	
 	var canvas = document.getElementById("fog_overlay");
 	var ctx = canvas.getContext("2d");
@@ -855,8 +855,8 @@ function drawing_mousemove(e) {
 
 function drawing_mouseup(e) {
 
-	mousex = (e.pageX - 200) * (1.0 / window.ZOOM);
-	mousey = (e.pageY - 200) * (1.0 / window.ZOOM);
+	mousex = Math.round(((e.pageX - 200) * (1.0 / window.ZOOM)));
+	mousey = Math.round(((e.pageY - 200) * (1.0 / window.ZOOM)));
 
 	if (window.DRAWSHAPE === 'select') {
 		$("#fog_overlay").css("z-index", "31");
@@ -1149,8 +1149,8 @@ function drawing_contextmenu(e) {
 				fill,
 				drawStroke,
 				lineWidth,
-				(e.pageX - 200) * (1.0 / window.ZOOM),
-				(e.pageY - 200) * (1.0 / window.ZOOM)
+				Math.round(((e.pageX - 200) * (1.0 / window.ZOOM))),
+				Math.round(((e.pageY - 200) * (1.0 / window.ZOOM)))
 			);
 		}
 		else

--- a/Fog.js
+++ b/Fog.js
@@ -875,6 +875,12 @@ function drawing_mouseup(e) {
 	{
 		return;
 	}
+	
+	// ignore middle-mouse clicks
+	if(e.which == 2)
+	{
+		return;
+	}
 
 	if (!window.MOUSEDOWN) {
 		return;

--- a/Main.js
+++ b/Main.js
@@ -1415,6 +1415,7 @@ function init_buttons() {
 	draw_menu.append("<div><button id='draw_circle' style='width:75px' class='drawbutton menu-option draw-option' data-shape='arc' data-type='draw'>Circle</button></div>");
 	draw_menu.append("<div><button id='draw_cone' style='width:75px' class='drawbutton menu-option draw-option' data-shape='cone' data-type='draw'>Cone</button></div>");
 	draw_menu.append("<div><button id='draw_line' style='width:75px' class='drawbutton menu-option draw-option' data-shape='line' data-type='draw'>Line</button></div>");
+	draw_menu.append("<div><button id='draw_brush' style='width:75px' class='drawbutton menu-option draw-option' data-shape='brush' data-type='draw'>Brush</button></div>");
 	draw_menu.append("<div><button id='draw_polygon' style='width:75px' class='drawbutton menu-option draw-option' data-shape='polygon' data-type='draw'>Polygon</button></div>");
 	draw_menu.append("<div><button id='draw_erase' style='width:75px' class='drawbutton menu-option draw-option' data-shape='rect' data-type='eraser'>Erase</button></div>");
 	
@@ -1469,6 +1470,8 @@ function init_buttons() {
 		$(this).css('background', 'green');
 	});
 
+	draw_menu.append("<div style='font-weight:bold'>Line Width</div>");
+	draw_menu.append("<div><input id='draw_line_width' type='range' style='width:75px' min='1' max='60' value='6' class='drawWidthSlider'></div>");
 
 	draw_menu.css("position", "fixed");
 	draw_menu.css("top", "25px");

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -102,7 +102,7 @@ body > button:hover,
 }
 
 .top_menu.visible {
-    max-height: 325px;
+    max-height: 400px;
 }
 
 .sidebar__controls > div button {


### PR DESCRIPTION
Add brush tool, gets the mouse position every 75ms to keep the number of points fairly low while still providing good tracking.
Add line-width slider for draw tools, works with the brush, lines, and any 'border' shape.
Made functions for drawing each shape to cut down on repeated code in drawing_mousemove, redraw_drawings, redraw_canvas.
Changed drawing_mousemove so the shape looks like what it will be while drawing, rather than always being red and transparent.
("Filled" and "Border" shapes are 90% opacity while drawing).
Adding fog now creates a grey shape as it is being drawn. Revealing still creates a red shape. This makes it less likely for DMs to mix them up as they are using them.
Right clicking while drawing shapes/fog will now cancel the draw.
Middle-clicking will no longer end a drawing, so users can pan while they draw.