### PR TITLE
Bugfix: Player token re-placed if token button clicked

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1025,6 +1025,15 @@ function token_button(e, tokenIndex = null, tokenTotal = null) {
 		id = uuid();
 	}
 
+	// if this is a player token, check if the token is already on the map
+	if(id in window.TOKEN_OBJECTS){
+		if(window.TOKEN_OBJECTS[id].isPlayer())
+		{
+			window.TOKEN_OBJECTS[id].highlight();
+			return;
+		}
+	}
+	
 	options = {
 		id: id,
 		imgsrc: imgsrc,


### PR DESCRIPTION
Bug: If the TOKEN button in the player list is clicked for a player who's token is already in the scene, the token will be re-placed in the middle of the scene for players, but the DM will not see the token move.
Fix: The TOKEN button will check to see if the player token already exists, and if so it will be highlighted for the DM.