### PR TITLE
Use higher resolution images for PC tokens

### DIFF
--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -207,6 +207,8 @@ function update_pclist() {
 // Higher res of the same character can be found at  https://www.dndbeyond.com/avatars/17/212/636377840850178381.jpeg
 // This is a slightly hacky method of getting the higher resolution image from the url of the thumbnail.
 function get_higher_res_url(thumbnailUrl) {
+	const thumbnailUrlMatcher = /avatars\/thumbnails\/\d+\/\d+\/\d\d\/\d\d\//
+	if (!thumbnailUrl.match(thumbnailUrlMatcher)) return thumbnailUrl
 	return thumbnailUrl
 		.replace('/thumbnails', '')
 		.replace(/\/\d\d\/\d\d\//, '/') // Remove the part of the url in the form /60/62

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -20,10 +20,12 @@ function update_pclist() {
 		tmp = $(this).find(".ddb-campaigns-character-card-header-upper-character-info-primary");
 		name = tmp.html();
 		tmp = $(this).find(".user-selected-avatar");
-		if (tmp.length > 0)
-			image = tmp.css("background-image").slice(5, -2); // url("x") TO -> x
-		else
+		if (tmp.length > 0) {
+			const lowResUrl = tmp.css("background-image").slice(5, -2); // url("x") TO -> x
+			image = get_higher_res_url(lowResUrl)
+		} else {
 			image = "/content/1-0-1436-0/skins/waterdeep/images/characters/default-avatar.png";
+		}
 		sheet = $(this).find(".ddb-campaigns-character-card-footer-links-item-view").attr("href");
 
 		pc = {
@@ -199,4 +201,13 @@ function update_pclist() {
 
 	// reset scroll position
 	$(".sidebar__pane-content").scrollTop(scroll_y);
+}
+
+// Low res thumbnails have the form https://www.dndbeyond.com/avatars/thumbnails/17/212/60/60/636377840850178381.jpeg
+// Higher res of the same character can be found at  https://www.dndbeyond.com/avatars/17/212/636377840850178381.jpeg
+// This is a slightly hacky method of getting the higher resolution image from the url of the thumbnail.
+function get_higher_res_url(thumbnailUrl) {
+	return thumbnailUrl
+		.replace('/thumbnails', '')
+		.replace(/\/\d\d\/\d\d\//, '/') // Remove the part of the url in the form /60/62
 }


### PR DESCRIPTION
Currently we're getting the PC images from the thumbnail of their character sheet, but this is a low quality version of the image. You can get the high resolution image by removing the `/thumbnails` and `/60/60` part of the url. (The numbers change depending on the character)

This is admittedly slightly hacky, but I can't see a better way of getting the high quality image at this time, and it makes a huge difference to the look of the VTT.