### PR TITLE
jitsi improvements

### DIFF
--- a/Jitsi.js
+++ b/Jitsi.js
@@ -67,21 +67,17 @@ function init_jitsi() {
 			VERTICAL_FILMSTRIP: false
 		},
 	};
-	api = new JitsiMeetExternalAPI(domain, options);
-	window.jitsiAPI = api;
+	window.jitsiAPI = new JitsiMeetExternalAPI(domain, options);
+	jitsi_bottom()
 
-	/* You can not execute any commands right after you instantiate the jitsi client
-	and there is really no way to wait for the client to be ready. A workaround is to
-	create a one time use handler just for startup, to render the pane and set the tile
-	layout, attached to the subjectChange event, which by chance is almost the last thing
-	the client does before being considered ready. After which, commands can be executed.
-	*/
-	api.addEventListener('subjectChange', jitsi_startup)
+	//You must wait for the local participant to join the conference before attempting to execute any commands against the api 
+	window.jitsiAPI.addEventListener('videoConferenceJoined', jitsi_startup)
 }
 
+// This only gets used once, the very first time after you start video
 function jitsi_startup() {
-	window.jitsiAPI.removeListener('subjectChange', jitsi_startup);
-	jitsi_bottom()
+	window.jitsiAPI.removeListener('videoConferenceJoined', jitsi_startup);
+	jitsi_bottom();
 }
 
 function jitsi_modal() {

--- a/Jitsi.js
+++ b/Jitsi.js
@@ -87,7 +87,7 @@ function jitsi_startup() {
 function jitsi_modal() {
 	$("#meet").css("position", "fixed").css("top", "100px").css("height", "80%").css("left", "50px").css("width", "75%");
 	window.tile_desired = true;
-	window.jitsiAPI.executeCommand(`setTileView`, false);
+	window.jitsiAPI.executeCommand(`setTileView`, true);
 	$("span", $("#jitsi_switch")).text("fullscreen_exit");
 	$("#jitsi_switch").attr("data-name","Exit fullscreen (v)");
 }
@@ -95,7 +95,7 @@ function jitsi_modal() {
 function jitsi_bottom() {
 	$("#meet").css("position", "fixed").css("top", "").css("height", "120px").css("left", "50px").css("width", "75%").css("bottom", "10px");
 	window.tile_desired = false;
-	window.jitsiAPI.executeCommand(`setTileView`, true);
+	window.jitsiAPI.executeCommand(`setTileView`, false);
 	$("span", $("#jitsi_switch")).text("fullscreen");
 	$("#jitsi_switch").attr("data-name","Fullscreen (v)");
 }

--- a/Jitsi.js
+++ b/Jitsi.js
@@ -47,40 +47,36 @@ function init_jitsi() {
 		configOverwrite: {
 			prejoinPageEnabled: false,
 			startWithAudioMuted: true,
+			// disableResponsiveTiles: true,
+			toolbarButtons: [
+				"camera",
+				"desktop",
+				"microphone",
+				"select-background",
+				"settings",
+				"shareaudio",
+				"tileview",
+				"videoquality"
+			],
 		},
 		interfaceConfigOverwrite: {
-			TOOLBAR_BUTTONS: ["microphone", "camera", "settings", "tileview"],
-			VERTICAL_FILMSTRIP: false,
-			filmStripOnly: true,
 			DISABLE_DOMINANT_SPEAKER_INDICATOR: true,
 			DISABLE_JOIN_LEAVE_NOTIFICATIONS: true,
-			TOOLBAR_TIMEOUT: 500,
 			INITIAL_TOOLBAR_TIMEOUT: 500,
-			SHOW_CHROME_EXTENSION_BANNER: false
-
+			SHOW_CHROME_EXTENSION_BANNER: false,
+			TOOLBAR_TIMEOUT: 500,
+			VERTICAL_FILMSTRIP: false
 		},
 	};
 	api = new JitsiMeetExternalAPI(domain, options);
 	window.jitsiAPI = api;
-	$("#meet").css("position", "fixed").css("top", "").css("height", "120px").css("left", "50px").css("width", "75%").css("bottom", "10px");
-	window.tile_desired = false;
-	api.addEventListener("tileViewChanged", jitsi_tile_listener);
-	setTimeout(jitsi_bottom, 10000)
-}
-
-
-function jitsi_tile_listener(event) {
-	console.log("jitsi_tile_listener status" + event.enabled);
-	window.jitsiAPI.removeEventListener("tileViewChanged", jitsi_tile_listener);
-	if (event.enabled != window.tile_desired)
-		window.jitsiAPI.executeCommand(`toggleTileView`);
-	setTimeout(function() { window.jitsiAPI.addEventListener("tileViewChanged", jitsi_tile_listener); }, 1000); // BUGGY AND HACKY
+	jitsi_bottom()
 }
 
 function jitsi_modal() {
 	$("#meet").css("position", "fixed").css("top", "100px").css("height", "80%").css("left", "50px").css("width", "75%");
 	window.tile_desired = true;
-	window.jitsiAPI.executeCommand(`toggleTileView`);
+	window.jitsiAPI.executeCommand(`setTileView`, false);
 	$("span", $("#jitsi_switch")).text("fullscreen_exit");
 	$("#jitsi_switch").attr("data-name","Exit fullscreen (v)");
 }
@@ -89,8 +85,7 @@ function jitsi_bottom() {
 	console.log("jitsi to bottom");
 	$("#meet").css("position", "fixed").css("top", "").css("height", "120px").css("left", "50px").css("width", "75%").css("bottom", "10px");
 	window.tile_desired = false;
-	//window.jitsiAPI.setLargeVideoParticipant(0);
-	window.jitsiAPI.executeCommand(`toggleTileView`);
+	window.jitsiAPI.executeCommand(`setTileView`, true);
 	$("span", $("#jitsi_switch")).text("fullscreen");
 	$("#jitsi_switch").attr("data-name","Fullscreen (v)");
 }

--- a/Jitsi.js
+++ b/Jitsi.js
@@ -69,6 +69,18 @@ function init_jitsi() {
 	};
 	api = new JitsiMeetExternalAPI(domain, options);
 	window.jitsiAPI = api;
+
+	/* You can not execute any commands right after you instantiate the jitsi client
+	and there is really no way to wait for the client to be ready. A workaround is to
+	create a one time use handler just for startup, to render the pane and set the tile
+	layout, attached to the subjectChange event, which by chance is almost the last thing
+	the client does before being considered ready. After which, commands can be executed.
+	*/
+	api.addEventListener('subjectChange', jitsi_startup)
+}
+
+function jitsi_startup() {
+	window.jitsiAPI.removeListener('subjectChange', jitsi_startup);
 	jitsi_bottom()
 }
 
@@ -81,7 +93,6 @@ function jitsi_modal() {
 }
 
 function jitsi_bottom() {
-	console.log("jitsi to bottom");
 	$("#meet").css("position", "fixed").css("top", "").css("height", "120px").css("left", "50px").css("width", "75%").css("bottom", "10px");
 	window.tile_desired = false;
 	window.jitsiAPI.executeCommand(`setTileView`, true);

--- a/Jitsi.js
+++ b/Jitsi.js
@@ -78,7 +78,7 @@ function jitsi_tile_listener(event) {
 }
 
 function jitsi_modal() {
-	$("#meet").css("position", "fixed").css("top", "100px").css("height", "80%").css("left", "50px").css("width", (window.width-400)+"px");
+	$("#meet").css("position", "fixed").css("top", "100px").css("height", "80%").css("left", "50px").css("width", "75%");
 	window.tile_desired = true;
 	window.jitsiAPI.executeCommand(`toggleTileView`);
 	$("span", $("#jitsi_switch")).text("fullscreen_exit");

--- a/Jitsi.js
+++ b/Jitsi.js
@@ -47,7 +47,6 @@ function init_jitsi() {
 		configOverwrite: {
 			prejoinPageEnabled: false,
 			startWithAudioMuted: true,
-			// disableResponsiveTiles: true,
 			toolbarButtons: [
 				"camera",
 				"desktop",


### PR DESCRIPTION
* added share audio feature (for sharing your computer's audio, a just a tab, etc)
* added share desktop feature (for sharing something quickly from your desktop, a tab, etc )
* added select background feature, for hiding the giant mess behind you
* moved deprecated `TOOLBAR_BUTTONS` options to `configOverwrite` object
* on video layout toggle, force the tiling state rather than toggling it
* fixed event listener workaround
* fixed bug where jitsi was being bottomed when not being asked to 
* general code cleanup
* fixed width overflow
  * width before
![Screen Shot 2021-09-20 at 9 54 03 AM](https://user-images.githubusercontent.com/8643560/134015326-a5c0c45a-a4a9-4a91-8678-509e07519751.png)
  *  width after
![Screen Shot 2021-09-20 at 9 56 25 AM](https://user-images.githubusercontent.com/8643560/134015362-7d7483fb-3f45-41fc-9eb8-5a081d8dc8b5.png)
 