### PR TITLE
Load player stats from json

### DIFF
--- a/DnDBeyond/DDBCharacterData.js
+++ b/DnDBeyond/DDBCharacterData.js
@@ -1,0 +1,627 @@
+// ==UserScript==
+// @name         Test Direct Data
+// @namespace    http://tampermonkey.net/
+// @version      0.1
+// @description  try to take over the world!
+// @author       You
+// @match        https://www.dndbeyond.com/campaigns/*
+// @require      http://code.jquery.com/jquery-3.4.1.min.js
+// @require      https://media.dndbeyond.com/character-tools/vendors~characterTools.bundle.f8b53c07d1796f1d29cb.min.js
+// @grant        none
+// ==/UserScript==
+
+var rulesUrls = ["https://character-service.dndbeyond.com/character/v4/rule-data?v=3.11.3", "https://gamedata-service.dndbeyond.com/vehicles/v3/rule-data?v=3.11.3"];
+var charJSONurlBase = "https://character-service.dndbeyond.com/character/v4/character/";
+
+var rulesData = {};
+
+//onload(charIDs);
+
+
+function get_pclist_player_data() {
+    window.pcs.forEach(function (pc) {
+        getPlayerData(pc.sheet, function (playerData) {
+            window.MB.handlePlayerData(playerData);
+        })
+    });
+}
+
+
+function getDDBCharData(charID, callback) {
+    let charState = generateSingleCharState(charID);
+    updateSingleCharData(charState, function (updatedState) {
+        if (callback) {
+            callback(charState.data);
+        }
+    });
+}
+
+function getPlayerData(sheet_url, callback) {
+    let charID = getPlayerIDFromSheet(sheet_url);
+    getDDBCharData(charID, function (charData) {
+
+        let conditions = [];
+        for (var i = 0; i < charData.conditions.length; i++) {
+            let condition = charData.conditions[i];
+            let conditionString = condition.definition.name;
+            if (condition.level) {
+                conditionString += " (Level " + condition.level + ")";
+            }
+            conditions.push(conditionString);
+        }
+
+        let abilities = [];
+        for (var i = 0; i < charData.abilities.length; i++) {
+            let modifier = "0";
+            if (charData.abilities[i].modifier > 0) {
+                modifier = "+" + charData.abilities[i].modifier;
+            }
+            else {
+                modifier = charData.abilities[i].modifier;
+            }
+            let ability = {
+                abilityName: charData.abilities[i].label,
+                abilityAbbr: charData.abilities[i].name,
+                modifier: modifier,
+                score: charData.abilities[i].totalScore,
+                save: charData.abilities[i].save,
+            }
+            abilities.push(ability);
+        }
+        let walkspeed = 30;
+        for (var i = 0; i < charData.speeds.length; i++) {
+            if (charData.speeds[i].key == "walk") {
+                walkspeed = charData.speeds[i].distance;
+            }
+        }
+
+        var playerdata = {
+            id: sheet_url,
+            hp: charData.hitPointInfo.remainingHp,
+            max_hp: charData.hitPointInfo.totalHp,
+            temp_hp: charData.hitPointInfo.tempHp,
+            ac: charData.armorClass, 
+            pp: charData.passivePerception,
+            conditions: conditions,
+            abilities: abilities,
+            walking: walkspeed+ "ft.",
+            inspiration: charData.hitPointInfo.inspiration,
+        };
+        if (callback) {
+            callback(playerdata);
+        }
+    });
+
+}
+
+function generateSingleCharState(charID) {
+    var stateTemplate = {
+        appEnv: {
+            authEndpoint: "https://auth-service.dndbeyond.com/v1/cobalt-token", characterEndpoint: "", characterId: 0, characterServiceBaseUrl: null, diceEnabled: true, diceFeatureConfiguration: {
+                apiEndpoint: "https://dice-service.dndbeyond.com", assetBaseLocation: "https://www.dndbeyond.com/dice", enabled: true, menu: true, notification: false, trackingId: ""
+            }, dimensions: { sheet: { height: 0, width: 1200 }, styleSizeType: 4, window: { height: 571, width: 1920 } }, isMobile: false, isReadonly: false, redirect: undefined, username: "example"
+        },
+        appInfo: { error: null },
+        character: {},
+        characterEnv: { context: "SHEET", isReadonly: false, loadingStatus: "LOADED" },
+        confirmModal: { modals: [] },
+        modal: { open: {} },
+        ruleData: rulesData.ruleset,
+        serviceData: { classAlwaysKnownSpells: {}, classAlwaysPreparedSpells: {}, definitionPool: {}, infusionsMappings: [], knownInfusionsMappings: [], ruleDataPool: rulesData.vehiclesRuleset, vehicleComponentMappings: [], vehicleMappings: [] },
+        sheet: { initError: null, initFailed: false },
+        sidebar: { activePaneId: null, alignment: "right", isLocked: false, isVisible: false, panes: [], placement: "overlay", width: 340 },
+        syncTransaction: { active: false, initiator: null },
+        toastMessage: {}
+    }
+
+    //console.debug("Generating char: " + charID);
+    var charState = {
+        url: charJSONurlBase + charID,
+        state: stateTemplate,
+        data: {}
+    }
+    charState.state.appEnv.characterId = charID;
+    return charState
+}
+
+function getCharacterJSON(charID, callback) {
+    get_cobalt_token(function (token) {
+        $.ajax({
+            url: charJSONurlBase + charID,
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader('Authorization', 'Bearer ' + token);
+            },
+            xhrFields: {
+                withCredentials: true
+            },
+            success: function (data) {
+                // self.playerCache[playerid] = data;
+                callback(data);
+            }
+        });
+    });
+}
+
+
+function updateSingleCharData(charState, callback) {
+    //console.log("Retriving Char Data");
+    var charURLs = [];
+    charURLs.push(charState.url);
+    getCharacterJSON(charState.state.appEnv.characterId, function (charJSON) {
+        if (charJSON.success == null || charJSON.lenth < 1 || charJSON.success != true) {
+            console.warn("charJSON " + charState.state.appEnv.characterId + " is null, empty or fail");
+        }
+        var charId = charJSON.data.id;
+        //console.debug("Processing Char: " + charId);
+        charState.state.character = charJSON.data;
+        var charData = window.moduleExport.getCharData(charState.state);
+        charState.data = charData;
+        if (callback) {
+            callback(charState);
+        }
+    });
+    //getJSONfromURLs(charURLs).then((js) => {
+    //    window.jstest = js;
+    //    js.forEach(function (charJSON, index) {
+    //        if (charJSON.success == null || charJSON.lenth < 1 || charJSON.success != true) {
+    //            console.warn("charJSON " + index + " is null, empty or fail");
+    //        }
+    //        var charId = charJSON.data.id;
+    //        console.debug("Processing Char: " + charId);
+    //        charactersData[charId].state.character = charJSON.data;
+    //        var charData = window.getCharData(charactersData[charId].state);
+    //        charactersData[charId].data = charData;
+    //    });
+    //    console.log("Updated Char Data");
+    //    console.debug(charactersData);
+    //    updateCharInfo();
+    //}).catch((error) => {
+    //    console.log(error);
+    //});
+}
+
+function retriveRules() {
+    return new Promise(function (resolve, reject) {
+        console.log("Retriving Rules Data");
+        getJSONfromURLs(rulesUrls).then((js) => {
+           //console.log("Rules Data Processing Start");
+            js.forEach(function(rule, index){
+                if (rule.success == null || rule.lenth < 1 || rule.success != true){
+                    console.warn("ruleset " + index + " is null, empty or fail");
+                }
+            });
+            rulesData = {
+                ruleset : js[0].data,
+                vehiclesRuleset : js[1].data
+            }
+            //console.debug("Rules Data:");
+            //console.debug(rulesData);
+            resolve();
+        }).catch((error) => {
+            reject(error);
+        });
+    });
+}
+
+//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+//        Custom additonal modules to be loaded with D&DBeyond's module loader
+//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+var initalModules = {
+    2080: function (module, __webpack_exports__, __webpack_require__) {
+        "use strict";
+        __webpack_require__.r(__webpack_exports__);
+        console.log("Module 2080: start");
+        // Unused modules:
+        // var react = __webpack_require__(0);
+        // var react_default = __webpack_require__.n(react);
+        // var react_dom = __webpack_require__(84);
+        // var react_dom_default = __webpack_require__.n(react_dom);
+        // var es = __webpack_require__(10);
+        //var character_rules_engine_web_adapter_es = __webpack_require__(136);
+        //var dist = __webpack_require__(710);
+        //var dist_default = __webpack_require__.n(dist);
+        var Core = __webpack_require__(5);
+        var character_rules_engine_lib_es = __webpack_require__(1);
+
+        var crk = "rb";
+        var ktl = "d";
+        var cmov = "ab";
+
+        var key = "";
+
+        for (key in character_rules_engine_lib_es) {
+            if (typeof character_rules_engine_lib_es[key].getAbilities === 'function') {
+                crk = key;
+                //console.log("crk found: " + key);
+            }
+            if (typeof character_rules_engine_lib_es[key].getSenseTypeModifierKey === 'function') {
+                ktl = key;
+                //console.log("ktl found: " + key);
+            }
+        }
+
+        for (key in Core) {
+            if (typeof Core[key].WALK !== 'undefined' && typeof Core[key].SWIM !== 'undefined' && typeof Core[key].CLIMB !== 'undefined' && typeof Core[key].FLY !== 'undefined' && typeof Core[key].BURROW !== 'undefined') {
+                cmov = key;
+                //console.log("cmov found: " + key);
+            }
+        }
+
+        var charf1 = character_rules_engine_lib_es[crk];
+        var charf2 = character_rules_engine_lib_es[ktl];
+        var coref1 = character_rules_engine_lib_es[cmov];
+
+        //function getAuthHeaders() {
+        //    return dist_default.a.makeGetAuthorizationHeaders({});
+
+        //}
+
+        function getCharData(state) {
+            /*
+                All parts of the following return are from http://media.dndbeyond.com/character-tools/characterTools.bundle.71970e5a4989d91edc1e.min.js, they are found in functions that have: '_mapStateToProps(state)' in the name, like function CharacterManagePane_mapStateToProps(state)
+                Any return that uses the function character_rules_engine_lib_es or character_rules_engine_web_adapter_es can be added to this for more return values as this list is not comprehensive.
+                Anything with selectors_appEnv is unnessisary,as it just returns values in state.appEnv.
+            */
+            //console.log("Module 2080: Processing State Info Into Data");
+
+            var ruleData = charf1.getRuleData(state);
+
+            function getSenseData(senses) { // finds returns the label
+                return Object.keys(senses).map(function (index) {
+                    let indexInt = parseInt(index);
+                    return {
+                        id: indexInt,
+                        key: charf2.getSenseTypeModifierKey(indexInt),
+                        name: charf2.getSenseTypeLabel(indexInt),
+                        distance: senses[indexInt]
+                    }
+                })
+            }
+
+            function getSpeedData(speeds) { // finds returns the label
+                let halfSpeed = roundDown(divide(speeds[Core[cmov].WALK], 2));
+                return Object.keys(speeds).map(function (index) {
+                    let distance = speeds[index];
+                    if (Core[cmov].SWIM === index || Core[cmov].CLIMB === index) {
+                        // swim speed is essentiall half walking speed rounded down if character doesn't have a set swim speed:
+                        // source https://www.dndbeyond.com/sources/basic-rules/adventuring#ClimbingSwimmingandCrawling
+                        distance = speeds[index] <= 0 ? halfSpeed : speeds[index];
+                    }
+                    return {
+                        id: charf2.getMovementTypeBySpeedMovementKey(index),
+                        key: index,
+                        name: charf2.getSpeedMovementKeyLabel(index, ruleData),
+                        distance: distance
+                    }
+                });
+            }
+            //let baseHp= charf1.getBaseHp(state);
+            //let overrideHp= charf1.getOverrideHp(state);
+            //let bonusHp= charf1.getBonusHp(state);
+            //let tempHp= charf1.getTempHp(state);
+            //let removedHp= charf1.getRemovedHp(state);
+
+            return {
+                name: charf1.getName(state),
+                avatarUrl: charf1.getAvatarUrl(state),
+                //baseHp: getBaseHp(state),
+                //overrideHp: getOverrideHp(state),
+                //bonusHp: getBonusHp(state),
+                //tempHp: getTempHp(state),
+                //removedHp: getRemovedHp(state),
+                hitPointInfo: charf1.getHitPointInfo(state), // unbelievably bloated
+                armorClass: charf1.getAcTotal(state),
+                conditions: charf1.getActiveConditions(state),
+                initiative: charf1.getProcessedInitiative(state),
+                hasInitiativeAdvantage: charf1.getHasInitiativeAdvantage(state),
+                resistances: charf1.getActiveGroupedResistances(state),
+                immunities: charf1.getActiveGroupedImmunities(state),
+                vulnerabilities: charf1.getActiveGroupedVulnerabilities(state),
+                fails: charf1.getDeathSavesFailCount(state),
+                successes: charf1.getDeathSavesSuccessCount(state),
+                abilities: charf1.getAbilities(state), // not sure what the difference is between this and abilityLookup, seems to be one is a object, the other an array...
+                //abilityLookup: charf1.getAbilityLookup(state),
+                passivePerception: charf1.getPassivePerception(state),
+                passiveInvestigation: charf1.getPassiveInvestigation(state),
+                passiveInsight: charf1.getPassiveInsight(state),
+                inspiration: charf1.getInspiration(state),
+                speeds: getSpeedData(charf1.getCurrentWeightSpeed(state)),
+                size: charf1.getSize(state),
+                equipped: {
+                    armorItems: charf1.getEquippedArmorItems(state),
+                    weaponItems: charf1.getEquippedWeaponItems(state),
+                    gearItems: charf1.getEquippedGearItems(state)
+                },
+                //spellCasterInfo: charf1.getSpellCasterInfo(state),
+                //choiceInfo: charf1.getChoiceInfo(state),
+                //classes: charf1.getClasses(state),
+                //feats: charf1.getBaseFeats(state),
+                //race: charf1.getRace(state),
+                //currentXp: charf1.getCurrentXp(state),
+                //preferences: charf1.getCharacterPreferences(state),
+                //totalClassLevel: charf1.getTotalClassLevel(state),
+                //startingClass: charf1.getStartingClass(state),
+                //background: charf1.getBackgroundInfo(state),
+                //notes: charf1.getCharacterNotes(state),
+                //totalWeight: charf1.getTotalWeight(state),
+                //carryCapacity: charf1.getCarryCapacity(state),
+                //pushDragLiftWeight: charf1.getPushDragLiftWeight(state),
+                //encumberedWeight: charf1.getEncumberedWeight(state),
+                //heavilyEncumberedWeight: charf1.getHeavilyEncumberedWeight(state),
+                //preferences: charf1.getCharacterPreferences(state),
+                //currencies: charf1.getCurrencies(state),
+                //attunedSlots: charf1.getAttunedSlots(state),
+                //attunableArmor: charf1.getAttunableArmor(state),
+                //attunableGear: charf1.getAttunableGear(state),
+                //attunableWeapons: charf1.getAttunableWeapons(state),
+               /* background: charf1.getBackgroundInfo(state),*/
+                //unequipped: {
+                //    armorItems: charf1.getUnequippedArmorItems(state),
+                //    weaponItems: charf1.getUnequippedWeaponItems(state),
+                //    gearItems: charf1.getUnequippedGearItems(state)
+                //},
+                //proficiencyBonus: charf1.getProficiencyBonus(state),
+                //preferences: charf1.getCharacterPreferences(state),
+                //senses: getSenseData(charf1.getSenseInfo(state)), //has to be further processed
+                //skills: charf1.getSkills(state),
+                //customSkills: charf1.getCustomSkills(state),
+                //savingThrowDiceAdjustments: charf1.getSavingThrowDiceAdjustments(state),
+                //situationalBonusSavingThrowsLookup: charf1.getSituationalBonusSavingThrowsLookup(state),
+                //deathSaveInfo: charf1.getDeathSaveInfo(state),
+                //proficiencyGroups: charf1.getProficiencyGroups(state),
+                //background: charf1.getBackgroundInfo(state),
+                //alignment: charf1.getAlignment(state),
+                //height: charf1.getHeight(state),
+                //weight: charf1.getWeight(state),
+                //faith: charf1.getFaith(state),
+                //skin: charf1.getSkin(state),
+                //eyes: charf1.getEyes(state),
+                //hair: charf1.getHair(state),
+                //age: charf1.getAge(state),
+                //gender: charf1.getGender(state),
+                //traits: charf1.getCharacterTraits(state),
+                //notes: charf1.getCharacterNotes(state),
+                //levelSpells: charf1.getLevelSpells(state),
+                //spellCasterInfo: charf1.getSpellCasterInfo(state),
+                //ruleData: charf1.getRuleData(state),
+                //xpInfo: charf1.getExperienceInfo(state),
+                //spellSlots: charf1.getSpellSlots(state),
+                //pactMagicSlots: charf1.getPactMagicSlots(state),
+                //attunedSlots: charf1.getAttunedSlots(state),
+                //hasMaxAttunedItems: charf1.hasMaxAttunedItems(state),
+                //weaponSpellDamageGroups: charf1.getWeaponSpellDamageGroups(state),
+                //inventory: charf1.getInventory(state),
+                //creatures: charf1.getCreatures(state),
+                //customItems: charf1.getCustomItems(state),
+                //weight: charf1.getTotalWeight(state),
+                //weightSpeedType: charf1.getCurrentWeightType(state),
+                //notes: charf1.getCharacterNotes(state),
+                //currencies: charf1.getCurrencies(state),
+                //activatables: charf1.getActivatables(state),
+                //attacks: charf1.getAttacks(state),
+                //weaponSpellDamageGroups: charf1.getWeaponSpellDamageGroups(state),
+                //attacksPerActionInfo: charf1.getAttacksPerActionInfo(state),
+                //ritualSpells: charf1.getRitualSpells(state),
+                //spellCasterInfo: charf1.getSpellCasterInfo(state),
+                //originRefRaceData: charf1.getDataOriginRefRaceData(state),
+                //hasSpells: charf1.hasSpells(state),
+               // optionalOrigins: charf1.getOptionalOrigins(state),
+            }
+        }
+        window.moduleExport = {
+            getCharData: getCharData,
+            //getAuthHeaders: getAuthHeaders,
+        }
+        console.log("Module 2080: end");
+    }
+};
+
+//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+//        D&DBeyond Module Loader
+//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+function loadModules(modules) {
+    /*
+        A near direct copy of the function from http://media.dndbeyond.com/character-tools/characterTools.bundle.71970e5a4989d91edc1e.min.js
+        This basically loads in the modules in https://media.dndbeyond.com/character-tools/vendors~characterTools.bundle.f8b53c07d1796f1d29cb.min.js and similar module based scripts
+        these are stored in window.jsonpDDBCT and can be loaded by this script and interacted with by active modules
+    */
+    console.log("Loading modules");
+    function webpackJsonpCallback(data) {
+        /*
+            This allows additonal modules to be added run, the input format needs to be at least a two dimentional array,
+            e.g. [[2],[function (module, exports, __webpack_require__) {...},...]] or [2],{34: function (module, exports, __webpack_require__) {...},...}] if you want to have set module id's
+            you can also run modules by adding a third element to the argument data, e.g. [4],{69: function (module, __webpack_exports__, __webpack_require__) {...},...}, [69,4]] which will run the module 69 in chunk 4
+            I am not 100% on the logic of this, so feel free to expand on this and futher comment to help out!
+        */
+        var chunkIds = data[0];
+        var moreModules = data[1];
+        var executeModules = data[2];
+        var moduleId,
+            chunkId,
+            i = 0,
+            resolves = [];
+        for (; i < chunkIds.length; i++) {
+            chunkId = chunkIds[i];
+            if (Object.prototype.hasOwnProperty.call(installedChunks, chunkId) && installedChunks[chunkId]) {
+                resolves.push(installedChunks[chunkId][0])
+            }
+            installedChunks[chunkId] = 0
+        }
+        for (moduleId in moreModules) {
+            if (Object.prototype.hasOwnProperty.call(moreModules, moduleId)) {
+                modules[moduleId] = moreModules[moduleId]
+            }
+        }
+        if (parentJsonpFunction) parentJsonpFunction(data);
+        while (resolves.length) {
+            resolves.shift()()
+        }
+        deferredModules.push.apply(deferredModules, executeModules || []);
+        return checkDeferredModules()
+    }
+    function checkDeferredModules() {
+        var result;
+        for (var i = 0; i < deferredModules.length; i++) {
+            var deferredModule = deferredModules[i];
+            var fulfilled = true;
+            for (var j = 1; j < deferredModule.length; j++) {
+                var depId = deferredModule[j];
+                if (installedChunks[depId] !== 0) fulfilled = false
+            }
+            if (fulfilled) {
+                deferredModules.splice(i--, 1);
+                result = __webpack_require__(__webpack_require__.s = deferredModule[0])
+            }
+        }
+        return result
+    }
+    var installedModules = {};
+    var installedChunks = {
+        0: 0
+    };
+    var deferredModules = [];
+    function __webpack_require__(moduleId) {
+        if (installedModules[moduleId]) {
+            return installedModules[moduleId].exports
+        }
+        var module = installedModules[moduleId] = {
+            i: moduleId,
+            l: false,
+            exports: {}
+        };
+        modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+        module.l = true;
+        return module.exports
+    }
+    __webpack_require__.m = modules;
+    __webpack_require__.c = installedModules;
+    __webpack_require__.d = function (exports, name, getter) {
+        if (!__webpack_require__.o(exports, name)) {
+            Object.defineProperty(exports, name, {
+                enumerable: true,
+                get: getter
+            })
+        }
+    };
+    __webpack_require__.r = function (exports) {
+        if (typeof Symbol !== "undefined" && Symbol.toStringTag) {
+            Object.defineProperty(exports, Symbol.toStringTag, {
+                value: "Module"
+            })
+        }
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        })
+    };
+    __webpack_require__.t = function (value, mode) {
+        if (mode & 1) value = __webpack_require__(value);
+        if (mode & 8) return value;
+        if (mode & 4 && typeof value === "object" && value && value.__esModule) return value;
+        var ns = Object.create(null);
+        __webpack_require__.r(ns);
+        Object.defineProperty(ns, "default", {
+            enumerable: true,
+            value: value
+        });
+        if (mode & 2 && typeof value != "string") {
+            for (var key in value) {
+                __webpack_require__.d(ns, key, function (key) {
+                    return value[key]
+                }.bind(null, key));
+            }
+        }
+
+        return ns
+    };
+    __webpack_require__.n = function (module) {
+        var getter = module && module.__esModule ? function getDefault() {
+            return module.default
+        }
+            : function getModuleExports() {
+                return module
+            };
+        __webpack_require__.d(getter, "a", getter);
+        return getter
+    };
+    __webpack_require__.o = function (object, property) {
+        return Object.prototype.hasOwnProperty.call(object, property)
+    };
+    __webpack_require__.p = "";
+    //window.jsonpDDBCT.push(modules);
+    var jsonpArray = window.jsonpDDBCT = window.jsonpDDBCT || [];
+    var oldJsonpFunction = jsonpArray.push.bind(jsonpArray); //This allows additonal modules to be added and run by using window.jsonpDDBCT.push(modules) which calls webpackJsonpCallback(modules) above
+    jsonpArray.push2 = webpackJsonpCallback;
+    jsonpArray = jsonpArray.slice();
+    for (var i = 0; i < jsonpArray.length; i++) webpackJsonpCallback(jsonpArray[i]);
+    var parentJsonpFunction = oldJsonpFunction;
+    deferredModules.push([2080, 2]); //This sets module 2080 as an active module and is run after the other modules are loaded
+    checkDeferredModules();
+    console.log("Finished loading modules");
+}
+
+//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+//        Generic Functions
+//---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+function getJSONfromURLs(urls) {
+    return new Promise(function (resolve, reject) {
+        //console.log("Fetching: ", urls);
+        var proms = urls.map(d => fetch(d));
+        Promise.all(proms)
+        .then(ps => Promise.all(ps.map(p => p.json()))) // p.json() also returns a promise
+        .then(jsons => {
+            //console.log("JSON Data Retrived");
+            resolve(jsons);
+        })
+        .catch((error) => {
+            reject(error);
+        });
+    });
+}
+
+function getSign(input){
+    if (input == null){
+        input = 0;
+    }
+    return input >= 0 ? positiveSign : negativeSign
+}
+
+function roundDown(input){
+    let number = parseInt(input);
+    if (isNaN(number)) {
+        return NaN;
+    }
+    return Math.floor(input);
+}
+
+function roundUp(input){
+    let number = parseInt(input);
+    if (isNaN(number)) {
+        return NaN;
+    }
+    return Math.ceil(input);
+}
+
+function divide(numeratorInput, denominatorInput){
+    let numerator = parseInt(numeratorInput);
+    let denominator = parseInt(denominatorInput);
+    if (isNaN(numerator) || isNaN(denominator)) {
+        return NaN;
+    }
+    return numerator/denominator;
+}
+
+function distanceUnit(input){
+    let number = parseInt(input);
+    if (isNaN(number)) {
+        number = 0;
+    }
+    let unit = 'ft.';
+    if (number && number % FEET_IN_MILES === 0) {
+        number = number / FEET_IN_MILES;
+        unit = 'mile' + (Math.abs(number) === 1 ? '' : 's');
+    }
+    return unit;
+}

