### PR TITLE
BUGFIX: Exception For Private Character Sheet

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -91,8 +91,15 @@ function increase_zoom() {
 
 function getPlayerIDFromSheet(sheet_url)
 {
-	var urlSplit = sheet_url.split("/");
-	var playerID = urlSplit[urlSplit.length - 1];
+	let playerid = -1;
+	if(sheet_url)
+	{
+		let urlSplit = sheet_url.split("/");
+		if(urlSplit.length > 0)
+		{
+			playerID = urlSplit[urlSplit.length - 1];
+		}
+	}
 	return playerID;
 }
 


### PR DESCRIPTION
BUG: If preload_player_sheet hits a bug it fails the extension, this is noticeable if you have a non-campaign owner DM acting as DM and a player has their sheet to private (for example). When it calls getPlayerIDFromSheet the variable is undefined causing a barf which prevents parts of the module from loading completely.
FIX: If the player sheet url is undefined, return a -1 player id (distinct from a 0 player ID for the DM)