### PR TITLE
rotate tokens with shift+arrow keys

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -329,4 +329,37 @@ Mousetrap.bind('command+z', function(e) {
     }
 });
 
+var rotationKeyPresses = [];
+window.addEventListener("keydown", async (event) => {
+    const arrowKeys = [ 'ArrowLeft', 'ArrowUp', 'ArrowRight', 'ArrowDown' ];
+    if (event.shiftKey && arrowKeys.includes(event.key) ) {
+        rotationKeyPresses.push(event.key)
+    }
+});
+window.addEventListener("keyup", async (event) => {
+    if (!event.shiftKey) {
+        rotationKeyPresses = [];
+        return;
+    }
+    if (rotationKeyPresses.includes('ArrowDown') && rotationKeyPresses.includes('ArrowLeft')) {
+        rotate_selected_tokens(45);
+    } else if (rotationKeyPresses.includes('ArrowLeft') && rotationKeyPresses.includes('ArrowUp')) {
+        rotate_selected_tokens(135);
+    } else if (rotationKeyPresses.includes('ArrowUp') && rotationKeyPresses.includes('ArrowRight')) {
+        rotate_selected_tokens(225);
+    } else if (rotationKeyPresses.includes('ArrowRight') && rotationKeyPresses.includes('ArrowDown')) {
+        rotate_selected_tokens(315);
+    } else if (rotationKeyPresses.includes('ArrowDown')) {
+        rotate_selected_tokens(0);
+    } else if (rotationKeyPresses.includes('ArrowLeft')) {
+        rotate_selected_tokens(90);
+    } else if (rotationKeyPresses.includes('ArrowUp')) {
+        rotate_selected_tokens(180);
+    } else if (rotationKeyPresses.includes('ArrowRight')) {
+        rotate_selected_tokens(270);
+    }
+
+    rotationKeyPresses = [];
+});
+
 }

--- a/Token.js
+++ b/Token.js
@@ -2180,6 +2180,18 @@ function rotation_towards_cursor(token, mousex, mousey, largerSnapAngle) {
 	return Math.round(degrees / snap) * snap
 }
 
+/// rotates all selected tokens to the specified newRotation
+function rotate_selected_tokens(newRotation) {
+	if ($("#select-button").hasClass("button-enabled") || !window.DM) { // players don't have a select tool
+		for (let i = 0; i < window.CURRENTLY_SELECTED_TOKENS.length; i++) {
+			let id = window.CURRENTLY_SELECTED_TOKENS[i];
+			let token = window.TOKEN_OBJECTS[id];
+			token.rotate(newRotation);
+		}
+		return false;
+	}
+}
+
 /// draws a rectangle around every selected token, and adds a rotation grabber
 function draw_selected_token_bounding_box() {
 	remove_selected_token_bounding_box()


### PR DESCRIPTION
This allows holding shift and pressing an arrow key to rotate selected tokens. It only supports cardinal directions because Mousetrap can't handle multiple arrow keys at the same time. 