--- a/DnDBeyond/DDBCharacterData.js
+++ b/DnDBeyond/DDBCharacterData.js
@@ -1,15 +1,3 @@
-// ==UserScript==
-// @name         Test Direct Data
-// @namespace    http://tampermonkey.net/
-// @version      0.1
-// @description  try to take over the world!
-// @author       You
-// @match        https://www.dndbeyond.com/campaigns/*
-// @require      http://code.jquery.com/jquery-3.4.1.min.js
-// @require      https://media.dndbeyond.com/character-tools/vendors~characterTools.bundle.f8b53c07d1796f1d29cb.min.js
-// @grant        none
-// ==/UserScript==
-
 var rulesUrls = ["https://character-service.dndbeyond.com/character/v4/rule-data?v=3.11.3", "https://gamedata-service.dndbeyond.com/vehicles/v3/rule-data?v=3.11.3"];
 var charJSONurlBase = "https://character-service.dndbeyond.com/character/v4/character/";
 
@@ -19,9 +7,16 @@ var rulesData = {};
 
 
 function get_pclist_player_data() {
+    var processedPlayers = [];
     window.pcs.forEach(function (pc) {
         getPlayerData(pc.sheet, function (playerData) {
-            window.MB.handlePlayerData(playerData);
+            window.PLAYER_STATS[playerData.id] = playerData;
+            window.MB.sendTokenUpdateFromPlayerData(playerData);
+            processedPlayers.push(playerData.id);
+            let players = Object.keys(window.PLAYER_STATS);
+            if (areArraysEqualSets(processedPlayers, players)) {
+                update_pclist();
+            }
         })
     });
 }
