### PR TITLE
support non-square token aspect ratio, add setting for legacy aspect ratio handling

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -89,6 +89,10 @@ function init_settings(){
 			name: 'revealname',
 			label: 'Show name to players'
 		},
+		{
+			name: 'legacyaspectratio',
+			label: 'Stretch non-square images (requires page refresh)'
+		}
 	];
 
 	settings_panel.append(`

--- a/Settings.js
+++ b/Settings.js
@@ -91,7 +91,7 @@ function init_settings(){
 		},
 		{
 			name: 'legacyaspectratio',
-			label: 'Stretch non-square images (requires page refresh)'
+			label: 'Stretch non-square token images by default'
 		}
 	];
 

--- a/Token.js
+++ b/Token.js
@@ -697,7 +697,11 @@ class Token {
 			if (this.options.rotation != undefined) {
 				rotation = this.options.rotation;
 			}
-			var tokimg = $("<img style='transform:scale(" + scale + ") rotate(" + rotation + "deg)' class='token-image'/>");
+			let imgClass = 'token-image';
+			if (window.TOKEN_SETTINGS['legacyaspectratio'] == true) {
+				imgClass = 'token-image legacy-aspect-ratio';
+			}
+			var tokimg = $("<img style='transform:scale(" + scale + ") rotate(" + rotation + "deg)' class='"+imgClass+"'/>");
 			if(!(this.options.square)){
 				tokimg.addClass("token-round");
 			}

--- a/Token.js
+++ b/Token.js
@@ -676,6 +676,15 @@ class Token {
 			if(this.options.disableaura){
 				old.find("img").css("box-shadow","");
 			}
+			
+			if(this.options.legacyaspectratio == false) {
+				// if the option is false, the token was either placed after the option was introduced, or the user actively chose to use the new option
+				old.find("img").addClass("preserve-aspect-ratio");
+			} else {
+				// if the option is undefined, this token was placed before the option existed and should therefore use the legacy behavior
+				// if the option is true, the user actively enabled the option
+				old.find("img").removeClass("preserve-aspect-ratio");
+			}
 
 			check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 		}
@@ -698,8 +707,8 @@ class Token {
 				rotation = this.options.rotation;
 			}
 			let imgClass = 'token-image';
-			if (window.TOKEN_SETTINGS['legacyaspectratio'] == true) {
-				imgClass = 'token-image legacy-aspect-ratio';
+			if(this.options.legacyaspectratio == false) {
+				imgClass = 'token-image preserve-aspect-ratio';
 			}
 			var tokimg = $("<img style='transform:scale(" + scale + ") rotate(" + rotation + "deg)' class='"+imgClass+"'/>");
 			if(!(this.options.square)){
@@ -1132,7 +1141,8 @@ function token_button(e, tokenIndex = null, tokenTotal = null) {
 			feet: "0",
 			color: "rgba(255, 255, 0, 0.1)"
 		},
-		auraVisible: true
+		auraVisible: true,
+		legacyaspectratio: window.TOKEN_SETTINGS['legacyaspectratio']
 	};
 	
 	
@@ -1189,6 +1199,18 @@ function token_button(e, tokenIndex = null, tokenTotal = null) {
 	if (typeof $(e.target).attr('data-stat') !== "undefined") {
 		options.monster = $(e.target).attr('data-stat');
 	}
+
+	if (options.monster || options.id.includes("/")) {
+		// monsters and players should use the global setting as the default
+		options.legacyaspectratio = window.TOKEN_SETTINGS['legacyaspectratio'];
+	} else if ($(e.target).attr('data-legacyaspectratio') == true || $(e.target).attr('data-legacyaspectratio') == 'true' || $(e.target).attr('data-legacyaspectratio') == undefined) {
+		// this is a custom token. It should use the setting that was defined when it was created
+		// if the option is undefined, this token was created before the option existed and should therefore use the legacy behavior
+		// if the option is true, the user actively enabled the option.
+		// if the option is false, then we want to preserve aspect ratio
+		options.legacyaspectratio = true;
+	}
+
 
 	if ($(e.target).attr('data-name')) {
 		options.name = $(e.target).attr('data-name');
@@ -1485,6 +1507,12 @@ function token_inputs(opt) {
 		}
 		else {
 			tok.options.revealname = false;
+		}
+		if (data.token_legacyaspectratio) {
+			tok.options.legacyaspectratio = true;
+		}
+		else {
+			tok.options.legacyaspectratio = false;
 		}
 	}
 	
@@ -1815,6 +1843,11 @@ function token_menu() {
 									type: 'checkbox',
 									name: 'Show name to players',
 									selected: window.TOKEN_OBJECTS[id].options.revealname,
+								},
+								token_legacyaspectratio: {
+									type: 'checkbox',
+									name: 'Stretch non-square token images',
+									selected: window.TOKEN_OBJECTS[id].options.legacyaspectratio == true || window.TOKEN_OBJECTS[id].options.legacyaspectratio == undefined
 								}
 							}
 						},

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1900,6 +1900,10 @@ function init_tokenmenu(){
 				<div><input type='checkbox' name='data-disableborder'></div>
 			</div>
 			<div>
+				<div>Stretch non-square token images by default</div>
+				<div><input type='checkbox' name='data-legacyaspectratio'></div>
+			</div>
+			<div>
 				<button id='tokenform-save'>Save</button>
 				<button id='tokenform-cancel'>Cancel</button>
 			</div>
@@ -1921,6 +1925,8 @@ function init_tokenmenu(){
 		newtoken['data-disablestat']=true;
 		if(tokenform.find("[name='data-disableborder']").is(":checked"))
 			newtoken['data-disableborder']=true;
+		newtoken['data-legacyaspectratio']=tokenform.find("[name='data-legacyaspectratio']").is(":checked");
+			
 		
 		if(!window.CURRENT_TOKEN_FOLDER.tokens)
 			window.CURRENT_TOKEN_FOLDER.tokens={};
@@ -1969,16 +1975,11 @@ function fill_tokenmenu(path){
 		$("#token-addtoken").removeAttr("disabled");
 	}
 	
-	var tokenImgClass = 'tokenentryimg';
-	if (window.TOKEN_SETTINGS['legacyaspectratio'] == true) {
-		tokenImgClass = 'tokenentryimg legacy-aspect-ratio';
-	}
-
 	if(path!=""){
 		var previous=path.substring(0,path.lastIndexOf("/"));
 		var newentry=$(`
 			<div data-path='${previous}' class='tokenfolder tokenmenuitem'>
-				<img data-path='${previous}' class='${tokenImgClass} tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
+				<img data-path='${previous}' class='tokenentryimg tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
 				<div>..</div>
 			</div>
 		`);
@@ -1990,7 +1991,7 @@ function fill_tokenmenu(path){
 		var newpath=path+"/"+f;
 		var newentry=$(`
 			<div data-path='${newpath}' class='tokenfolder tokenmenuitem'>
-				<img data-path='${newpath}' class='${tokenImgClass} tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
+				<img data-path='${newpath}' class='tokenentryimg tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
 				<div class="label-one-line">${f}</div>
 			</div>
 		`);
@@ -2014,6 +2015,15 @@ function fill_tokenmenu(path){
 	});
 	
 	for(let t in folder.tokens){
+
+		var tokenImgClass = 'tokenentryimg';
+		if (folder.tokens[t]["data-legacyaspectratio"] == false) {
+				// if the option is undefined, this token was created before the option existed and should therefore use the legacy behavior
+				// if the option is true, the user actively enabled the option.
+				// if the option is false, then we want to preserve aspect ratio
+			tokenImgClass = 'tokenentryimg preserve-aspect-ratio';
+		}
+
 		var newentry=$(`
 			<div class='tokenentry tokenmenuitem'>
 				<img class='${tokenImgClass}' src='${parse_img(folder.tokens[t]["data-img"])}'></img>

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1969,11 +1969,16 @@ function fill_tokenmenu(path){
 		$("#token-addtoken").removeAttr("disabled");
 	}
 	
+	var tokenImgClass = 'tokenentryimg';
+	if (window.TOKEN_SETTINGS['legacyaspectratio'] == true) {
+		tokenImgClass = 'tokenentryimg legacy-aspect-ratio';
+	}
+
 	if(path!=""){
 		var previous=path.substring(0,path.lastIndexOf("/"));
 		var newentry=$(`
 			<div data-path='${previous}' class='tokenfolder tokenmenuitem'>
-				<img data-path='${previous}' class='tokenentryimg tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
+				<img data-path='${previous}' class='${tokenImgClass} tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
 				<div>..</div>
 			</div>
 		`);
@@ -1985,7 +1990,7 @@ function fill_tokenmenu(path){
 		var newpath=path+"/"+f;
 		var newentry=$(`
 			<div data-path='${newpath}' class='tokenfolder tokenmenuitem'>
-				<img data-path='${newpath}' class='tokenentryimg tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
+				<img data-path='${newpath}' class='${tokenImgClass} tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
 				<div class="label-one-line">${f}</div>
 			</div>
 		`);
@@ -2011,7 +2016,7 @@ function fill_tokenmenu(path){
 	for(let t in folder.tokens){
 		var newentry=$(`
 			<div class='tokenentry tokenmenuitem'>
-				<img class='tokenentryimg' src='${parse_img(folder.tokens[t]["data-img"])}'></img>
+				<img class='${tokenImgClass}' src='${parse_img(folder.tokens[t]["data-img"])}'></img>
 				<div class="label-one-line">${t}</div>
 				<button class='tokenadd' >Token</button>
 			</div>

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -382,7 +382,6 @@ div#scene_properties form > div {
 
 .token-image {
     cursor: move;
-    object-fit: contain;
 }
 
 .hasTooltip::after {
@@ -938,7 +937,6 @@ div#scene_properties form > div {
 .tokenentryimg {
 	width:60px;
 	height:60px;
-    object-fit: contain;
 }
 
 .tokenmenuitem {
@@ -1259,6 +1257,6 @@ body {
     width: auto;
 }
 
-.legacy-aspect-ratio {
-    object-fit: fill;
+.preserve-aspect-ratio {
+    object-fit: contain;
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -382,6 +382,7 @@ div#scene_properties form > div {
 
 .token-image {
     cursor: move;
+    object-fit: contain;
 }
 
 .hasTooltip::after {
@@ -937,6 +938,7 @@ div#scene_properties form > div {
 .tokenentryimg {
 	width:60px;
 	height:60px;
+    object-fit: contain;
 }
 
 .tokenmenuitem {
@@ -1255,4 +1257,8 @@ body {
     overflow: visible;
     white-space: normal;
     width: auto;
+}
+
+.legacy-aspect-ratio {
+    object-fit: fill;
 }


### PR DESCRIPTION
# What

This does 2 things:
1. token images are no longer stretched to fill the space. This allows non-square images to be used.
1. a new setting has been added to allow existing users to switch back to the legacy behavior which stretches non-square images to fill the space.

# Discussion

I used `object-fit: contain` rather than `object-fit: cover` because images that go outside the token div get cropped when using `cover`. I couldn't figure out how to allow the images to `overflow` properly so I opted for `contain` instead. If we want to allow images to overflow, I think we might need some HTML restructuring. I can try to figure that out if that's the route we want to go, but I wanted to keep the changes to a minimum.

# Screenshot
The boat on the right side is a custom token.  
The image on the left is with the legacy option enabled showing that the token is stretched to a square.  
The image on the right is the new default behavior showing that the token maintains the aspect ratio of the image.  
<img width="1389" alt="Screen Shot 2021-11-15 at 11 28 44 AM" src="https://user-images.githubusercontent.com/584771/141827042-4113b028-0bb4-446f-916b-036701ade7ff.png">

