### PR TITLE
prevent hp and max hp from being negative

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -222,10 +222,10 @@ class Token {
 
 		if ( ( (!(this.options.monster > 0)) || window.DM || (!window.DM && this.options.hidestat)) && !this.options.disablestat && old.find(".hp").length > 0) {
 			if (old.find(".hp").val().startsWith("+") || old.find(".hp").val().startsWith("-")) {
-				old.find(".hp").val(parseInt(this.options.hp) + parseInt(old.find(".hp").val()));
+				old.find(".hp").val(Math.max(0, parseInt(this.options.hp) + parseInt(old.find(".hp").val())));
 			}
 			if (old.find(".max_hp").val().startsWith("+") || old.find(".max_hp").val().startsWith("-")) {
-				old.find(".max_hp").val(parseInt(this.options.max_hp) + parseInt(old.find(".max_hp").val()));
+				old.find(".max_hp").val(Math.max(0, parseInt(this.options.max_hp) + parseInt(old.find(".max_hp").val())));
 			}
 			$("input").blur();
 


### PR DESCRIPTION
I often find myself subtracting the damage the players deal before checking the monsters hp to see if it would kill it, resulting in that final blow dropping the monster into the negative rather than `0` and killing it. This causes me to adjust the hp twice twice.

Either way, I don't believe hp (or max hp) could ever be negative in 5e, this change fixes that by forcing `0` as the maximum for either hp or max hp. Final blows greater than the monsters current hp will correctly result in it dieing and receiving the big red ❌  instead if it dropping into negative numbers and still "looking" alive.

![Kapture 2021-09-19 at 21 56 58](https://user-images.githubusercontent.com/8643560/133950863-54c606db-8ace-4442-b781-89fb92d27aa5.gif)
