### PR TITLE
fixing jitsi modal width overflow

### DIFF
--- a/Jitsi.js
+++ b/Jitsi.js
@@ -78,7 +78,7 @@ function jitsi_tile_listener(event) {
 }
 
 function jitsi_modal() {
-	$("#meet").css("position", "fixed").css("top", "100px").css("height", "80%").css("left", "50px").css("width", (window.width-400)+"px");
+	$("#meet").css("position", "fixed").css("top", "100px").css("height", "80%").css("left", "50px").css("width", "75%");
 	window.tile_desired = true;
 	window.jitsiAPI.executeCommand(`toggleTileView`);
 	$("#jitsi_switch").html("<span class='material-icons button-icon' data-name='Exit fullscreen (v)>fullscreen_exit</span>");


### PR DESCRIPTION
Currently, if you open the jitsi modal (gallery mode) the right side runs way off the screen, in some cases (depending on your display size) pushing all the participants out of view. This change addresses that by setting the width of the modal relative to the space and not statically based on `window.width`.


## Before
![Screen Shot 2021-09-20 at 9 54 03 AM](https://user-images.githubusercontent.com/8643560/134015326-a5c0c45a-a4a9-4a91-8678-509e07519751.png)

## After
![Screen Shot 2021-09-20 at 9 56 25 AM](https://user-images.githubusercontent.com/8643560/134015362-7d7483fb-3f45-41fc-9eb8-5a081d8dc8b5.png)
 