### PR TITLE
Bugfix: Hide DM button for non-DM

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1558,7 +1558,7 @@ function init_stream_button() {
 $(function() {
 	window.EXTENSION_PATH = $("#extensionpath").attr('data-path');
 	var is_dm=false;
-	if($(".ddb-campaigns-detail-body-dm-notes-label").length>0){
+	if($(".ddb-campaigns-detail-body-dm-notes-private").length>0){
 		is_dm=true;
 	}
 	


### PR DESCRIPTION
Bug: If a campaign has any public notes, all players can see the "JOIN AS DM" button.
Fix: look for .ddb-campaigns-detail-body-dm-notes-private instead of .ddb-campaigns-detail-body-dm-notes-label to determine if the JOIN AS DM button shows up