### PR TITLE
BUGFIX: Place Token In Unload Scene

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -484,6 +484,10 @@ class Token {
 
 
 	place(animationDuration) {
+		if(!window.CURRENT_SCENE_DATA){
+			// No scene loaded!
+			return;
+		}
 		if (animationDuration == undefined || parseFloat(animationDuration) == NaN) {
 			animationDuration = 1000;
 		}


### PR DESCRIPTION
Check if a scene has been loaded before trying to place a token