### PR TITLE
Prevent token image distortion

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -378,6 +378,7 @@ div#scene_properties form > div {
 
 .token-image {
     cursor: move;
+    object-fit: cover;
 }
 
 .hasTooltip::after {


### PR DESCRIPTION
Adds `object-fit: cover` to token image, preventing distortion on resize.