@@ -624,4 +619,28 @@ function distanceUnit(input){
         unit = 'mile' + (Math.abs(number) === 1 ? '' : 's');
     }
     return unit;
+}
+
+function areArraysEqualSets(a1, a2) {
+    const superSet = {};
+    for (const i of a1) {
+        const e = i + typeof i;
+        superSet[e] = 1;
+    }
+
+    for (const i of a2) {
+        const e = i + typeof i;
+        if (!superSet[e]) {
+            return false;
+        }
+        superSet[e] = 2;
+    }
+
+    for (let e in superSet) {
+        if (superSet[e] === 1) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/DnDBeyond/LICENSE
+++ b/DnDBeyond/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 mivalsten
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Load.js
+++ b/Load.js
@@ -4,7 +4,7 @@ l.setAttribute("id", "extensionpath");
 l.setAttribute("data-path", chrome.runtime.getURL("/"));
 (document.body || document.documentElement).appendChild(l);
 
-["jquery.magnific-popup.min.js","purify.min.js","Journal.js","Settings.js","SoundPad.js","color-picker.js", "TokenMenu.js","SceneData.js", "jquery.ui.touch-punch.js", "CombatTracker.js", "StatHandler.js", "rpg-dice-roller.bundle.min.js", "MonsterDice.js", "Fog.js", "jquery.contextMenu.js", "PlayerPanel.js", "Token.js", "Jitsi.js", "MessageBroker.js", "ScenesHandler.js", "MonsterPanel.js", "ScenesPanel.js", "Main.js", "mousetrap.1.6.5.min.js", "KeypressHandler.js"].forEach(function(value, index, array) {
+["DnDBeyond/DDBCharacterData.js","jquery.magnific-popup.min.js","purify.min.js","Journal.js","Settings.js","SoundPad.js","color-picker.js", "TokenMenu.js","SceneData.js", "jquery.ui.touch-punch.js", "CombatTracker.js", "StatHandler.js", "rpg-dice-roller.bundle.min.js", "MonsterDice.js", "Fog.js", "jquery.contextMenu.js", "PlayerPanel.js", "Token.js", "Jitsi.js", "MessageBroker.js", "ScenesHandler.js", "MonsterPanel.js", "ScenesPanel.js", "Main.js", "mousetrap.1.6.5.min.js", "KeypressHandler.js"].forEach(function(value, index, array) {
 	var s = document.createElement('script');
 
 	s.src = chrome.runtime.getURL(value);

--- a/Main.js
+++ b/Main.js
@@ -1551,8 +1551,9 @@ function init_ui() {
 				retriveRules();
 				loadModules(initalModules);
 				window.character_update_task = setInterval(get_pclist_player_data, 10000);
-            }
-		},100);
+			}
+		}, 100);
+	}
 }
 
 function init_buttons() {

--- a/Main.js
+++ b/Main.js
@@ -55,6 +55,22 @@ function validateUrl(value) {
   return /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(value);
 }
 
+function loadScript(url, callback) {
+	// Adding the script tag to the head as suggested before
+	var head = document.head;
+	var script = document.createElement('script');
+	script.type = 'text/javascript';
+	script.src = url;
+
+	// Then bind the event to the callback function.
+	// There are several events for cross browser compatibility.
+	script.onreadystatechange = callback;
+	script.onload = callback;
+
+	// Fire the loading
+	head.appendChild(script);
+}
+
 const MAX_ZOOM = 5
 const MIN_ZOOM = 0.1
 function change_zoom(newZoom, x, y) {
@@ -683,8 +699,9 @@ function init_sheet(){
 	}
 }
 
-function preload_player_sheet(pc_sheet, loadWait = 0)
+function init_player_sheet(pc_sheet, loadWait = 0)
 {
+	
 	let container = $("#sheet");
 	iframe = $("<iframe id='PlayerSheet"+getPlayerIDFromSheet(pc_sheet)+"' src=''></iframe>")
 	//iframe.css('display', 'none');
@@ -693,6 +710,8 @@ function preload_player_sheet(pc_sheet, loadWait = 0)
 	iframe.css("top", "24px");
 	iframe.css("left", "0px");
 	iframe.css("height", "0px");
+	iframe.attr('data-sheet_url', pc_sheet);
+	iframe.attr('data-init_load', 0);
 	container.append(iframe);
 	iframe.on("load", function(event) {
 		$(event.target).contents().find("#mega-menu-target").remove();
@@ -700,26 +719,29 @@ function preload_player_sheet(pc_sheet, loadWait = 0)
 		$(event.target).contents().find(".page-header").remove();
 		$(event.target).contents().find(".homebrew-comments").remove();
 
-
+		
 		// DICE STREAMING ?!?!
 		if(!window.DM){
 			let firstTime=false;
 			if(!window.MYMEDIASTREAM)
-				firstTime=true;
-			window.MYMEDIASTREAM=$(event.target).contents().find(".dice-rolling-panel__container").get(0).captureStream(0);
+				firstTime = true;
+			let diceRollPanel = $(event.target).contents().find(".dice-rolling-panel__container");
+			if (diceRollPanel.length > 0) {
+				window.MYMEDIASTREAM = diceRollPanel.get(0).captureStream(0);
 
 
-			if(window.JOINTHEDICESTREAM){
-				// we should tear down and reconnect
-				for(let i in window.STREAMPEERS){
-					console.log("replacing the track")
-					window.STREAMPEERS[i].getSenders()[0].replaceTrack(window.MYMEDIASTREAM.getVideoTracks()[0]);
+				if (window.JOINTHEDICESTREAM) {
+					// we should tear down and reconnect
+					for (let i in window.STREAMPEERS) {
+						console.log("replacing the track")
+						window.STREAMPEERS[i].getSenders()[0].replaceTrack(window.MYMEDIASTREAM.getVideoTracks()[0]);
+					}
 				}
-			}
 
-			if(firstTime)
-				$("#stream_button").click();
-
+				if (firstTime)
+					$("#stream_button").click();
+            }
+				
 		}
 
 		// CHARACTER
@@ -738,7 +760,12 @@ function preload_player_sheet(pc_sheet, loadWait = 0)
 					max_hp = window.PLAYERDATA.max_hp;
 				else
 					max_hp = 0;
+			}
 
+			var temp_hp = 0;
+			var temp_hp_element = $(event.target).contents().find(".ct-health-summary__hp-item--temp > .ct-health-summary__hp-item-content > .ct-health-summary__hp-number ");
+			if (temp_hp_element.length > 0) {
+				temp_hp = temp_hp_element.html();
 			}
 
 
@@ -782,6 +809,7 @@ function preload_player_sheet(pc_sheet, loadWait = 0)
 				id: tokenid,
 				hp: current_hp,
 				max_hp: max_hp,
+				temp_hp: temp_hp,
 				ac: $(event.target).contents().find(".ddbc-armor-class-box__value").html(),
 				pp: pp.html(),
 				conditions: conditions,
@@ -882,6 +910,7 @@ function preload_player_sheet(pc_sheet, loadWait = 0)
 				var ac_element = $(event.target).contents().find(".ct-combat .ddbc-armor-class-box,ct-combat-mobile__extra--ac");
 				if (ac_element.length > 0) {
 					synchp();
+					$(event.target).attr('data-init_load', 1);
 				} else {
 					if (timeElapsed < 15000) {
 						waitToSync(timeElapsed + 500);
@@ -892,23 +921,23 @@ function preload_player_sheet(pc_sheet, loadWait = 0)
 		waitToSync();
 		//setTimeout(function(){$(event.target).contents().find(".ct-character-header__group--game-log").remove();},10000); // AND OTHER HACK!
 	});
-	var loadSheet = function (sheetFrame, sheet_url) {
-		sheetFrame.attr('src', sheet_url);
-	};
-	setTimeout(loadSheet, loadWait,iframe,pc_sheet);
+	
+	if((!window.DM) ||(window.KEEP_PLAYER_SHEET_LOADED))
+	{
+		var loadSheet = function (sheetFrame, sheet_url) {
+			sheetFrame.attr('src', sheet_url);
+		};
+		setTimeout(loadSheet, loadWait,iframe,pc_sheet);
+	}
 }
 
-function preload_player_sheets()
+function init_player_sheets()
 {
 	// preload character sheets
 	// wait a few seconds before actually loading the iframes, and wait a second between each load to avoid 429 errors
 	var sheetLoadWait = 4000;
-	// for (var i = window.pcs.length - 1; i >= 0; i--) {
-		// preload_player_sheet(window.pcs[i].sheet, sheetLoadWait);
-		// sheetLoadWait += 1000;
-	// }
 	window.pcs.forEach(function(pc, index) {
-		preload_player_sheet(pc.sheet, sheetLoadWait);
+		init_player_sheet(pc.sheet, sheetLoadWait);
 		sheetLoadWait += 1500;
 	});
 }
@@ -923,22 +952,22 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 		// Open the sheet
 		if(window.DM)
 		{
-			//unlock and hide any other open sheets
 			$("#sheet").find("iframe").each(function(){
-				if($(this).attr('src') !== sheet_url)
+				
+				if($(this).attr('data-sheet_url') == sheet_url)
 				{
+					if($(this).attr('src') !== sheet_url)
+					{
+						console.log("loading player sheet" + sheet_url);
+						$(this).attr('src', sheet_url);
+					}
+				}
+				else
+				{
+					//unlock and hide any other open sheets
 					if($(this).css('height') !== '0px')
 					{
-						if (window.DM) {
-							data = {
-								player_sheet: $(this).attr('src')
-							};
-							window.MB.sendMessage("custom/myVTT/unlock", data);
-						}
-						$(this).animate({
-							height:0
-						},500);
-						// $(this).css("height", "0px");
+						close_player_sheet($(this).attr('data-sheet_url'), false);
 					}
 				}
 			});
@@ -951,17 +980,20 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 		}
 		else
 		{
-			if(window.JOINTHEDICESTREAM){
-				iframe.contents().find(".dice-rolling-panel__container").get(0).height=600;
-				iframe.contents().find(".dice-rolling-panel__container").height(600);
-				
-				if(!window.STREAMTASK){
-						window.STREAMTASK=setInterval(() => {
-							if(window.MYMEDIASTREAM.requestFrame)
+			if (window.JOINTHEDICESTREAM) {
+				let diceRollPanel = iframe.contents().find(".dice-rolling-panel__container");
+				if (diceRollPanel.length > 0) {
+					diceRollPanel.get(0).height = 600;
+					diceRollPanel.height(600);
+
+					if (!window.STREAMTASK) {
+						window.STREAMTASK = setInterval(() => {
+							if (window.MYMEDIASTREAM.requestFrame)
 								window.MYMEDIASTREAM.requestFrame(); // Firefox :( 
 							else
-							window.MYMEDIASTREAM.getVideoTracks()[0].requestFrame(); // Chrome :|
-						} ,1000 / 30)
+								window.MYMEDIASTREAM.getVideoTracks()[0].requestFrame(); // Chrome :|
+						}, 1000 / 30)
+					}
 				}
 			}
 		}
@@ -992,25 +1024,30 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 		//sheet is already open, close the sheet
 		close_player_sheet(sheet_url);
 	}
-	
 }
 
-function close_player_sheet(sheet_url)
+function close_player_sheet(sheet_url, hide_container = true)
 {
 	let container = $("#sheet");
 	let iframe = $("[id='PlayerSheet"+getPlayerIDFromSheet(sheet_url)+"']");
 	// hide the buttons first, they tend to float over everything
-	container.find("button").css('display', 'none');
-	if (container.css("z-index") > 0) {
-		container.animate({
-						right: 343 - 1530,
-						'z-index': 0,
-						height: 0
-					}, 500);
+	if(hide_container)
+	{
+		container.find("button").css('display', 'none');
+		if (container.css("z-index") > 0) {
+			container.animate({
+							right: 343 - 1530,
+							'z-index': 0,
+							height: 0
+						}, 500);
+		}
 	}
-	iframe.animate({
-		height:0
-	},500);
+	setTimeout(function(_iframe){
+		console.log("animating close sheet" + _iframe.attr('data-sheet_url'));
+		_iframe.animate({
+			height:0
+		},500);
+	},50, iframe)
 	
 	if(window.DM)
 	{
@@ -1018,6 +1055,13 @@ function close_player_sheet(sheet_url)
 			player_sheet: sheet_url
 		};
 		window.MB.sendMessage("custom/myVTT/unlock", data);
+		if(!window.KEEP_PLAYER_SHEET_LOADED)
+		{
+			setTimeout(function(_iframe){
+				console.log("closing sheet" + _iframe.attr('data-sheet_url'));
+				_iframe.attr('src','');
+			},500, iframe)
+		}
 	}
 	else
 	{
@@ -1346,11 +1390,16 @@ function init_ui() {
 	init_pclist();
 	if(window.DM)
 	{
-		preload_player_sheets();
+		init_player_sheets();
 	}
 	else
 	{
-		preload_player_sheet(window.PLAYER_SHEET);
+		setTimeout(function() {
+			window.MB.sendMessage("custom/myVTT/syncmeup");
+			window.MB.sendMessage("custom/myVTT/playerjoin");
+			init_player_sheet(window.PLAYER_SHEET);
+			//open_player_sheet(window.PLAYER_SHEET, false);
+		}, 5000);
 	}
 
 	$(".sidebar__pane-content").css("background", "rgba(255,255,255,1)");
@@ -1488,6 +1537,22 @@ function init_ui() {
 
 
 	init_journal($("#message-broker-client").attr("data-gameId"));
+	
+	if (window.DM) {
+		// use DDB character tools to update character info every 10 seconds
+		loadScript("https://media.dndbeyond.com/character-tools/vendors~characterTools.bundle.f8b53c07d1796f1d29cb.min.js",
+			function () {
+				window.character_tools_loaded = true;
+			});
+		window.load_rules_task = setInterval(function () {
+			if (window.character_tools_loaded) {
+				clearInterval(window.load_rules_task);
+				// Load DDB character modules and rules
+				retriveRules();
+				loadModules(initalModules);
+				window.character_update_task = setInterval(get_pclist_player_data, 10000);
+            }
+		},100);
 }
 
 function init_buttons() {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -504,7 +504,7 @@ class MessageBroker {
 		}, 30000);
 	}
 
-    handleCT(data){
+    	handleCT(data){
 		$("#combat_area").empty();
 		ct_load(data);
 	}
@@ -514,7 +514,14 @@ class MessageBroker {
 			return;
 
 		window.PLAYER_STATS[data.id] = data;
+		this.sendTokenUpdateFromPlayerData(data);
 
+		// update combat tracker:
+
+		update_pclist();
+	}
+
+	sendTokenUpdateFromPlayerData(data) {
 		if (data.id in window.TOKEN_OBJECTS) {
 			var cur = window.TOKEN_OBJECTS[data.id];
 
@@ -529,7 +536,7 @@ class MessageBroker {
 
 				window.MB.inject_chat(msgdata);
 			}
-			cur.options.hp = data.hp;
+			cur.options.hp = +data.hp + (data.temp_hp ? +data.temp_hp : 0);
 
 
 			cur.options.max_hp = data.max_hp;
@@ -539,11 +546,7 @@ class MessageBroker {
 			cur.place();
 			window.MB.sendMessage('custom/myVTT/token', cur.options);
 		}
-
-		// update combat tracker:
-
-		update_pclist();
-	}
+    	}
 	
 	convertChat(data,local=false) {
 		//Security logic to prevent content being sent which can execute JavaScript.

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -525,26 +525,33 @@ class MessageBroker {
 		if (data.id in window.TOKEN_OBJECTS) {
 			var cur = window.TOKEN_OBJECTS[data.id];
 
-			console.log("old " + cur.options.hp + " new " + data.hp);
-			console.log(data.conditions);
-			if (typeof cur.options.hp != "undefined" && cur.options.hp > data.hp && cur.options.custom_conditions.includes("Concentration(Reminder)")) {
-				var msgdata = {
-					player: cur.options.name,
-					img: cur.options.imgsrc,
-					text: "<b>Check for concentration!!</b>",
-				};
+			// test for any change
+			if ((cur.options.hp !== +data.hp + (data.temp_hp ? +data.temp_hp : 0)) ||
+				(cur.options.max_hp !== data.max_hp) ||
+				(cur.options.ac !== data.ac) ||
+				(!areArraysEqualSets(cur.options.conditions, data.conditions)))
+			{
+				console.log("old " + cur.options.hp + " new " + data.hp);
+				console.log(data.conditions);
+				if (typeof cur.options.hp != "undefined" && cur.options.hp > data.hp && cur.options.custom_conditions.includes("Concentration(Reminder)")) {
+					var msgdata = {
+						player: cur.options.name,
+						img: cur.options.imgsrc,
+						text: "<b>Check for concentration!!</b>",
+					};
 
-				window.MB.inject_chat(msgdata);
+					window.MB.inject_chat(msgdata);
+				}
+				cur.options.hp = +data.hp + (data.temp_hp ? +data.temp_hp : 0);
+
+
+				cur.options.max_hp = data.max_hp;
+				cur.options.ac = data.ac;
+				cur.options.conditions = data.conditions;
+
+				cur.place();
+				window.MB.sendMessage('custom/myVTT/token', cur.options);
 			}
-			cur.options.hp = +data.hp + (data.temp_hp ? +data.temp_hp : 0);
-
-
-			cur.options.max_hp = data.max_hp;
-			cur.options.ac = data.ac;
-			cur.options.conditions = data.conditions;
-
-			cur.place();
-			window.MB.sendMessage('custom/myVTT/token', cur.options);
 		}
     	}
 	

--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,7 @@
 	"jquery.magnific-popup.min.js",
 	"magnific-popup.css",
 	"Journal.js",
+	"DnDBeyond/DDBCharacterData.js",
 	"assets/*"
 	]
 }


### PR DESCRIPTION
Using the DnDBeyond character API at https://character-service.dndbeyond.com/character/v4/character/ and the the DnDBeyond javascript middleware at https://media.dndbeyond.com/character-tools/vendors~characterTools.bundle.f8b53c07d1796f1d29cb.min.js, as well as code for how to combine the two from https://github.com/TeaWithLucas/DNDBeyond-DM-Screen, fetch the player character info without having to load the player sheet web page. The update runs every 10 seconds.

Tokens will only be updated if any stats have changed, otherwise there would be a flood of token update messages.

Also, DMs will no longer automatically open all player sheets or keep them open in the background. The flag window.KEEP_PLAYER_SHEET_LOADED can turn that function back on if we want it to be an option in the future