### PR TITLE
Hook DDB's processFlashMessages function to avoid calling it during animations

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1583,6 +1583,16 @@ function init_ui() {
 		},10000);
 		setTimeout(get_pclist_player_data,25000);
 	}
+
+	// Hook DDB's processFlashMessages function to avoid calling it during animations
+	// It gets called every 2.5 seconds and runs for approx. 200ms, depending on cookie size
+	var origProcessFlashMessages = Cobalt.Core.processFlashMessages;
+	Cobalt.Core.processFlashMessages = function(i, r) {
+		// Allow DDB to process only while we're not during animation to avoid stutters
+		if (!window.MOUSEDOWN || i != "FlashMessageAjax") {
+			return origProcessFlashMessages(i, r);
+		}
+	};
 }
 
 function init_buttons() {


### PR DESCRIPTION
DDB's scripts call a function named processFlashMessages every 2500ms.
The function runs on the main thread for a very long time - profiling shows it takes about 200-250ms.
If we're during 'animation' - i.e. drawing, selecting, measuring with the ruler etc. - the function call introduces a noticeable stutter as new GPU frames are stalled.

This patch hooks their function and avoids calling it while the mouse button is 'down', only if the message received as argument is "FlashMessageAjax".