### PR TITLE
Improve token image customization UX

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1468,7 +1468,6 @@ function init_ui() {
 	init_combat_tracker();
 
 	token_menu();
-	build_token_image_map_menu();
 	load_custom_image_mapping();
 
 
@@ -1527,6 +1526,12 @@ function init_ui() {
 		$("body").css("cursor", "");
 		if (event.target.tagName.toLowerCase() !== 'a') {
 			$("#splash").remove(); // don't remove the splash screen if clicking an anchor tag otherwise the browser won't follow the link
+		}
+		if (token_customization_modal_is_open() && event.which == 1) {
+			// if the click was outside the customization modal, close the modal, but allow right clicking because contextMenu events are outside the modal
+			if (event.target.closest(".token-image-modal") == undefined) {
+				close_token_customization_modal();
+			}
 		}
 	}
 

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -31,30 +31,27 @@ function init_monster_panel() {
 		list.on("contextmenu", ".monster-row__cell--avatar", function(e) {
 			e.preventDefault();
 		});
-
-		// present our own custom monster image menu
-		list.on("mousedown", ".monster-row__cell--avatar", function(e) {
-
-			e.stopPropagation();
-			e.target = this; // hack per passarlo a token_button
-
-			let monsterImage = $(this);
-			let monsterid = monsterImage.parent().parent().attr('id').replace("monster-row-", "");
-			let ogImgSrc = monsterImage.find('img').attr('src');
-
-			if ($.find("#custom-img-src-anchor").length == 0) {
-				// contextMenu doesn't seem to be able to use elements inside the monster panel iframe so
-				// inject an element outside of the monster panel iframe
-				// then display a contextMenu from that point.
-				$('<span id="custom-img-src-anchor" style="position:absolute;" />').insertBefore(panel);
-			}
-			$("#custom-img-src-anchor").css("top", e.pageY + "px");
-			$("#custom-img-src-anchor").data("monster-id", monsterid);
-			$("#custom-img-src-anchor").data("monster-og-img-src", ogImgSrc);
-
-			// open our context menu
-			$("#custom-img-src-anchor").contextMenu();
+		// find the monster row, grab the monster details, then open the token customization modal
+		const open_token_customization_modal_from_monster_row = function(event) {
+			event.preventDefault();
+			event.stopPropagation();
+			let monsterRow = event.target.closest(".monster-row");
+			currentlyCustomizingMonster = {
+				monsterId: monsterRow.id.replace("monster-row-", ""),
+				monsterName: $(monsterRow).find(".monster-row__name").text(),
+				defaultImg: parse_img($(monsterRow).find(".monster-row__cell--avatar img").attr("src"))
+			};
+			display_token_customization_modal();
+		};
+		// clicking the menu looking button opens our token customization modal
+		list.on("click", ".monster-row__cell--drag-handle", function(event) {
+			open_token_customization_modal_from_monster_row(event);
 		});
+		// right clicking the monster image used to open a contextMenu. our token customization modal to preserve that functionality
+		list.on("mouseup", ".monster-row__cell--avatar", function(event) {
+			open_token_customization_modal_from_monster_row(event);
+		});
+		register_token_image_context_menu();
 
 		list.on("contextmenu", "button.monster-row__add-button", function(e) {
 			e.preventDefault();
@@ -102,7 +99,7 @@ function init_monster_panel() {
 				button.attr('data-maxhp', stat.data.averageHitPoints);
 				button.attr('data-ac', stat.data.armorClass);
 				token_button(e);
-			})
+			});
 
 
 
@@ -135,3 +132,271 @@ function init_monster_panel() {
 	iframe.attr("src", "/encounter-builder");
 }
 
+var currentlyCustomizingMonster = {};
+function register_token_image_context_menu() {
+	$.contextMenu({
+		selector: ".custom-token-image-item",
+		items: {
+			place: {
+				name: "Place Token",
+				callback: function(itemKey, opt, originalEvent) {
+					let selectedItem = $(opt.$trigger[0]);
+					let monsterId = selectedItem.data("monster");
+					let monsterName = selectedItem.data("name");
+					let imgSrc = selectedItem.find("img").attr("src");
+					originalEvent.target = selectedItem;
+					place_custom_monster_img(originalEvent, monsterId, monsterName, imgSrc, false)
+				}
+			},
+			placeHidden: {
+				name: "Place Hidden Token",
+				callback: function(itemKey, opt, originalEvent) {
+					let selectedItem = $(opt.$trigger[0]);
+					let monsterId = selectedItem.data("monster");
+					let monsterName = selectedItem.data("name");
+					let imgSrc = selectedItem.find("img").attr("src");
+					originalEvent.target = selectedItem;
+					place_custom_monster_img(originalEvent, monsterId, monsterName, imgSrc, true)
+				}
+			},
+			copy: {
+				name: "Copy Url",
+				callback: function(itemKey, opt, e) {
+					let selectedItem = $(opt.$trigger[0]);
+					let imgSrc = selectedItem.find("img").attr("src");
+					copy_to_clipboard(imgSrc);
+				}
+			},
+			border: "---",
+			remove: { 
+				name: "Remove",
+				callback: function(itemKey, opt, originalEvent) {
+					let selectedItem = $(opt.$trigger[0]);
+					let monsterId = selectedItem.data("monster");
+					let imgIndex = parseInt(selectedItem.data("custom-img-index"));
+					if (window.confirm("Are you sure you want to remove this custom image?")) {
+						remove_custom_token_image(monsterId, imgIndex);
+						selectedItem.remove();
+						if (get_custom_monster_images(monsterId).length == 0) {
+							// the user removed the last custom image. redraw the modal so the default image shows up
+							display_token_customization_modal();
+						}
+					}
+				}
+			}
+		}
+	});
+}
+
+function token_customization_modal_is_open() {
+	return $(".token-image-modal").length > 0;
+}
+
+function close_token_customization_modal() {
+	$(".token-image-modal").remove();
+}
+
+function display_token_customization_modal(placedToken) {
+
+	// close any that are already open. This shouldn't be necessary, but it doesn't hurt just in case
+	close_token_customization_modal();
+	
+	let monsterId = currentlyCustomizingMonster.monsterId;
+	let monsterName = currentlyCustomizingMonster.monsterName;
+	let defaultImg = currentlyCustomizingMonster.defaultImg;
+	if (monsterId == undefined || monsterName == undefined || defaultImg == undefined) {
+		console.warn(`Failed to display monster customization modal; monsterId = ${monsterId}, monsterName = ${monsterName}, defaultImg = ${defaultImg}`)
+		return
+	}
+
+	let customImages = get_custom_monster_images(monsterId);
+
+	// build the modal header
+	let closeButton = $(`<button class="ddbeb-modal__close-button qa-modal_close" title="Close Modal"><svg class="" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"><g transform="rotate(-45 50 50)"><rect x="0" y="45" width="100" height="10"></rect></g><g transform="rotate(45 50 50)"><rect x="0" y="45" width="100" height="10"></rect></g></svg></button>`); 
+	closeButton.click(close_token_customization_modal);
+	let modalHeader = $(`
+		<div class="token-image-modal-header">
+			<div class="token-image-modal-header-title">${monsterName}</div>
+			<div class="token-image-modal-header-subtitle">Token Images</div>
+		</div>
+	`);
+
+	if (placedToken != undefined) {
+		// the user is updating a token that has already been placed. Add some explanation text to help them figure out how to use this in case it's their first time here.
+		modalHeader.append($(`<div class="token-image-modal-explanation">Click an image below to update your token or enter a new image URL at the bottom.</div>`))
+	} else {
+		modalHeader.append($(`<div class="token-image-modal-explanation">When placing tokens, one of these images will be chosen at random. Right-click an image for more options.</div>`))
+	}
+
+	const determineLabelText = function() {
+		if (placedToken != undefined) {
+			return "Enter a new image URL";	
+		} else if (get_custom_monster_images(monsterId).length == 0) {
+			return "Replace The Default Image";
+		} else {
+			return "Add More Custom Images";
+		}
+	}
+
+	// build the modal body
+	let modalBody = $(`<div class="token-image-modal-body"></div>`);
+	let removeAllButton = $(`<button class="token-image-modal-remove-all-button" data-monster-id="${monsterId}" title="Reset this monster back to the default image.">Remove All Custom Images</button><`);
+	removeAllButton.click(function(event) {
+		let monsterId = $(event.target).data("monster-id");
+		if (window.confirm(`Are you sure you want to remove all custom images for ${monsterName}?\nThis will reset the monster images back to the default`)) {
+			remove_all_custom_token_images(monsterId);
+			display_token_customization_modal(placedToken);
+			footerLabel.text(determineLabelText());
+		}
+	})
+
+	if (customImages != undefined && customImages.length > 0) {
+		for (let i = 0; i < customImages.length; i++) { 
+			let imageUrl = parse_img(customImages[i]);
+			let tokenDiv = build_token_customization_item(monsterId, monsterName, imageUrl, i, placedToken);
+			modalBody.append(tokenDiv);
+		}
+		removeAllButton.show();
+	} else {
+		let tokenDiv = build_token_customization_item(monsterId, monsterName, defaultImg, -1, placedToken);
+		modalBody.append(tokenDiv);
+		removeAllButton.hide();
+	}
+
+	// build the modal footer
+	let inputWrapper = $(`<div style="width:90%;"></div>`);
+	let footerLabelText = determineLabelText();
+	let footerLabel = $(`<div class="token-image-modal-footer-title" style="width:100%; padding-left:0px">${footerLabelText}</div>`)
+	inputWrapper.append(footerLabel);
+	let urlInput = $(`<input title="${footerLabelText}" placeholder="https://..." name="addCustomImage" type="text" style="width:100%" data-monster-id="${monsterId}" />`);
+	const add_token_customization_image = function(imageUrl) {
+		if (get_custom_monster_images(monsterId).length == 0) {
+			// this is the first custom image so remove the default image before appending the new one, and show the remove all button
+			modalBody.empty();
+			removeAllButton.show();
+		}
+		add_custom_image_mapping(monsterId, imageUrl);
+		let updatedImages = get_custom_monster_images(monsterId);
+		let imgIndex = updatedImages.indexOf(imageUrl);
+		let tokenDiv = build_token_customization_item(monsterId, monsterName, imageUrl, imgIndex, placedToken);
+		modalBody.append(tokenDiv);	
+		footerLabel.text(determineLabelText())
+	}
+	urlInput.on('keyup', function(event) {
+		let imageUrl = event.target.value;
+		if (event.key == "Enter" && imageUrl != undefined && imageUrl.length > 0) {
+			add_token_customization_image(imageUrl);
+		}
+	});
+	inputWrapper.append(urlInput);
+	let modalFooter = $(`<div class="token-image-modal-footer"></div>`);
+	modalFooter.append(inputWrapper);
+
+	// put it all together
+	let sidebarContent = $(".sidebar__pane-content");
+	let width = parseInt(sidebarContent.width());
+	let top = parseInt(sidebarContent.position().top) + 10;
+	let height = parseInt(sidebarContent.height());
+	let modalContent = $(`<div class="token-image-modal-content" style="height:${height-20}px;"></div>`); // remove 20px to account for the padding on .token-image-modal
+	modalContent.append(closeButton);
+	modalContent.append(modalHeader);
+	modalContent.append(modalBody);
+	modalContent.append(removeAllButton);
+	modalContent.append(modalFooter);
+
+	if (placedToken) {
+		// allow them to only use the new url for 
+		let onlyForThisTokenButton = $(`<button class="token-image-modal-add-button" style="margin:4px;" data-monster-id="${monsterId}" title="This url will be used for this token only. New tokens will continue to use the images shown above.">Set for this token only</button>`);
+		onlyForThisTokenButton.click(function(event) {
+			let imageUrl = $(`input[name='addCustomImage']`)[0].value;
+			if (imageUrl != undefined && imageUrl.length > 0) {
+				placedToken.options.imgsrc = parse_img(imageUrl);
+				close_token_customization_modal();
+				placedToken.place_sync_persist();
+			}
+		});
+		modalContent.append(onlyForThisTokenButton);	
+		let addForAllButton = $(`<button class="token-image-modal-add-button" style="margin:4px;" data-monster-id="${monsterId}" title="New tokens will use this new image instead of the default image. If you have more than one custom image, one will be chosen at random when you place a new token.">Add for all future tokens</button>`);
+		addForAllButton.click(function(event) {
+			let imageUrl = $(`input[name='addCustomImage']`)[0].value;
+			if (imageUrl != undefined && imageUrl.length > 0) {
+				add_token_customization_image(imageUrl);
+			}
+		});
+		modalContent.append(addForAllButton);
+		modalContent.append($(`<div class="token-image-modal-explanation" style="padding:4px;">You can access this modal from the Monsters tab by clicking the button on the right side of the monster row.</div>`));
+	} else {
+		let addButton = $(`<button class="token-image-modal-add-button" data-monster-id="${monsterId}">Add</button>`);
+		addButton.click(function(event) {
+			let imageUrl = $(`input[name='addCustomImage']`)[0].value;
+			if (imageUrl != undefined && imageUrl.length > 0) {
+				add_token_customization_image(imageUrl);
+			}
+		});
+		modalFooter.append(addButton);	
+	}
+
+	let modal = $(`<div class="token-image-modal" style="width:${width}px;top:${top}px;right:0px;left:auto;height:${height}px;position:fixed;"></div>`);
+	let overlay = $(`<div class="token-image-modal-overlay"></div>`)
+	modal.append(overlay);
+	modal.append(modalContent);
+
+	// display it
+	$("#VTTWRAPPER").append(modal);
+}
+
+function build_token_customization_item(monsterId, monsterName, imageUrl, customImgIndex, placedToken) {
+	let tokenDiv = $(`<div class="custom-token-image-item" data-monster="${monsterId}" data-name="${monsterName}" data-custom-img-index="${customImgIndex}" style="float: left; width:30%"><img alt="token-img" style="transform: scale(0.75); display: inline-block; overflow: hidden; width:100%; height:100%" class="token-image token-round" src="${imageUrl}" /></div>`);
+	if (placedToken != undefined) {
+		// the user is changing their token image, allow them to simply click an image
+		// we don't want to allow drag and drop from this modal
+		tokenDiv.click(function() {
+			placedToken.options.imgsrc = parse_img(imageUrl);
+			close_token_customization_modal();
+			placedToken.place_sync_persist();
+		});
+	} else {
+		// the user is managing the image for a token, allow them to drag any image onto the scene to place it
+		// TODO: build this 
+		// tokenDiv.draggable({
+		// 	start: function (event) { 
+		// 		console.log("custom-token-image-item drag start");
+		// 	},
+		// 	drag: function(event, ui) {
+		// 		console.log("custom-token-image-item drag drag");
+		// 	},
+		// 	stop: function (event) { 
+		// 		console.log("custom-token-image-item drag stop");
+		// 	}
+		// });	
+	}
+	return tokenDiv;
+}
+
+function place_custom_monster_img(e, monsterId, monsterName, imgSrc, hidden) {
+	let button = e.target;
+	button.attr('data-stat', monsterId);
+	button.attr("data-name", monsterName);
+	button.attr('data-img', imgSrc);
+	button.attr('data-custom-img', imgSrc);
+
+	if (hidden) {
+		button.attr('data-hidden', 1)
+	} else {
+		button.removeAttr('data-hidden');
+	}
+
+	window.StatHandler.getStat(monsterId, function(stat) {
+		if (stat.data.sizeId == 5)
+			button.attr("data-size", Math.round(window.CURRENT_SCENE_DATA.hpps) * 2);
+		if (stat.data.sizeId == 6)
+			button.attr("data-size", Math.round(window.CURRENT_SCENE_DATA.hpps) * 3);
+		if (stat.data.sizeId == 7)
+			button.attr("data-size", Math.round(window.CURRENT_SCENE_DATA.hpps) * 4);
+		button.attr('data-hp', stat.data.averageHitPoints);
+		button.attr('data-maxhp', stat.data.averageHitPoints);
+		button.attr('data-ac', stat.data.armorClass);
+		token_button(e);
+	})
+
+}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1361,3 +1361,10 @@ body {
     color: #979AA4;
     font-family: "Roboto Condensed",Roboto,Helvetica,sans-serif;
 }
+.custom-token-image-item {
+    float: left; 
+    width:30%;
+}
+.custom-token-image-item.ui-draggable-dragging {
+    width: auto;
+}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1260,3 +1260,104 @@ body {
 .preserve-aspect-ratio {
     object-fit: contain;
 }
+
+.token-image-modal {
+    position: fixed;
+    z-index: 99999;
+    /* display: flex; */
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    overflow-y: auto;
+    background-color: rgb(235, 241, 245);
+    /* background-color: rgba(0,0,0,.5); */
+}
+.token-image-modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+.token-image-modal-content {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: stretch;
+    position: relative;
+    overflow-y: auto;
+    border-radius: 3px;
+    border: 1px solid #d8e1e8;
+    background-color: #fff;
+}
+.token-image-modal-header {
+    padding: 4px;
+}
+.token-image-modal-header-title {
+    text-transform: uppercase;
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: .5px;
+    display: flex;
+    align-items: center;
+}
+.token-image-modal-header-subtitle {
+    font-size: 12px;
+    font-weight: 700;
+    color: #738694;
+    line-height: 1.4;
+}
+.token-image-modal-body {
+    position: relative; 
+    width:100%; 
+    /* max-height: 90%; */
+    overflow-y: auto;
+    flex: auto;
+}
+.token-image-modal-footer {
+    height: 52px;
+    border-top: 1px solid #d8e1e8;
+    display: flex;
+    align-items: center;
+    padding: 4px;
+    width: 100%;
+}
+.token-image-modal-footer-title {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    flex-grow: 1;
+    color: #738694;
+    font-size: 13px;
+    line-height: 1.4;
+}
+.token-image-modal-remove-all-button {
+    appearance: none;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    background: #e40712;
+    border: none;
+    color: #fff;
+    align-self: stretch;
+    font-size: 12px;
+    padding: 4px;
+    margin: 10px;
+}
+.token-image-modal-add-button {
+    appearance: none;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    background: #1b9af0;
+    border: none;
+    color: #fff;
+    align-self: stretch;
+    margin: 0px 4px 0px 4px;
+    padding: 10px;
+}
+.token-image-modal-explanation {
+    font-size: 14px;
+    color: #979AA4;
+    font-family: "Roboto Condensed",Roboto,Helvetica,sans-serif;
+}


### PR DESCRIPTION
# What
This completely overhauls the custom token image experience. It drastically improves the UI, and makes all the interactions much cleaner and easier to understand. It's still a _relatively_ hidden feature, but I added some information when accessing it via the context menu that should help with discoverability.

### Modal Window
Custom image configuration now uses a modal instead of a context menu. This can still be accessed by right-clicking the image on a monster row, but can also be accessed by clicking the button on the right side of the monster row. This modal can also be accessed for a placed token, via the token context menu. When accessing the modal for a placed token, there are extra options for setting the image on that token without saving the image for other tokens.

### Demo Video
https://www.dropbox.com/s/fg1ilkp585fsquf/custom-token-modal-5.mov?raw=1

### Screenshots

This is what it looks like by default
<img width="352" alt="Screen Shot 2021-11-19 at 1 28 05 PM" src="https://user-images.githubusercontent.com/584771/142680426-be51b609-8d2c-425e-b412-42c96aa4d6ea.png">

This is what it looks like with some custom images 
<img width="346" alt="Screen Shot 2021-11-19 at 1 28 46 PM" src="https://user-images.githubusercontent.com/584771/142680494-6dfbb829-cd43-41ff-9622-ce4a97ae65a2.png">

This is what it looks like when accessed from the context menu of a placed token
<img width="345" alt="Screen Shot 2021-11-19 at 1 29 36 PM" src="https://user-images.githubusercontent.com/584771/142680610-85758aed-4723-4087-b224-0117509009af.png">

This is what it looks like with a bunch of images
![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/584771/142681890-96f03f62-6e47-487e-8a4f-7f644e262279.gif)

