### PR TITLE
Tokens pane rebuild

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -342,21 +342,21 @@ window.addEventListener("keyup", async (event) => {
         return;
     }
     if (rotationKeyPresses.includes('ArrowDown') && rotationKeyPresses.includes('ArrowLeft')) {
-        rotate_selected_tokens(45);
+        rotate_selected_tokens(45, true);
     } else if (rotationKeyPresses.includes('ArrowLeft') && rotationKeyPresses.includes('ArrowUp')) {
-        rotate_selected_tokens(135);
+        rotate_selected_tokens(135, true);
     } else if (rotationKeyPresses.includes('ArrowUp') && rotationKeyPresses.includes('ArrowRight')) {
-        rotate_selected_tokens(225);
+        rotate_selected_tokens(225, true);
     } else if (rotationKeyPresses.includes('ArrowRight') && rotationKeyPresses.includes('ArrowDown')) {
-        rotate_selected_tokens(315);
+        rotate_selected_tokens(315, true);
     } else if (rotationKeyPresses.includes('ArrowDown')) {
-        rotate_selected_tokens(0);
+        rotate_selected_tokens(0, true);
     } else if (rotationKeyPresses.includes('ArrowLeft')) {
-        rotate_selected_tokens(90);
+        rotate_selected_tokens(90, true);
     } else if (rotationKeyPresses.includes('ArrowUp')) {
-        rotate_selected_tokens(180);
+        rotate_selected_tokens(180, true);
     } else if (rotationKeyPresses.includes('ArrowRight')) {
-        rotate_selected_tokens(270);
+        rotate_selected_tokens(270, true);
     }
 
     rotationKeyPresses = [];

--- a/Main.js
+++ b/Main.js
@@ -1,5 +1,9 @@
 
 function parse_img(url){
+	if (url === undefined) {
+		console.warn("parse_img was called without a url");
+		return "";
+	}
 	retval=url;
 	if(retval.startsWith("https://drive.google.com") && retval.indexOf("uc?id=") < 0)
 		retval='https://drive.google.com/uc?id=' + retval.split('/')[5];
@@ -1500,7 +1504,7 @@ function init_ui() {
 	init_combat_tracker();
 
 	token_menu();
-	load_custom_image_mapping();
+	load_custom_monster_image_mapping();
 
 
 	window.WaypointManager=new WaypointManagerClass();

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -5,1828 +5,38 @@ tokenbuiltin = {
 			tokens: {
 				'Blood': {
 					'data-img': 'https://drive.google.com/file/d/1frTuvq-64DA23ayC6P0XGZyo0M6paEID/view?usp=sharing',
-					'data-disablestat': true,
 					'data-disableborder': true,
 					'data-square': true,
 				},
 				'Big Bang': {
 					'data-img': 'https://drive.google.com/file/d/19pbEuWVSQo15vmlsnJry-q3ordcAlaej/view?usp=sharing',
-					'data-disablestat': true,
 					'data-disableborder': true,
 					'data-square': true,
 				},
 				'Fire': {
 					'data-img': 'https://drive.google.com/file/d/1_wE3B5rvr38cM9NMbCQ__WUf0RIXIuhQ/view?usp=sharing',
-					'data-disablestat': true,
 					'data-disableborder': true,
 					'data-square': true,
 				},
 				'Flame 1': {
 					'data-img': 'https://thumbs.gfycat.com/GiddyMajorDingo-small.gif',
-					'data-disablestat': true,
 					'data-disableborder': true,
 					'data-square': true,
 				},
 				'Flame 2': {
 					'data-img': 'https://cutewallpaper.org/21/fire-gif-transparent-background/Fire-PNG-Gif-Transparent-Fire-GifPNG-Images-PlusPNG.gif',
-					'data-disablestat': true,
 					'data-disableborder': true,
 					'data-square': true,
 				},
 				'Nebula': {
 					'data-img': 'https://drive.google.com/file/d/1AeoKU444D3DrtjebegH0yRXNolrqw89K/view?usp=sharing',
-					'data-disablestat': true,
 					'data-disableborder': true,
 					'data-square': true,
 				},
 				'Web': {
 					'data-img': 'https://drive.google.com/file/d/1rGuD7FMtzy6XR0qcsewndhS33wZL8vEM/view?usp=sharing',
-					'data-disablestat': true,
 					'data-disableborder': true,
 					'data-square': true,
-				},
-			}
-		},
-		'Elves [M]': {
-			tokens: {
-				'Elf 1': {
-					'data-img': 'https://i.imgur.com/KhyErAR.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 2': {
-					'data-img': 'https://i.imgur.com/bh9ZIeg.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 3': {
-					'data-img': 'https://i.imgur.com/K8U1b0h.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 4': {
-					'data-img': 'https://i.imgur.com/T3LBvjm.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 5': {
-					'data-img': 'https://i.imgur.com/06A68du.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 6': {
-					'data-img': 'https://i.imgur.com/DF1dSy7.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 7': {
-					'data-img': 'https://i.imgur.com/lG3wpol.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 8': {
-					'data-img': 'https://i.imgur.com/JC0VwYz.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 9': {
-					'data-img': 'https://i.imgur.com/iNaGb82.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 10': {
-					'data-img': 'https://i.imgur.com/w4rZdMx.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 11': {
-					'data-img': 'https://i.imgur.com/Eagxsqn.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 12': {
-					'data-img': 'https://i.imgur.com/PN7rm5K.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 13': {
-					'data-img': 'https://i.imgur.com/vkEGS5t.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 14': {
-					'data-img': 'https://i.imgur.com/5cUJo1X.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 15': {
-					'data-img': 'https://i.imgur.com/36nKnjL.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 16': {
-					'data-img': 'https://i.imgur.com/zzVxVGA.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 17': {
-					'data-img': 'https://i.imgur.com/f24uQF7.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 18': {
-					'data-img': 'https://i.imgur.com/2d2apvN.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 19': {
-					'data-img': 'https://i.imgur.com/ukdo8ds.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 20': {
-					'data-img': 'https://i.imgur.com/F9r9k3P.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 21': {
-					'data-img': 'https://i.imgur.com/dH30PNn.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 22': {
-					'data-img': 'https://i.imgur.com/9zg0eK8.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 23': {
-					'data-img': 'https://i.imgur.com/xQ0uII4.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 24': {
-					'data-img': 'https://i.imgur.com/Yt6osn6.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 25': {
-					'data-img': 'https://i.imgur.com/bNdE7DR.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 26': {
-					'data-img': 'https://i.imgur.com/AF3fv3C.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 27': {
-					'data-img': 'https://i.imgur.com/j3aX15i.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 28': {
-					'data-img': 'https://i.imgur.com/X1GP2WM.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 29': {
-					'data-img': 'https://i.imgur.com/v5FHlGi.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 30': {
-					'data-img': 'https://i.imgur.com/LfbJzvb.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 31': {
-					'data-img': 'https://i.imgur.com/V0rwmIX.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 32': {
-					'data-img': 'https://i.imgur.com/hqSP2Rs.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 33': {
-					'data-img': 'https://i.imgur.com/MNUuxZj.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 34': {
-					'data-img': 'https://i.imgur.com/dl8Vf71.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 35': {
-					'data-img': 'https://i.imgur.com/wSofg8Z.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 36': {
-					'data-img': 'https://i.imgur.com/mxXCnY1.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 37': {
-					'data-img': 'https://i.imgur.com/uwQOjqz.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 38': {
-					'data-img': 'https://i.imgur.com/d8FvdaA.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 39': {
-					'data-img': 'https://i.imgur.com/b3n8zEv.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 40': {
-					'data-img': 'https://i.imgur.com/aiHUW1S.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 41': {
-					'data-img': 'https://i.imgur.com/685hEZP.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 42': {
-					'data-img': 'https://i.imgur.com/bO5teIc.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 43': {
-					'data-img': 'https://i.imgur.com/4sbNTs1.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 44': {
-					'data-img': 'https://i.imgur.com/x5PsGUD.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Elves [F]': {
-			tokens: {
-				'Elf 45': {
-					'data-img': 'https://i.imgur.com/5brExHK.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 46': {
-					'data-img': 'https://i.imgur.com/97Ssvg7.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 47': {
-					'data-img': 'https://i.imgur.com/Ql7WS0c.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 48': {
-					'data-img': 'https://i.imgur.com/vv4dBMN.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 49': {
-					'data-img': 'https://i.imgur.com/RBJ0P2K.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 50': {
-					'data-img': 'https://i.imgur.com/BVyZapA.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 51': {
-					'data-img': 'https://i.imgur.com/LyGbTHB.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 52': {
-					'data-img': 'https://i.imgur.com/MvxHbId.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 53': {
-					'data-img': 'https://i.imgur.com/S2taBOJ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 54': {
-					'data-img': 'https://i.imgur.com/gbu9vUX.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 55': {
-					'data-img': 'https://i.imgur.com/6tSIQyq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 56': {
-					'data-img': 'https://i.imgur.com/Y4d6rzn.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 57': {
-					'data-img': 'https://i.imgur.com/mo6XKpV.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 58': {
-					'data-img': 'https://i.imgur.com/RdTPLng.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 59': {
-					'data-img': 'https://i.imgur.com/CBwlgMF.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 60': {
-					'data-img': 'https://i.imgur.com/8n7IpwR.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 61': {
-					'data-img': 'https://i.imgur.com/rGbRzLw.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Elf 62': {
-					'data-img': 'https://i.imgur.com/2Lglcip.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Humans [M]': {
-			tokens: {
-				'Human 1': {
-					'data-img': 'https://i.imgur.com/vyeBFvg.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 2': {
-					'data-img': 'https://i.imgur.com/iicVOSh.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 3': {
-					'data-img': 'https://i.imgur.com/RXQvDzB.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 4': {
-					'data-img': 'https://i.imgur.com/yMm3znX.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 5': {
-					'data-img': 'https://i.imgur.com/ZLYlstS.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 6': {
-					'data-img': 'https://i.imgur.com/E4aNjka.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 7': {
-					'data-img': 'https://i.imgur.com/sJodY4T.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 8': {
-					'data-img': 'https://i.imgur.com/cfsFqZk.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 9': {
-					'data-img': 'https://i.imgur.com/XdXU7mn.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 10': {
-					'data-img': 'https://i.imgur.com/GcNRFqx.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 11': {
-					'data-img': 'https://i.imgur.com/zVfhSCK.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 12': {
-					'data-img': 'https://i.imgur.com/0Hz1O3A.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 13': {
-					'data-img': 'https://i.imgur.com/nEh1ufo.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 14': {
-					'data-img': 'https://i.imgur.com/6XEUaP5.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 15': {
-					'data-img': 'https://i.imgur.com/VSU5NHE.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 16': {
-					'data-img': 'https://i.imgur.com/rYyd1h2.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 17': {
-					'data-img': 'https://i.imgur.com/07ffel4.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 18': {
-					'data-img': 'https://i.imgur.com/pyXlYqe.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 19': {
-					'data-img': 'https://i.imgur.com/KS2Hybd.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 20': {
-					'data-img': 'https://i.imgur.com/T6v1q7T.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 21': {
-					'data-img': 'https://i.imgur.com/juJzfQr.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 22': {
-					'data-img': 'https://i.imgur.com/RGzc7aD.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 23': {
-					'data-img': 'https://i.imgur.com/9J2iKvp.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 24': {
-					'data-img': 'https://i.imgur.com/2SaSS0Y.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 25': {
-					'data-img': 'https://i.imgur.com/jJ4c6ba.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 26': {
-					'data-img': 'https://i.imgur.com/k7Wx4mJ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 27': {
-					'data-img': 'https://i.imgur.com/Vo1U9cK.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 28': {
-					'data-img': 'https://i.imgur.com/LVWkKVI.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 29': {
-					'data-img': 'https://i.imgur.com/yMMA82P.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 30': {
-					'data-img': 'https://i.imgur.com/f0N2oJa.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 31': {
-					'data-img': 'https://i.imgur.com/XJR4m0s.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 32': {
-					'data-img': 'https://i.imgur.com/8BKKghq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 33': {
-					'data-img': 'https://i.imgur.com/FBPr0Qx.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 34': {
-					'data-img': 'https://i.imgur.com/zPJVZV9.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 35': {
-					'data-img': 'https://i.imgur.com/Fxnv4ze.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 36': {
-					'data-img': 'https://i.imgur.com/D3MfkZH.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 37': {
-					'data-img': 'https://i.imgur.com/fXa8rTq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 38': {
-					'data-img': 'https://i.imgur.com/azyGhw3.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 39': {
-					'data-img': 'https://i.imgur.com/QmmV63Y.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 40': {
-					'data-img': 'https://i.imgur.com/r84pZVU.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 41': {
-					'data-img': 'https://i.imgur.com/qQKIKnR.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 42': {
-					'data-img': 'https://i.imgur.com/cDq8Vsr.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 43': {
-					'data-img': 'https://i.imgur.com/CbANiCZ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 44': {
-					'data-img': 'https://i.imgur.com/roOhEoe.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 45': {
-					'data-img': 'https://i.imgur.com/2cLWc3p.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 46': {
-					'data-img': 'https://i.imgur.com/BgvoUWh.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 47': {
-					'data-img': 'https://i.imgur.com/PXEx15g.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 48': {
-					'data-img': 'https://i.imgur.com/GlG30ko.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 49': {
-					'data-img': 'https://i.imgur.com/MilamyO.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 50': {
-					'data-img': 'https://i.imgur.com/fnmpif1.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 51': {
-					'data-img': 'https://i.imgur.com/LxSkBCv.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 52': {
-					'data-img': 'https://i.imgur.com/BDWVEoG.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 53': {
-					'data-img': 'https://i.imgur.com/H8gIrL2.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 54': {
-					'data-img': 'https://i.imgur.com/Kz31l7I.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 55': {
-					'data-img': 'https://i.imgur.com/URuYHUf.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 56': {
-					'data-img': 'https://i.imgur.com/jpYQQCi.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 57': {
-					'data-img': 'https://i.imgur.com/onBgm22.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 58': {
-					'data-img': 'https://i.imgur.com/s86MIgN.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 59': {
-					'data-img': 'https://i.imgur.com/AW2altj.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 60': {
-					'data-img': 'https://i.imgur.com/gGag3hL.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 61': {
-					'data-img': 'https://i.imgur.com/C184k7z.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 62': {
-					'data-img': 'https://i.imgur.com/Q2EL6Zo.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 63': {
-					'data-img': 'https://i.imgur.com/AqOra0V.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 64': {
-					'data-img': 'https://i.imgur.com/NRowLmi.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 65': {
-					'data-img': 'https://i.imgur.com/47levai.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 66': {
-					'data-img': 'https://i.imgur.com/yDhhssO.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 67': {
-					'data-img': 'https://i.imgur.com/1J3nNHm.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 68': {
-					'data-img': 'https://i.imgur.com/S1uJBLa.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 69': {
-					'data-img': 'https://i.imgur.com/QT918eT.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 70': {
-					'data-img': 'https://i.imgur.com/FFLNXSA.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 71': {
-					'data-img': 'https://i.imgur.com/98mmYIW.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 72': {
-					'data-img': 'https://i.imgur.com/xi7maaE.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 73': {
-					'data-img': 'https://i.imgur.com/XBzgh8w.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 74': {
-					'data-img': 'https://i.imgur.com/pFW96Y2.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 75': {
-					'data-img': 'https://i.imgur.com/d1Cnrja.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 76': {
-					'data-img': 'https://i.imgur.com/fHSoonu.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 77': {
-					'data-img': 'https://i.imgur.com/UltpGWb.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 78': {
-					'data-img': 'https://i.imgur.com/wRUadat.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 79': {
-					'data-img': 'https://i.imgur.com/MvMSm3r.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 80': {
-					'data-img': 'https://i.imgur.com/eMfk7Zx.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 81': {
-					'data-img': 'https://i.imgur.com/yMNo6I9.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 82': {
-					'data-img': 'https://i.imgur.com/qjGsNn7.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 83': {
-					'data-img': 'https://i.imgur.com/JnJiGoa.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 84': {
-					'data-img': 'https://i.imgur.com/ZTSWn3Y.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 85': {
-					'data-img': 'https://i.imgur.com/v4F4gjg.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 86': {
-					'data-img': 'https://i.imgur.com/gJ9XBJI.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 87': {
-					'data-img': 'https://i.imgur.com/D7tMAL2.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 88': {
-					'data-img': 'https://i.imgur.com/hEQxRZy.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 89': {
-					'data-img': 'https://i.imgur.com/4RZiadV.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 90': {
-					'data-img': 'https://i.imgur.com/NYZJ8xP.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 91': {
-					'data-img': 'https://i.imgur.com/alANUDw.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 92': {
-					'data-img': 'https://i.imgur.com/3pxBGbD.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 93': {
-					'data-img': 'https://i.imgur.com/DHfRth2.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 94': {
-					'data-img': 'https://i.imgur.com/1bX4Qln.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 95': {
-					'data-img': 'https://i.imgur.com/0rzf1SN.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 96': {
-					'data-img': 'https://i.imgur.com/DFP9CIA.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 97': {
-					'data-img': 'https://i.imgur.com/fBh4m9C.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 98': {
-					'data-img': 'https://i.imgur.com/JqhtEZ0.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 99': {
-					'data-img': 'https://i.imgur.com/6l2RDlv.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 100': {
-					'data-img': 'https://i.imgur.com/FZmdqsr.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Humans [F]': {
-			tokens: {
-				'Human 101': {
-					'data-img': 'https://i.imgur.com/NjP2sGL.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 102': {
-					'data-img': 'https://i.imgur.com/H8Q36Zh.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 103': {
-					'data-img': 'https://i.imgur.com/RZq8SBK.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 104': {
-					'data-img': 'https://i.imgur.com/HHwopfD.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 105': {
-					'data-img': 'https://i.imgur.com/XqxVZmK.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 106': {
-					'data-img': 'https://i.imgur.com/CPAfuWB.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 107': {
-					'data-img': 'https://i.imgur.com/74bpcvT.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 108': {
-					'data-img': 'https://i.imgur.com/urg9Qhh.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 109': {
-					'data-img': 'https://i.imgur.com/t4yQcY9.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 110': {
-					'data-img': 'https://i.imgur.com/eymbYs8.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 111': {
-					'data-img': 'https://i.imgur.com/HOgBuYA.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 112': {
-					'data-img': 'https://i.imgur.com/FofhAaY.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 113': {
-					'data-img': 'https://i.imgur.com/ftlyRz6.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 114': {
-					'data-img': 'https://i.imgur.com/ufdYpaw.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 115': {
-					'data-img': 'https://i.imgur.com/PZ0UHJV.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 116': {
-					'data-img': 'https://i.imgur.com/6Ha5aDY.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 117': {
-					'data-img': 'https://i.imgur.com/DOnKbPL.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 118': {
-					'data-img': 'https://i.imgur.com/lbxFV6I.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 119': {
-					'data-img': 'https://i.imgur.com/2U9nwqu.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 120': {
-					'data-img': 'https://i.imgur.com/KcIaDqG.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 121': {
-					'data-img': 'https://i.imgur.com/NDNovgG.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 122': {
-					'data-img': 'https://i.imgur.com/RZkpx3l.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 123': {
-					'data-img': 'https://i.imgur.com/fZKrYaJ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 124': {
-					'data-img': 'https://i.imgur.com/AuXrxtN.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 125': {
-					'data-img': 'https://i.imgur.com/tG53u3r.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Human 126': {
-					'data-img': 'https://i.imgur.com/9emKSJI.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				}
-			},
-		},
-		'Dwarf [M]': {
-			tokens: {
-				'Dwarf 1': {
-					'data-img': 'https://i.imgur.com/T6K1v8s.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 2': {
-					'data-img': 'https://i.imgur.com/7xgLl17.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 3': {
-					'data-img': 'https://i.imgur.com/zO45eax.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 4': {
-					'data-img': 'https://i.imgur.com/w7KIJiI.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 5': {
-					'data-img': 'https://i.imgur.com/G9iZhpX.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 6': {
-					'data-img': 'https://i.imgur.com/F2hwQHB.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 7': {
-					'data-img': 'https://i.imgur.com/eamn3uD.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 8': {
-					'data-img': 'https://i.imgur.com/BSg4egK.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 9': {
-					'data-img': 'https://i.imgur.com/WRS4HKH.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 10': {
-					'data-img': 'https://i.imgur.com/G6aLVWI.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 11': {
-					'data-img': 'https://i.imgur.com/iSz72pl.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 12': {
-					'data-img': 'https://i.imgur.com/04X94ln.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 13': {
-					'data-img': 'https://i.imgur.com/F5kRG9O.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 14': {
-					'data-img': 'https://i.imgur.com/kANojx5.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 15': {
-					'data-img': 'https://i.imgur.com/SPQXGob.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 16': {
-					'data-img': 'https://i.imgur.com/jhVxT3w.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 17': {
-					'data-img': 'https://i.imgur.com/usObgvL.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 18': {
-					'data-img': 'https://i.imgur.com/4LUdLCx.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 19': {
-					'data-img': 'https://i.imgur.com/78ZtTUn.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Dwarf [F]': {
-			tokens: {
-				'Dwarf 20': {
-					'data-img': 'https://i.imgur.com/4Xuzbp6.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 21': {
-					'data-img': 'https://i.imgur.com/AmuvYtQ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 22': {
-					'data-img': 'https://i.imgur.com/ZJvqWHQ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 23': {
-					'data-img': 'https://i.imgur.com/eiWM0V7.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 24': {
-					'data-img': 'https://i.imgur.com/UED8IzA.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dwarf 25': {
-					'data-img': 'https://i.imgur.com/BwDRKyr.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Drow [M]': {
-			tokens: {
-				'Drow 1': {
-					'data-img': 'https://i.imgur.com/RgY5TkF.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 2': {
-					'data-img': 'https://i.imgur.com/RsCAhou.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 3': {
-					'data-img': 'https://i.imgur.com/nwAzSyq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 4': {
-					'data-img': 'https://i.imgur.com/aBlbyWo.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 5': {
-					'data-img': 'https://i.imgur.com/jEBw3ta.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 6': {
-					'data-img': 'https://i.imgur.com/oXyKmyK.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 7': {
-					'data-img': 'https://i.imgur.com/4BKZMqc.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 8': {
-					'data-img': 'https://i.imgur.com/8TcrJ88.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 9': {
-					'data-img': 'https://i.imgur.com/jCWJC1V.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 10': {
-					'data-img': 'https://i.imgur.com/WbWzpGq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 11': {
-					'data-img': 'https://i.imgur.com/O6ui3WV.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 12': {
-					'data-img': 'https://i.imgur.com/Qr8TXfP.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 13': {
-					'data-img': 'https://i.imgur.com/9NuWJG6.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 14': {
-					'data-img': 'https://i.imgur.com/2LwVTUr.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Drow [F]': {
-			tokens: {
-				'Drow 15': {
-					'data-img': 'https://i.imgur.com/lwPqseX.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 16': {
-					'data-img': 'https://i.imgur.com/cVaeAum.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 17': {
-					'data-img': 'https://i.imgur.com/2qHM12W.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 18': {
-					'data-img': 'https://i.imgur.com/apqxuLf.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 19': {
-					'data-img': 'https://i.imgur.com/OkdFTrq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 20': {
-					'data-img': 'https://i.imgur.com/W4NtBsW.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 21': {
-					'data-img': 'https://i.imgur.com/yoIYDKO.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 22': {
-					'data-img': 'https://i.imgur.com/d4baR5O.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 23': {
-					'data-img': 'https://i.imgur.com/hpxtRYf.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 24': {
-					'data-img': 'https://i.imgur.com/SwxOZEX.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 25': {
-					'data-img': 'https://i.imgur.com/wGyXG6h.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 26': {
-					'data-img': 'https://i.imgur.com/ZolhnEc.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 27': {
-					'data-img': 'https://i.imgur.com/ROnLoAj.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 28': {
-					'data-img': 'https://i.imgur.com/PM09pdy.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 29': {
-					'data-img': 'https://i.imgur.com/6c8FF5q.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 30': {
-					'data-img': 'https://i.imgur.com/aqjKtH5.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 31': {
-					'data-img': 'https://i.imgur.com/v49Gd3r.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 32': {
-					'data-img': 'https://i.imgur.com/FHMszi4.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Drow 33': {
-					'data-img': 'https://i.imgur.com/Lom5T9S.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Dragonborn [M]': {
-			tokens: {
-				'Dragonborn 1': {
-					'data-img': 'https://i.imgur.com/0qQpdH6.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 2': {
-					'data-img': 'https://i.imgur.com/EnMudqy.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 3': {
-					'data-img': 'https://i.imgur.com/ovnswTE.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 4': {
-					'data-img': 'https://i.imgur.com/29uuOXb.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 5': {
-					'data-img': 'https://i.imgur.com/Tjyc9Eq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 6': {
-					'data-img': 'https://i.imgur.com/5k3RtNI.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 7': {
-					'data-img': 'https://i.imgur.com/YHOfDUc.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 8': {
-					'data-img': 'https://i.imgur.com/tQdEaQp.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 9': {
-					'data-img': 'https://i.imgur.com/bZZbhFd.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 10': {
-					'data-img': 'https://i.imgur.com/qpbahvt.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 11': {
-					'data-img': 'https://i.imgur.com/lSZIr0v.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 12': {
-					'data-img': 'https://i.imgur.com/Yxd8OuY.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 13': {
-					'data-img': 'https://i.imgur.com/Uha5043.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 14': {
-					'data-img': 'https://i.imgur.com/87kkYBT.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 15': {
-					'data-img': 'https://i.imgur.com/Mu4isFZ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Dragonborn [F]': {
-			tokens: {
-				'Dragonborn 16': {
-					'data-img': 'https://i.imgur.com/92aaNuq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 17': {
-					'data-img': 'https://i.imgur.com/4WTK514.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 18': {
-					'data-img': 'https://i.imgur.com/vV4mfTo.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Dragonborn 19': {
-					'data-img': 'https://i.imgur.com/RdJKUBF.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Genasi': {
-			tokens: {
-				'Genasi 1': {
-					'data-img': 'https://i.imgur.com/YnlG0US.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Genasi 2': {
-					'data-img': 'https://i.imgur.com/6TrSNc8.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Genasi 3': {
-					'data-img': 'https://i.imgur.com/VFn3KwT.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Genasi 4': {
-					'data-img': 'https://i.imgur.com/B1pH2vd.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Genasi 5': {
-					'data-img': 'https://i.imgur.com/m9HfCRo.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Genasi 6': {
-					'data-img': 'https://i.imgur.com/LN9r5Qq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Tiefling [M]': {
-			tokens: {
-				'Tiefling 1': {
-					'data-img': 'https://i.imgur.com/iLKRQF5.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 2': {
-					'data-img': 'https://i.imgur.com/H6EYE4b.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 3': {
-					'data-img': 'https://i.imgur.com/0lzHtWi.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 4': {
-					'data-img': 'https://i.imgur.com/6zcM3U9.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 5': {
-					'data-img': 'https://i.imgur.com/vLPCfzf.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 6': {
-					'data-img': 'https://i.imgur.com/pwuN7KB.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 7': {
-					'data-img': 'https://i.imgur.com/8GsL6N4.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 8': {
-					'data-img': 'https://i.imgur.com/YKFLCMO.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 9': {
-					'data-img': 'https://i.imgur.com/J5FescQ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 10': {
-					'data-img': 'https://i.imgur.com/LHbk4bR.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 11': {
-					'data-img': 'https://i.imgur.com/YGs9gP0.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Tiefling [F]': {
-			tokens: {
-				'Tiefling 12': {
-					'data-img': 'https://i.imgur.com/r6fKPlI.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 13': {
-					'data-img': 'https://i.imgur.com/gbs56aT.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 14': {
-					'data-img': 'https://i.imgur.com/LL8SD3k.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 15': {
-					'data-img': 'https://i.imgur.com/7gBPY82.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 16': {
-					'data-img': 'https://i.imgur.com/YjAMYM1.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 17': {
-					'data-img': 'https://i.imgur.com/dP9wszv.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 18': {
-					'data-img': 'https://i.imgur.com/HtsCPgu.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 19': {
-					'data-img': 'https://i.imgur.com/n2nb2NL.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 20': {
-					'data-img': 'https://i.imgur.com/STNSgme.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 21': {
-					'data-img': 'https://i.imgur.com/4iZmAAl.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 22': {
-					'data-img': 'https://i.imgur.com/LcPOA39.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 23': {
-					'data-img': 'https://i.imgur.com/xDTDx7I.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 24': {
-					'data-img': 'https://i.imgur.com/PyecEQG.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 25': {
-					'data-img': 'https://i.imgur.com/jRK8fZ6.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 26': {
-					'data-img': 'https://i.imgur.com/gPK3Qz7.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 27': {
-					'data-img': 'https://i.imgur.com/XwKL0NN.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 28': {
-					'data-img': 'https://i.imgur.com/rYc2U8J.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Tiefling 29': {
-					'data-img': 'https://i.imgur.com/jHI0pdZ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Warforged': {
-			tokens: {
-				'Warforged 1': {
-					'data-img': 'https://i.imgur.com/N5Nvgkw.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 2': {
-					'data-img': 'https://i.imgur.com/8K3HZZJ.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 3': {
-					'data-img': 'https://i.imgur.com/KrYnmri.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 4': {
-					'data-img': 'https://i.imgur.com/JtyrFHx.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 5': {
-					'data-img': 'https://i.imgur.com/ApJMypw.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 6': {
-					'data-img': 'https://i.imgur.com/2p3WTci.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 7': {
-					'data-img': 'https://i.imgur.com/309BYqb.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 8': {
-					'data-img': 'https://i.imgur.com/r7my3b6.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 9': {
-					'data-img': 'https://i.imgur.com/SVo3VpB.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 10': {
-					'data-img': 'https://i.imgur.com/zrN3Vnt.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Warforged 11': {
-					'data-img': 'https://i.imgur.com/eKfE1AV.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Orcs [M]': {
-			tokens: {
-				'Orc 1': {
-					'data-img': 'https://i.imgur.com/4pWxSUn.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 2': {
-					'data-img': 'https://i.imgur.com/OCrXvMz.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 3': {
-					'data-img': 'https://i.imgur.com/DcDsPj1.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 4': {
-					'data-img': 'https://i.imgur.com/mSZB6Xi.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 5': {
-					'data-img': 'https://i.imgur.com/BjgMrNq.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 6': {
-					'data-img': 'https://i.imgur.com/PSoXLYT.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 7': {
-					'data-img': 'https://i.imgur.com/W27Ad8q.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 8': {
-					'data-img': 'https://i.imgur.com/NChSGAp.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 9': {
-					'data-img': 'https://i.imgur.com/l3AOJfN.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 10': {
-					'data-img': 'https://i.imgur.com/sKQLsz5.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 11': {
-					'data-img': 'https://i.imgur.com/i1taIwb.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Orcs [F]': {
-			tokens: {
-				'Orc 12': {
-					'data-img': 'https://i.imgur.com/gmUUKun.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 13': {
-					'data-img': 'https://i.imgur.com/L0lLPWH.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 14': {
-					'data-img': 'https://i.imgur.com/Pwpr4Lp.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Orc 15': {
-					'data-img': 'https://i.imgur.com/Zz9cnLt.png',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-			}
-		},
-		'Misc NPC': {
-			tokens: {
-				'Maid': {
-					'data-img': 'https://drive.google.com/file/d/1wB5yKNKQ5dqkLhvWA5UZybLBBTDu-57c/view?usp=sharing',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Male Comm.': {
-					'data-img': 'https://drive.google.com/file/d/1H-5cCt03oIB43CnhmdaHM6P2Aw8T2n60/view?usp=sharing',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Male Guard': {
-					'data-img': 'https://drive.google.com/file/d/1C9ghQrfHckKPOMEHdmStaN47y0OXUPZ9/view?usp=sharing',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'Female Comm.': {
-					'data-img': 'https://drive.google.com/file/d/14sNpLcJlzOfL4A5Qb_zdrYmOTZk51GTM/view?usp=sharing',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 1': {
-					'data-img': 'https://i.pinimg.com/564x/fa/93/fb/fa93fbf94a90d2068af62b5a34b48d2d.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 2': {
-					'data-img': 'https://i.pinimg.com/564x/b1/88/10/b18810e3a419fe6c9666ec64c67fdb4f.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 3': {
-					'data-img': 'https://i.pinimg.com/564x/b1/61/18/b16118b557ed8cd55a72631ff763fa97.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 4': {
-					'data-img': 'https://i.pinimg.com/564x/f7/6c/e5/f76ce511507ceb4be5003507c4b3190e.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 5': {
-					'data-img': 'https://i.pinimg.com/564x/d5/9b/e6/d59be622749ea74ccbc88485783e679c.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 6': {
-					'data-img': 'https://i.pinimg.com/564x/55/22/96/55229604ec385c8c1bf442a187a3aeeb.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 7': {
-					'data-img': 'https://i.pinimg.com/564x/da/56/f5/da56f50ba711df5b7c80e2fc240d9786.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 8': {
-					'data-img': 'https://i.pinimg.com/236x/62/45/8e/62458effd9b3901aa220954d50410988.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 9': {
-					'data-img': 'https://i.pinimg.com/236x/dc/39/e3/dc39e3e0edf1204d128565084146e221.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 10': {
-					'data-img': 'https://i.pinimg.com/236x/5a/13/5f/5a135f30617868eb35a78c0c268bd069.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 11': {
-					'data-img': 'https://i.pinimg.com/236x/6a/e2/51/6ae25147759cdf023dac43cdfeb68ef7.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 12': {
-					'data-img': 'https://i.pinimg.com/236x/d5/9b/e6/d59be622749ea74ccbc88485783e679c.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
-				},
-				'NPC 13': {
-					'data-img': 'https://i.pinimg.com/236x/ec/24/81/ec2481a73c161cbbb70622e485bba1ae.jpg',
-					'data-disablestat': true,
-					'data-disableborder': true,
 				},
 			}
 		},
@@ -1835,12 +45,452 @@ tokenbuiltin = {
 				'Heartseeker Blade': {
 					'data-img': 'https://drive.google.com/file/d/1Ft84c1VwnEhwKPew8Yyq8w8NFViC7Mr7/view?usp=sharing',
 					'data-disablestat': true,
-				},
+				}
 			}
+		},
+	},
+	tokens: {
+		'Commoner': {
+			'data-img': 'https://drive.google.com/file/d/1H-5cCt03oIB43CnhmdaHM6P2Aw8T2n60/view?usp=sharing',
+			'data-alternative-images': [
+				'https://drive.google.com/file/d/1H-5cCt03oIB43CnhmdaHM6P2Aw8T2n60/view?usp=sharing',
+				'https://drive.google.com/file/d/14sNpLcJlzOfL4A5Qb_zdrYmOTZk51GTM/view?usp=sharing',
+				'https://i.pinimg.com/564x/fa/93/fb/fa93fbf94a90d2068af62b5a34b48d2d.jpg',
+				'https://i.pinimg.com/564x/b1/88/10/b18810e3a419fe6c9666ec64c67fdb4f.jpg',
+				'https://i.pinimg.com/564x/b1/61/18/b16118b557ed8cd55a72631ff763fa97.jpg',
+				'https://i.pinimg.com/564x/f7/6c/e5/f76ce511507ceb4be5003507c4b3190e.jpg',
+				'https://i.pinimg.com/564x/d5/9b/e6/d59be622749ea74ccbc88485783e679c.jpg',
+				'https://i.pinimg.com/564x/55/22/96/55229604ec385c8c1bf442a187a3aeeb.jpg',
+				'https://i.pinimg.com/564x/da/56/f5/da56f50ba711df5b7c80e2fc240d9786.jpg',
+				'https://i.pinimg.com/236x/62/45/8e/62458effd9b3901aa220954d50410988.jpg',
+				'https://i.pinimg.com/236x/dc/39/e3/dc39e3e0edf1204d128565084146e221.jpg',
+				'https://i.pinimg.com/236x/5a/13/5f/5a135f30617868eb35a78c0c268bd069.jpg',
+				'https://i.pinimg.com/236x/6a/e2/51/6ae25147759cdf023dac43cdfeb68ef7.jpg',
+				'https://i.pinimg.com/236x/d5/9b/e6/d59be622749ea74ccbc88485783e679c.jpg',
+				'https://i.pinimg.com/236x/ec/24/81/ec2481a73c161cbbb70622e485bba1ae.jpg',
+			]
+		},
+		'Dragonborn [F]': {
+			'data-img': 'https://i.imgur.com/92aaNuq.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/92aaNuq.png',
+				'https://i.imgur.com/4WTK514.png',
+				'https://i.imgur.com/vV4mfTo.png',
+				'https://i.imgur.com/RdJKUBF.png',
+			]
+		},
+		'Dragonborn [M]': {
+			'data-img': 'https://i.imgur.com/0qQpdH6.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/0qQpdH6.png',
+				'https://i.imgur.com/EnMudqy.png',
+				'https://i.imgur.com/ovnswTE.png',
+				'https://i.imgur.com/29uuOXb.png',
+				'https://i.imgur.com/Tjyc9Eq.png',
+				'https://i.imgur.com/5k3RtNI.png',
+				'https://i.imgur.com/YHOfDUc.png',
+				'https://i.imgur.com/tQdEaQp.png',
+				'https://i.imgur.com/bZZbhFd.png',
+				'https://i.imgur.com/qpbahvt.png',
+				'https://i.imgur.com/lSZIr0v.png',
+				'https://i.imgur.com/Yxd8OuY.png',
+				'https://i.imgur.com/Uha5043.png',
+				'https://i.imgur.com/87kkYBT.png',
+				'https://i.imgur.com/Mu4isFZ.png',
+			]
+		},
+		'Drow [F]': {
+			'data-img': 'https://i.imgur.com/lwPqseX.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/lwPqseX.png',
+				'https://i.imgur.com/cVaeAum.png',
+				'https://i.imgur.com/2qHM12W.png',
+				'https://i.imgur.com/apqxuLf.png',
+				'https://i.imgur.com/OkdFTrq.png',
+				'https://i.imgur.com/W4NtBsW.png',
+				'https://i.imgur.com/yoIYDKO.png',
+				'https://i.imgur.com/d4baR5O.png',
+				'https://i.imgur.com/hpxtRYf.png',
+				'https://i.imgur.com/SwxOZEX.png',
+				'https://i.imgur.com/wGyXG6h.png',
+				'https://i.imgur.com/ZolhnEc.png',
+				'https://i.imgur.com/ROnLoAj.png',
+				'https://i.imgur.com/PM09pdy.png',
+				'https://i.imgur.com/6c8FF5q.png',
+				'https://i.imgur.com/aqjKtH5.png',
+				'https://i.imgur.com/v49Gd3r.png',
+				'https://i.imgur.com/FHMszi4.png',
+				'https://i.imgur.com/Lom5T9S.png',
+			]
+		},
+		'Drow [M]': {
+			'data-img': 'https://i.imgur.com/RgY5TkF.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/RgY5TkF.png',
+				'https://i.imgur.com/RsCAhou.png',
+				'https://i.imgur.com/nwAzSyq.png',
+				'https://i.imgur.com/aBlbyWo.png',
+				'https://i.imgur.com/jEBw3ta.png',
+				'https://i.imgur.com/oXyKmyK.png',
+				'https://i.imgur.com/4BKZMqc.png',
+				'https://i.imgur.com/8TcrJ88.png',
+				'https://i.imgur.com/jCWJC1V.png',
+				'https://i.imgur.com/WbWzpGq.png',
+				'https://i.imgur.com/O6ui3WV.png',
+				'https://i.imgur.com/Qr8TXfP.png',
+				'https://i.imgur.com/9NuWJG6.png',
+				'https://i.imgur.com/2LwVTUr.png',
+			]
+		},
+		'Dwarf [F]': {
+			'data-img': 'https://i.imgur.com/4Xuzbp6.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/4Xuzbp6.png',
+				'https://i.imgur.com/AmuvYtQ.png',
+				'https://i.imgur.com/ZJvqWHQ.png',
+				'https://i.imgur.com/eiWM0V7.png',
+				'https://i.imgur.com/UED8IzA.png',
+				'https://i.imgur.com/BwDRKyr.png',
+			]
+		},
+		'Dwarf [M]': {
+			'data-img': 'https://i.imgur.com/T6K1v8s.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/T6K1v8s.png',
+				'https://i.imgur.com/7xgLl17.png',
+				'https://i.imgur.com/zO45eax.png',
+				'https://i.imgur.com/w7KIJiI.png',
+				'https://i.imgur.com/G9iZhpX.png',
+				'https://i.imgur.com/F2hwQHB.png',
+				'https://i.imgur.com/eamn3uD.png',
+				'https://i.imgur.com/BSg4egK.png',
+				'https://i.imgur.com/WRS4HKH.png',
+				'https://i.imgur.com/G6aLVWI.png',
+				'https://i.imgur.com/iSz72pl.png',
+				'https://i.imgur.com/04X94ln.png',
+				'https://i.imgur.com/F5kRG9O.png',
+				'https://i.imgur.com/kANojx5.png',
+				'https://i.imgur.com/SPQXGob.png',
+				'https://i.imgur.com/jhVxT3w.png',
+				'https://i.imgur.com/usObgvL.png',
+				'https://i.imgur.com/4LUdLCx.png',
+				'https://i.imgur.com/78ZtTUn.png',
+			]
+		},
+		'Elf [F]': {
+			'data-img': 'https://i.imgur.com/5brExHK.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/5brExHK.png',
+				'https://i.imgur.com/97Ssvg7.png',
+				'https://i.imgur.com/Ql7WS0c.png',
+				'https://i.imgur.com/vv4dBMN.png',
+				'https://i.imgur.com/RBJ0P2K.png',
+				'https://i.imgur.com/BVyZapA.png',
+				'https://i.imgur.com/LyGbTHB.png',
+				'https://i.imgur.com/MvxHbId.png',
+				'https://i.imgur.com/S2taBOJ.png',
+				'https://i.imgur.com/gbu9vUX.png',
+				'https://i.imgur.com/6tSIQyq.png',
+				'https://i.imgur.com/Y4d6rzn.png',
+				'https://i.imgur.com/mo6XKpV.png',
+				'https://i.imgur.com/RdTPLng.png',
+				'https://i.imgur.com/CBwlgMF.png',
+				'https://i.imgur.com/8n7IpwR.png',
+				'https://i.imgur.com/rGbRzLw.png',
+				'https://i.imgur.com/2Lglcip.png',
+			]
+		},
+		'Elf [M]': {
+			'data-img': 'https://i.imgur.com/KhyErAR.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/KhyErAR.png',
+				'https://i.imgur.com/bh9ZIeg.png',
+				'https://i.imgur.com/K8U1b0h.png',
+				'https://i.imgur.com/T3LBvjm.png',
+				'https://i.imgur.com/06A68du.png',
+				'https://i.imgur.com/DF1dSy7.png',
+				'https://i.imgur.com/lG3wpol.png',
+				'https://i.imgur.com/JC0VwYz.png',
+				'https://i.imgur.com/iNaGb82.png',
+				'https://i.imgur.com/w4rZdMx.png',
+				'https://i.imgur.com/Eagxsqn.png',
+				'https://i.imgur.com/PN7rm5K.png',
+				'https://i.imgur.com/vkEGS5t.png',
+				'https://i.imgur.com/5cUJo1X.png',
+				'https://i.imgur.com/36nKnjL.png',
+				'https://i.imgur.com/zzVxVGA.png',
+				'https://i.imgur.com/f24uQF7.png',
+				'https://i.imgur.com/2d2apvN.png',
+				'https://i.imgur.com/ukdo8ds.png',
+				'https://i.imgur.com/F9r9k3P.png',
+				'https://i.imgur.com/dH30PNn.png',
+				'https://i.imgur.com/9zg0eK8.png',
+				'https://i.imgur.com/xQ0uII4.png',
+				'https://i.imgur.com/Yt6osn6.png',
+				'https://i.imgur.com/bNdE7DR.png',
+				'https://i.imgur.com/AF3fv3C.png',
+				'https://i.imgur.com/j3aX15i.png',
+				'https://i.imgur.com/X1GP2WM.png',
+				'https://i.imgur.com/v5FHlGi.png',
+				'https://i.imgur.com/LfbJzvb.png',
+				'https://i.imgur.com/V0rwmIX.png',
+				'https://i.imgur.com/hqSP2Rs.png',
+				'https://i.imgur.com/MNUuxZj.png',
+				'https://i.imgur.com/dl8Vf71.png',
+				'https://i.imgur.com/wSofg8Z.png',
+				'https://i.imgur.com/mxXCnY1.png',
+				'https://i.imgur.com/uwQOjqz.png',
+				'https://i.imgur.com/d8FvdaA.png',
+				'https://i.imgur.com/b3n8zEv.png',
+				'https://i.imgur.com/aiHUW1S.png',
+				'https://i.imgur.com/685hEZP.png',
+				'https://i.imgur.com/bO5teIc.png',
+				'https://i.imgur.com/4sbNTs1.png',
+				'https://i.imgur.com/x5PsGUD.png',
+			]
+		},
+		'Genasi': {
+			'data-img': 'https://i.imgur.com/YnlG0US.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/YnlG0US.png',
+				'https://i.imgur.com/6TrSNc8.png',
+				'https://i.imgur.com/VFn3KwT.png',
+				'https://i.imgur.com/B1pH2vd.png',
+				'https://i.imgur.com/m9HfCRo.png',
+				'https://i.imgur.com/LN9r5Qq.png',
+			]
+		},
+		'Guard [M]': {
+			'data-img': 'https://drive.google.com/file/d/1C9ghQrfHckKPOMEHdmStaN47y0OXUPZ9/view?usp=sharing',
+			'data-alternative-images': [
+				'https://drive.google.com/file/d/1C9ghQrfHckKPOMEHdmStaN47y0OXUPZ9/view?usp=sharing'
+			]
+		},
+		'Human [F]': {
+			'data-img': 'https://i.imgur.com/NjP2sGL.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/NjP2sGL.png',
+				'https://i.imgur.com/H8Q36Zh.png',
+				'https://i.imgur.com/RZq8SBK.png',
+				'https://i.imgur.com/HHwopfD.png',
+				'https://i.imgur.com/XqxVZmK.png',
+				'https://i.imgur.com/CPAfuWB.png',
+				'https://i.imgur.com/74bpcvT.png',
+				'https://i.imgur.com/urg9Qhh.png',
+				'https://i.imgur.com/t4yQcY9.png',
+				'https://i.imgur.com/eymbYs8.png',
+				'https://i.imgur.com/HOgBuYA.png',
+				'https://i.imgur.com/FofhAaY.png',
+				'https://i.imgur.com/ftlyRz6.png',
+				'https://i.imgur.com/ufdYpaw.png',
+				'https://i.imgur.com/PZ0UHJV.png',
+				'https://i.imgur.com/6Ha5aDY.png',
+				'https://i.imgur.com/DOnKbPL.png',
+				'https://i.imgur.com/lbxFV6I.png',
+				'https://i.imgur.com/2U9nwqu.png',
+				'https://i.imgur.com/KcIaDqG.png',
+				'https://i.imgur.com/NDNovgG.png',
+				'https://i.imgur.com/RZkpx3l.png',
+				'https://i.imgur.com/fZKrYaJ.png',
+				'https://i.imgur.com/AuXrxtN.png',
+				'https://i.imgur.com/tG53u3r.png',
+				'https://i.imgur.com/9emKSJI.png',
+			]
+		},
+		'Human [M]': {
+			'data-img': 'https://i.imgur.com/vyeBFvg.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/vyeBFvg.png',
+				'https://i.imgur.com/iicVOSh.png',
+				'https://i.imgur.com/RXQvDzB.png',
+				'https://i.imgur.com/yMm3znX.png',
+				'https://i.imgur.com/ZLYlstS.png',
+				'https://i.imgur.com/E4aNjka.png',
+				'https://i.imgur.com/sJodY4T.png',
+				'https://i.imgur.com/cfsFqZk.png',
+				'https://i.imgur.com/XdXU7mn.png',
+				'https://i.imgur.com/GcNRFqx.png',
+				'https://i.imgur.com/zVfhSCK.png',
+				'https://i.imgur.com/0Hz1O3A.png',
+				'https://i.imgur.com/nEh1ufo.png',
+				'https://i.imgur.com/6XEUaP5.png',
+				'https://i.imgur.com/VSU5NHE.png',
+				'https://i.imgur.com/rYyd1h2.png',
+				'https://i.imgur.com/07ffel4.png',
+				'https://i.imgur.com/pyXlYqe.png',
+				'https://i.imgur.com/KS2Hybd.png',
+				'https://i.imgur.com/T6v1q7T.png',
+				'https://i.imgur.com/juJzfQr.png',
+				'https://i.imgur.com/RGzc7aD.png',
+				'https://i.imgur.com/9J2iKvp.png',
+				'https://i.imgur.com/2SaSS0Y.png',
+				'https://i.imgur.com/jJ4c6ba.png',
+				'https://i.imgur.com/k7Wx4mJ.png',
+				'https://i.imgur.com/Vo1U9cK.png',
+				'https://i.imgur.com/LVWkKVI.png',
+				'https://i.imgur.com/yMMA82P.png',
+				'https://i.imgur.com/f0N2oJa.png',
+				'https://i.imgur.com/XJR4m0s.png',
+				'https://i.imgur.com/8BKKghq.png',
+				'https://i.imgur.com/FBPr0Qx.png',
+				'https://i.imgur.com/zPJVZV9.png',
+				'https://i.imgur.com/Fxnv4ze.png',
+				'https://i.imgur.com/D3MfkZH.png',
+				'https://i.imgur.com/fXa8rTq.png',
+				'https://i.imgur.com/azyGhw3.png',
+				'https://i.imgur.com/QmmV63Y.png',
+				'https://i.imgur.com/r84pZVU.png',
+				'https://i.imgur.com/qQKIKnR.png',
+				'https://i.imgur.com/cDq8Vsr.png',
+				'https://i.imgur.com/CbANiCZ.png',
+				'https://i.imgur.com/roOhEoe.png',
+				'https://i.imgur.com/2cLWc3p.png',
+				'https://i.imgur.com/BgvoUWh.png',
+				'https://i.imgur.com/PXEx15g.png',
+				'https://i.imgur.com/GlG30ko.png',
+				'https://i.imgur.com/MilamyO.png',
+				'https://i.imgur.com/fnmpif1.png',
+				'https://i.imgur.com/LxSkBCv.png',
+				'https://i.imgur.com/BDWVEoG.png',
+				'https://i.imgur.com/H8gIrL2.png',
+				'https://i.imgur.com/Kz31l7I.png',
+				'https://i.imgur.com/URuYHUf.png',
+				'https://i.imgur.com/jpYQQCi.png',
+				'https://i.imgur.com/onBgm22.png',
+				'https://i.imgur.com/s86MIgN.png',
+				'https://i.imgur.com/AW2altj.png',
+				'https://i.imgur.com/gGag3hL.png',
+				'https://i.imgur.com/C184k7z.png',
+				'https://i.imgur.com/Q2EL6Zo.png',
+				'https://i.imgur.com/AqOra0V.png',
+				'https://i.imgur.com/NRowLmi.png',
+				'https://i.imgur.com/47levai.png',
+				'https://i.imgur.com/yDhhssO.png',
+				'https://i.imgur.com/1J3nNHm.png',
+				'https://i.imgur.com/S1uJBLa.png',
+				'https://i.imgur.com/QT918eT.png',
+				'https://i.imgur.com/FFLNXSA.png',
+				'https://i.imgur.com/98mmYIW.png',
+				'https://i.imgur.com/xi7maaE.png',
+				'https://i.imgur.com/XBzgh8w.png',
+				'https://i.imgur.com/pFW96Y2.png',
+				'https://i.imgur.com/d1Cnrja.png',
+				'https://i.imgur.com/fHSoonu.png',
+				'https://i.imgur.com/UltpGWb.png',
+				'https://i.imgur.com/wRUadat.png',
+				'https://i.imgur.com/MvMSm3r.png',
+				'https://i.imgur.com/eMfk7Zx.png',
+				'https://i.imgur.com/yMNo6I9.png',
+				'https://i.imgur.com/qjGsNn7.png',
+				'https://i.imgur.com/JnJiGoa.png',
+				'https://i.imgur.com/ZTSWn3Y.png',
+				'https://i.imgur.com/v4F4gjg.png',
+				'https://i.imgur.com/gJ9XBJI.png',
+				'https://i.imgur.com/D7tMAL2.png',
+				'https://i.imgur.com/hEQxRZy.png',
+				'https://i.imgur.com/4RZiadV.png',
+				'https://i.imgur.com/NYZJ8xP.png',
+				'https://i.imgur.com/alANUDw.png',
+				'https://i.imgur.com/3pxBGbD.png',
+				'https://i.imgur.com/DHfRth2.png',
+				'https://i.imgur.com/1bX4Qln.png',
+				'https://i.imgur.com/0rzf1SN.png',
+				'https://i.imgur.com/DFP9CIA.png',
+				'https://i.imgur.com/fBh4m9C.png',
+				'https://i.imgur.com/JqhtEZ0.png',
+				'https://i.imgur.com/6l2RDlv.png',
+				'https://i.imgur.com/FZmdqsr.png',
+			]
+		},
+		'Maid [F]': {
+			'data-img': 'https://drive.google.com/file/d/1wB5yKNKQ5dqkLhvWA5UZybLBBTDu-57c/view?usp=sharing',
+			'data-alternative-images': [
+				'https://drive.google.com/file/d/1wB5yKNKQ5dqkLhvWA5UZybLBBTDu-57c/view?usp=sharing'
+			]
+		},
+		'Orc [F]': {
+			'data-img': 'https://i.imgur.com/gmUUKun.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/gmUUKun.png',
+				'https://i.imgur.com/L0lLPWH.png',
+				'https://i.imgur.com/Pwpr4Lp.png',
+				'https://i.imgur.com/Zz9cnLt.png',
+			]
+		},
+		'Orc [M]': {
+			'data-img': 'https://i.imgur.com/4pWxSUn.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/4pWxSUn.png',
+				'https://i.imgur.com/OCrXvMz.png',
+				'https://i.imgur.com/DcDsPj1.png',
+				'https://i.imgur.com/mSZB6Xi.png',
+				'https://i.imgur.com/BjgMrNq.png',
+				'https://i.imgur.com/PSoXLYT.png',
+				'https://i.imgur.com/W27Ad8q.png',
+				'https://i.imgur.com/NChSGAp.png',
+				'https://i.imgur.com/l3AOJfN.png',
+				'https://i.imgur.com/sKQLsz5.png',
+				'https://i.imgur.com/i1taIwb.png',
+			]
+		},
+		'Tiefling [F]': {
+			'data-img': 'https://i.imgur.com/r6fKPlI.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/r6fKPlI.png',
+				'https://i.imgur.com/gbs56aT.png',
+				'https://i.imgur.com/LL8SD3k.png',
+				'https://i.imgur.com/7gBPY82.png',
+				'https://i.imgur.com/YjAMYM1.png',
+				'https://i.imgur.com/dP9wszv.png',
+				'https://i.imgur.com/HtsCPgu.png',
+				'https://i.imgur.com/n2nb2NL.png',
+				'https://i.imgur.com/STNSgme.png',
+				'https://i.imgur.com/4iZmAAl.png',
+				'https://i.imgur.com/LcPOA39.png',
+				'https://i.imgur.com/xDTDx7I.png',
+				'https://i.imgur.com/PyecEQG.png',
+				'https://i.imgur.com/jRK8fZ6.png',
+				'https://i.imgur.com/gPK3Qz7.png',
+				'https://i.imgur.com/XwKL0NN.png',
+				'https://i.imgur.com/rYc2U8J.png',
+				'https://i.imgur.com/jHI0pdZ.png',
+			]
+		},
+		'Tiefling [M]': {
+			'data-img': 'https://i.imgur.com/iLKRQF5.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/iLKRQF5.png',
+				'https://i.imgur.com/H6EYE4b.png',
+				'https://i.imgur.com/0lzHtWi.png',
+				'https://i.imgur.com/6zcM3U9.png',
+				'https://i.imgur.com/vLPCfzf.png',
+				'https://i.imgur.com/pwuN7KB.png',
+				'https://i.imgur.com/8GsL6N4.png',
+				'https://i.imgur.com/YKFLCMO.png',
+				'https://i.imgur.com/J5FescQ.png',
+				'https://i.imgur.com/LHbk4bR.png',
+				'https://i.imgur.com/YGs9gP0.png',
+			]
+		},
+		'Warforged': {
+			'data-img': 'https://i.imgur.com/N5Nvgkw.png',
+			'data-alternative-images': [
+				'https://i.imgur.com/N5Nvgkw.png',
+				'https://i.imgur.com/8K3HZZJ.png',
+				'https://i.imgur.com/KrYnmri.png',
+				'https://i.imgur.com/JtyrFHx.png',
+				'https://i.imgur.com/ApJMypw.png',
+				'https://i.imgur.com/2p3WTci.png',
+				'https://i.imgur.com/309BYqb.png',
+				'https://i.imgur.com/r7my3b6.png',
+				'https://i.imgur.com/SVo3VpB.png',
+				'https://i.imgur.com/zrN3Vnt.png',
+				'https://i.imgur.com/eKfE1AV.png',
+			]
 		}
 	}
 };
-		
+
 
 tokendata={
 	folders:{},
@@ -1854,97 +504,62 @@ function init_tokenmenu(){
 		tokendata=$.parseJSON(localStorage.getItem('CustomTokens'));
 	}
 	tokendata.folders['AboveVTT BUILTIN']=tokenbuiltin;
-	tokens_panel=$("<div id='tokens-panel' class='sidepanel-content'/>");
+	
+	let tokens_panel = $("<div id='tokens-panel' class='sidepanel-content'/>");
 	tokens_panel.hide();
-	tokens_panel.append("<div class='panel-warning'>THIS IS AN EXPERIMENTAL FEATURE. DON'T START SPENDING HOURS ADDING TOKENS YET. YOU MAY LOOSE THEM</div>");
-	header=$("<div id='tokens-panel-header'/>");
-	tokens_panel.append(header);
-	addfolder=$("<button id='token-addfolder'>Add Folder</button>");
+	let tokens_panel_content = $(`<div class="token-image-modal-content"></div>`);
+	tokens_panel.append(tokens_panel_content);
+	tokens_panel_content.append("<div class='panel-warning'>THIS IS AN EXPERIMENTAL FEATURE. DON'T START SPENDING HOURS ADDING TOKENS YET. YOU MAY LOSE THEM</div>");
 	
-	addfolder.click(function(){
-		var newfoldername=prompt("Enter the name of the new folder");
-		if(!window.CURRENT_TOKEN_FOLDER.folders)
-			window.CURRENT_TOKEN_FOLDER.folders={};
-		window.CURRENT_TOKEN_FOLDER.folders[newfoldername]={};
-		fill_tokenmenu(window.CURRENT_TOKEN_PATH);
-		persist_customtokens();
+	let header = $("<div id='tokens-panel-header'></div>");
+	let backButton = $(`<div class="tokens-panel-back-button"><div>Back</div></div>`);
+	header.append(backButton);
+	backButton.click(function(event) {
+		let previous = containing_folder_path(window.CURRENT_TOKEN_PATH);
+		fill_tokenmenu(previous);
 	});
 	
-	header.append(addfolder);
-	addtoken=$("<button id='token-addtoken'>Add Token</button>");
-	addtoken.click(function(){
-		if($("#token-form").is(":hidden"))
-			$("#token-form").show();
-	});
-	header.append(addtoken);
-	
-	
-	tokenform=$("<div id='token-form'/>");
-	
-	tokenform.append(`
-		<form>
-			<div>
-				<div>Name</div>
-				<div><input name='data-name'></div>
-			</div>
-			<div>
-				<div>Image URL:</div>
-				<div><input name='data-img'></div>
-			</div>
-			<div>
-				<div>Image type</div>
-				<div><select name='data-square'><option value='0'>Round</option><option value='1'>Square</option></select></div>
-			</div>
-			<div>
-				<div>Hide Border</div>
-				<div><input type='checkbox' name='data-disableborder'></div>
-			</div>
-			<div>
-				<div>Stretch non-square token images by default</div>
-				<div><input type='checkbox' name='data-legacyaspectratio'></div>
-			</div>
-			<div>
-				<button id='tokenform-save'>Save</button>
-				<button id='tokenform-cancel'>Cancel</button>
-			</div>
-		</form>
-	`);
-	
-	tokenform.find("form").on('submit',function(e) { e.preventDefault(); });
-	tokenform.find("#tokenform-save").click(function(){
-		var tokenname=tokenform.find("[name='data-name']").val();
-		var newtoken={};
-		newtoken['data-img']=tokenform.find("[name='data-img']").val();
-		if(newtoken['data-img'].startsWith("data:")){
-			alert("WARNING. You're tring to add an url that begins with data: . Please only add urls that starts with http: or https");
-			return;
-		}
-
-		newtoken['data-square']=tokenform.find("[name='data-square']").val();
-		newtoken['data-name']=tokenform.find("[name='data-name']").val();
-		newtoken['data-disablestat']=true;
-		if(tokenform.find("[name='data-disableborder']").is(":checked"))
-			newtoken['data-disableborder']=true;
-		newtoken['data-legacyaspectratio']=tokenform.find("[name='data-legacyaspectratio']").is(":checked");
-			
-		
-		if(!window.CURRENT_TOKEN_FOLDER.tokens)
-			window.CURRENT_TOKEN_FOLDER.tokens={};
-		window.CURRENT_TOKEN_FOLDER.tokens[tokenname]=newtoken;
-		fill_tokenmenu(window.CURRENT_TOKEN_PATH);
-		tokenform.hide();
-		persist_customtokens();
-	});
-	
-	tokenform.find("#tokenform-cancel").click(function(){
-		tokenform.hide();
-	});
-	
-	tokenform.hide();
-	tokens_panel.append(tokenform);
-	tokens_panel.append("<div id='tokens-panel-data' />");
+	tokens_panel_content.append(header);
+	tokens_panel_content.append("<div id='tokens-panel-data' />");
 	$(".sidebar__pane-content").append(tokens_panel);
 	fill_tokenmenu("");
+
+	let footer = $("<div id='tokens-panel-footer'></div>");
+	let addTokenButton = $(`<button id='add-token-btn'>Add Token</button>`);
+	addTokenButton.click(function(event) {
+		let path = $(event.target).attr("data-folder-path");
+		if (path === undefined) {
+			path = "";
+		}
+		display_custom_token_form(path);
+	});
+	let addFolderButton = $(`<button id='add-folder-btn'>Add Folder</button>`);
+	addFolderButton.click(function(event) {
+		var newfoldername = prompt("Enter the name of the new folder");
+		if (newfoldername == undefined || newfoldername == "") {
+			// don't add folders when cancel is pressed or if they didn't enter a folder name at all
+			return;
+		}
+		let path = window.CURRENT_TOKEN_PATH;
+		if (path === undefined) {
+			path = "";
+		}
+		let folder = convert_path(path);
+		if(!folder.folders) {
+			folder.folders = {};
+		}
+		folder.folders[newfoldername] = {};
+		persist_customtokens();
+		fill_tokenmenu(`${path}/${newfoldername}`);
+	});
+
+	footer.append(addTokenButton);
+	footer.append(addFolderButton);
+	tokens_panel_content.append(footer);
+
+
+	register_token_row_context_menu();             // context menu for each row
+	register_custom_monster_image_context_menu();  // context menu for images within the customization modal
 }
 
 function convert_path(path){
@@ -1960,105 +575,1099 @@ function convert_path(path){
 }
 
 function fill_tokenmenu(path){
-	console.log(path);
-	var folder=convert_path(path);
-	window.CURRENT_TOKEN_FOLDER=folder;
-	window.CURRENT_TOKEN_PATH=path;
+	console.log(`fill_tokenmenu ${path}`);
+	if (path === undefined) {
+		path = "";
+	}
+	window.CURRENT_TOKEN_PATH = path; // be careful using this. It should only be used for folder navigation
+	let folder = convert_path(path);
 	$("#tokens-panel-data").empty();
-	
-	if (path.startsWith("/AboveVTT BUILTIN")){
-		$("#token-addfolder").attr("disabled","disabled");
-		$("#token-addtoken").attr("disabled","disabled");
+	$("#add-token-btn").attr("data-folder-path", path);
+	$("#add-folder-btn").attr("data-folder-path", path);
+	if (path == "") {
+		$("#tokens-panel-header .tokens-panel-back-button").hide();
+	} else {
+		$("#tokens-panel-header .tokens-panel-back-button").show();
 	}
-	else{
-		$("#token-addfolder").removeAttr("disabled");
-		$("#token-addtoken").removeAttr("disabled");
-	}
-	
-	if(path!=""){
-		var previous=path.substring(0,path.lastIndexOf("/"));
-		var newentry=$(`
-			<div data-path='${previous}' class='tokenfolder tokenmenuitem'>
-				<img data-path='${previous}' class='tokenentryimg tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
-				<div>..</div>
-			</div>
-		`);
-		$("#tokens-panel-data").append(newentry);
-	}
-	
-	
-	for(let f in folder.folders){
-		var newpath=path+"/"+f;
-		var newentry=$(`
-			<div data-path='${newpath}' class='tokenfolder tokenmenuitem'>
-				<img data-path='${newpath}' class='tokenentryimg tokenfolderimg' src='${window.EXTENSION_PATH+"assets/folder.svg"}'>
-				<div class="label-one-line">${f}</div>
-			</div>
-		`);
-		if(!path.startsWith("/AboveVTT BUILTIN") && !f.startsWith("AboveVTT BUILTIN")){
-			delbutton=$("<button class='delfolder'>DEL</button>");
-			delbutton.attr('data-target',f);
-			newentry.append(delbutton);
-			delbutton.click(function(e){
-				r = confirm("This will delete this token folder. Are you sure?");
-				if (r == true) {
-					delete window.CURRENT_TOKEN_FOLDER.folders[$(this).attr('data-target')];
-					fill_tokenmenu(window.CURRENT_TOKEN_PATH);
-					persist_customtokens();
-				}
-			});
-		}
-		$("#tokens-panel-data").append(newentry);
-	}
-	$(".tokenfolderimg").click(function(e){
-		fill_tokenmenu($(this).attr('data-path'));
-	});
-	
-	for(let t in folder.tokens){
 
-		var tokenImgClass = 'tokenentryimg';
-		if (folder.tokens[t]["data-legacyaspectratio"] == false) {
-				// if the option is undefined, this token was created before the option existed and should therefore use the legacy behavior
-				// if the option is true, the user actively enabled the option.
-				// if the option is false, then we want to preserve aspect ratio
-			tokenImgClass = 'tokenentryimg preserve-aspect-ratio';
-		}
-
-		var newentry=$(`
-			<div class='tokenentry tokenmenuitem'>
-				<img class='${tokenImgClass}' src='${parse_img(folder.tokens[t]["data-img"])}'></img>
-				<div class="label-one-line">${t}</div>
-				<button class='tokenadd' >Token</button>
-			</div>
-		`);
-		
-		if(!path.startsWith("/AboveVTT BUILTIN")){
-			delbutton=$("<button class='tokendel'>DEL</button>");
-			delbutton.attr('data-target',t);
-			newentry.append(delbutton);
-		}
-		
-		for(prop in folder.tokens[t]){
-			newentry.find(".tokenadd").attr(prop,folder.tokens[t][prop]);
-		}
-		
-		newentry.find(".tokendel").click(function(){
-			r = confirm("This will delete this token. Are you sure?");
-			if (r == true) {
-				delete window.CURRENT_TOKEN_FOLDER.tokens[$(this).attr('data-target')];
-				fill_tokenmenu(window.CURRENT_TOKEN_PATH);
-				persist_customtokens();
-			}
-		});
-		
-		$("#tokens-panel-data").append(newentry);
-	}
+	draw_custom_token_list(folder, path);
 	
-	$(".tokenadd").click(token_button);
+	// don't allow users to add tokens or folders inside the builtin folder
+	if (is_builtin(path)) {
+		$("#tokens-panel-footer").hide();
+	} else {
+		$("#tokens-panel-footer").show();
+	}
 }
 
 function persist_customtokens(){
 	tokendata.folders["AboveVTT BUILTIN"]={};
 	localStorage.setItem("CustomTokens",JSON.stringify(tokendata));
 	tokendata.folders["AboveVTT BUILTIN"]=tokenbuiltin;
+}
+
+function draw_custom_token_list(folder, path) {
+
+	$("#tokens-panel-data").empty();
+
+	let list = $(`<div class="custom-token-list"></div>`);
+	if (folder.folders) {
+		for(let f in folder.folders) {
+			let row = build_custom_token_row(f, window.EXTENSION_PATH + "assets/folder.svg", undefined, false);
+			row.find(".custom-token-image-row-handle").remove(); // no drag handle on the right side of folders
+			row.find(".custom-token-image-row-add svg").css("fill", "#fff");
+			row.find(".custom-token-image-row-add").css("border", "#fff");
+			row.find(".custom-token-image-row-add").prop("disabled", true);
+			let currentFolderPath = path + "/" + f;
+			row.click(function () {
+				fill_tokenmenu(currentFolderPath);
+			});
+			row.attr('data-folder-name', f);
+			row.attr('data-folder-path', path);
+			list.append(row);
+		}
+	}
+
+	if (folder.tokens) {
+		for(let t in folder.tokens) {
+			let token = folder.tokens[t]
+			let name = token["data-name"];
+			if (name == undefined) {
+				name = t;
+			}
+			let imgSrc = token["data-img"];
+			let tokenSize = token["data-token-size"];
+			let subtitleText = "Small / Medium (5ft)";
+			if (tokenSize != undefined) {
+				switch (tokenSize) {
+					case "custom": 
+						subtitleText = "Custom (Xft)"; // figure this out
+						break; 
+					case 2: subtitleText = "Large (10ft)"; break;
+					case 3: subtitleText = "Huge (15ft)"; break;
+					case 4: subtitleText = "Gargantuan (20ft)"; break;
+				}
+			}
+			let row = build_custom_token_row(name, imgSrc, subtitleText);
+			for(prop in token){
+				row.find(".custom-token-image-row-add").attr(prop, token[prop]);
+			}
+			row.find(".custom-token-image-row-add").attr("data-disablestat", true);
+			row.find(".custom-token-image-row-add").attr("data-token-size", tokenSize);
+			row.find(".custom-token-image-row-add").attr('data-tokendatapath', path);
+			row.find(".custom-token-image-row-add").attr('data-tokendataname', t);
+			row.find(".custom-token-image-row-add").click(function(event) {
+				// token_button uses target which will often be the svg inside of the button, but we want to use the button which will always be currentTarget
+				place_token_from_modal(path, t, false);
+				// event.target = $(event.currentTarget).clone(true);
+				// token_button(event);
+			});
+	
+			row.attr('data-tokendatapath', path);
+			row.attr('data-tokendataname', t);
+			row.find(".custom-token-image-row-handle").click(function() {
+				display_custom_token_form(path, t, token);
+			});
+	
+			list.append(row);
+		}
+	}
+
+	$("#tokens-panel-data").append(list);
+}
+
+function build_custom_token_row(name, imgSrc, subtitleText, enableDrag = true) {
+
+	let row = $(`<div class="custom-token-image-row"></div>`);
+	let rowItem = $(`<div class="custom-token-image-row-item"></div>`);
+	row.append(rowItem);
+
+	let imgHolder = $(`<div class="custom-token-image-row-img"></div>`);
+	let img = $(`<img src="${parse_img(imgSrc)}" />`);
+	imgHolder.append(img);
+
+	let details = $(`<div class="custom-token-image-row-details"></div>`);
+	let title = $(`<div class="custom-token-image-row-details-title">${name}</div>`);
+	details.append(title);
+	if (subtitleText != undefined) {
+		let subtitle = $(`<div class="custom-token-image-row-details-subtitle">${subtitleText}</div>`);
+		details.append(subtitle);
+	}
+
+	let addButton = $(`
+		<button class="custom-token-image-row-add" title="${name}" data-name="${name}" data-img="${imgSrc}">
+			<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.2 10.8V18h3.6v-7.2H18V7.2h-7.2V0H7.2v7.2H0v3.6h7.2z"></path></svg>
+		</button>
+	`);
+	let handle = $(`<div class="custom-token-image-row-handle"><svg class="monster-row__cell--drag-handle__icon" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11 2a1 1 0 110 2H1a1 1 0 110-2h10zm0 6a1 1 0 110 2H1a1 1 0 110-2h10z"></path></svg></div>`);
+
+	rowItem.append(imgHolder);
+	rowItem.append(details);
+	rowItem.append(addButton);
+	rowItem.append(handle);
+
+	if (enableDrag) {
+		rowItem.draggable({
+			appendTo: "#VTTWRAPPER",
+			zIndex: 100000,
+			cancel: '.custom-token-image-row-handle',
+			helper: function(event) {
+				let helper = $(event.currentTarget).find(".custom-token-image-row-img img").clone();
+				let addButton = $(event.currentTarget).find(".custom-token-image-row-add");
+				let path = addButton.attr("data-tokendatapath");
+				let name = addButton.attr("data-tokendataname");
+				helper.attr("src", random_image_for_token(path, name));
+				return helper;
+			},
+			start: function (event, ui) {
+				console.log("row-item drag start");
+				let addButton = $(event.currentTarget).find(".custom-token-image-row-add");
+				let tokenSize = addButton.data('token-size');
+				if (tokenSize === undefined) {
+					tokenSize = 1;
+				}
+				let width = Math.round(window.CURRENT_SCENE_DATA.hpps) * tokenSize;
+				let helperWidth = width / (1.0 / window.ZOOM);
+				$(ui.helper).css('width', `${helperWidth}px`);
+				$(this).draggable('instance').offset.click = {
+					left: Math.floor(ui.helper.width() / 2),
+					top: Math.floor(ui.helper.height() / 2)
+				};
+			},
+			stop: function (event, ui) { 
+				// place a token where this was dropped
+				console.log("row-item drag stop");
+				let src = $(ui.helper).attr("src");
+				let addButton = $(event.target).find(".custom-token-image-row-add");
+				let path = addButton.attr("data-tokendatapath");
+				let name = addButton.attr("data-tokendataname");
+				place_token_from_modal(path, name, event.shiftKey, src, event.pageX, event.pageY);
+			}
+		});
+	}
+	return row;
+}
+
+
+function register_token_row_context_menu() {
+
+	// don't allow the context menu when right clicking on the add button since that adds a hidden token
+	$(".custom-token-image-row").on("contextmenu", ".custom-token-image-row-add", function(event) {
+		event.preventDefault();
+		event.stopPropagation();
+		// token_button uses target which will often be the svg inside of the button, but we want to use the button which will always be currentTarget
+		let tokendatapath = $(event.currentTarget).attr("data-tokendatapath");
+		let tokendataname = $(event.currentTarget).attr("data-tokendataname");
+		if (tokendataname === undefined) {
+			tokendataname = $(event.currentTarget).attr("data-name");
+		}
+		place_token_from_modal(tokendatapath, tokendataname, true);
+	});
+
+	$.contextMenu({
+		selector: ".custom-token-image-row",
+		build: function(element, e) {
+
+			let items = {};
+			
+			let folderName = $(element).attr("data-folder-name");
+			let isFolder = folderName !== undefined;
+			
+			let tokenAddButton = $(element).find(".custom-token-image-row-add");
+
+			let path = "";
+			if (isFolder) {
+				path = $(element).attr("data-folder-path");
+			} else {
+				path = tokenAddButton.attr("data-tokendatapath");
+			}
+			if (path === undefined) {
+				path = "";
+			}
+			let folder = convert_path(path);
+
+			let tokenName = tokenAddButton.attr("data-tokendataname");
+			if (tokenName === undefined) {
+				tokenName = tokenAddButton.attr("data-name");
+			}
+			
+			if (!isFolder) {
+				// add token items
+
+				items["place"] = {
+					name: "Place Token",
+					callback: function(itemKey, opt, originalEvent) {
+						place_token_from_modal(path, tokenName, false);
+					}
+				};
+				
+				items["placeHidden"] = {
+					name: "Place Hidden Token",
+					callback: function(itemKey, opt, originalEvent) {
+						place_token_from_modal(path, tokenName, true);
+					}
+				};
+
+				items["copyUrl"] = {
+					name: "Copy Url",
+					callback: function(itemKey, opt, originalEvent) {
+						let imgSrc = tokenAddButton.attr("data-img");
+						copy_to_clipboard(imgSrc);
+					}
+				};
+
+			} 
+
+			// add delete menu option
+			if (path.startsWith("/AboveVTT BUILTIN")) {
+				items["no-delete"] = {
+					name: "Folders and Tokens provided by AboveVTT cannot be edited or deleted",
+					disabled: true
+				};
+			} else {
+
+				items["edit"] = {
+					name: "Edit",
+					callback: function(itemKey, opt, originalEvent) {
+						if (isFolder) {
+							var newfoldername = prompt("Enter the name of the folder", folderName);
+							if (newfoldername != undefined && newfoldername.length > 0) {
+								if(!folder.folders) {
+									folder.folders = {};
+								}
+								folder.folders[newfoldername] = folder.folders[folderName];
+								delete folder.folders[folderName];
+								fill_tokenmenu(path);
+								persist_customtokens();
+							}
+						} else {
+							display_custom_token_form(path, tokenName);
+						}
+					}
+				};
+	
+				items["border"] = "---";
+	
+				// not a built in folder or token, add an option to delete
+				items["delete"] = {
+					name: "Delete",
+					callback: function(itemKey, opt, originalEvent) {
+						if (isFolder) {
+							console.log(`delete selected; folderName = ${folderName}`);
+							if (confirm(`Are you sure you want to delete the folder "${folderName}"? The folder and all tokens in it will be deleted. This cannot be undone.`)) {
+								delete folder.folders[folderName];
+								fill_tokenmenu(path);
+								persist_customtokens();
+							}
+						} else {
+							console.log(`delete selected; tokenName = ${tokenName}`);
+							if (confirm(`Are you sure you want to delete the token "${tokenName}"? This cannot be undone.`)) {
+								delete folder.tokens[tokenName];
+								fill_tokenmenu(path);
+								persist_customtokens();
+							}
+						}
+					}
+				};
+			}
+			return { items: items };
+		}
+	});
+}
+
+function is_builtin(path) {
+	if (path === undefined) {
+		console.warn("is_builtin was called without a path");
+		return false;
+	}
+	return path.startsWith("/AboveVTT BUILTIN");
+}
+
+function display_custom_token_form(path, name, token) {
+
+	// close any that are already open. This shouldn't be necessary, but it doesn't hurt just in case
+	close_token_customization_modal();
+
+	if (path === undefined) {
+		console.warn("display_custom_token_form was called without a path");
+		path = "";
+	}
+	let folder = convert_path(path);
+
+	if (name !== undefined && token === undefined) {
+		// we got a name, but not a token. Let's see if we can find a token that matches the name
+		token = folder.tokens[name];
+	}
+
+	let explanationText = "Enter a url at the bottom to create a new token.";
+	let headerTitle = name === undefined ? "New Token" : name
+	let modalHeader = build_token_modal_header(headerTitle, explanationText);
+
+	if (token !== undefined) {
+		explanationText = "When placing tokens, one of these images will be chosen at random. Right-click an image for more options.";
+		modalHeader.find(".token-image-modal-header-subtitle").hide();
+		migrate_token_image_data(token);
+	}
+
+	// build the modal body
+	let modalBody = $(`<div class="token-image-modal-body"></div>`);
+	// add all of the tokens images to the body
+	redraw_images_in_modal_body(modalBody, path, name, token);
+
+	// put it all together
+	let modal = build_modal_container();
+	let modalContent = modal.find(".token-image-modal-content");
+	modalContent.append(modalHeader);
+	modalContent.append(modalBody);
+	if (!is_builtin(path)) {
+		// only allow editing of non-builtin tokens
+		let modalFooter = build_custom_token_form_footer(path, name, token);
+		modalContent.append(modalFooter);
+	}
+
+	// display it
+	$("#VTTWRAPPER").append(modal);
+	update_modal_images(populate_token_from_form(token));
+}
+
+function build_custom_token_form_footer(path, name, token) {
+	let footerText = token == undefined ? "Enter an Image Url" : "Add More Custom Images";
+	const footerSubmit = function(imgUrl) {
+		submit_custom_token_form(path);
+	}
+	let modalFooter = build_token_modal_footer(footerText, footerSubmit);
+	let inputWrapper = modalFooter.find(".token-image-modal-footer-input-wrapper");
+	inputWrapper.css("width", "100%");
+	let nameInput = $(`<input data-previous-name="${name}" title="token name" placeholder="my token name" name="addCustomName" type="text" style="width:100%" value="${name == undefined ? '' : name}" />`);
+	nameInput.on('keyup', function(event) {
+		if (event.key == "Enter") {
+			submit_custom_token_form(path);
+		}
+	});
+
+	// TODO: add a custom option and allow users to specify the size 			<option value="custom">Custom</option>
+	let tokenSizeInput = $(`
+		<select name="data-token-size">
+			<option value="1">Small/Medium (5ft)</option>
+			<option value="2">Large (10ft)</option>
+			<option value="3">Huge (15ft)</option>
+			<option value="4">Gargantuan (20ft)</option>
+		</select>
+	`);	
+	let tokenSize = token == undefined ? undefined : token["data-token-size"];
+	if (tokenSize != undefined) {
+		if (tokenSize > 4) {
+			tokenSizeInput.val("custom");
+		} else {
+			tokenSizeInput.val(`${tokenSize}`);
+		}
+	} else {
+		tokenSizeInput.val("default");
+	}
+
+	let tokenTypeInput = $(`
+		<select name="data-square">
+			<option value="default">Default</option>
+			<option value="round">Round</option>
+			<option value="square">Square</option>
+		</select>
+	`);
+	// this is explicitly looking for 
+	let tokenType = token == undefined ? undefined : token["data-square"];
+	// this is explicitly looking for true/false because the default value is undefined
+	if (tokenType == true) {
+		tokenTypeInput.val("square");
+	} else if (tokenType == false) {
+		tokenTypeInput.val("round");
+	} else {
+		tokenTypeInput.val("default");
+	}
+
+	let hideBorderInput = $(`
+		<select name="data-disableborder">
+			<option value="default">Default</option>
+			<option value="enabled">Border</option>
+			<option value="disabled">No Border</option>
+		</select>
+	`);
+	let hideBorder = token == undefined ? undefined : token["data-disableborder"];
+	// this is explicitly looking for true/false because the default value is undefined
+	if (hideBorder == true) {
+		hideBorderInput.val("disabled");
+	} else if (hideBorder == false) {
+		hideBorderInput.val("enabled");
+	} else {
+		hideBorderInput.val("default");
+	}
+
+	let aspectRatioInput = $(`
+		<select name="data-legacyaspectratio">
+			<option value="default">Default</option>
+			<option value="maintain">Maintain</option>
+			<option value="legacy">Stretch</option>
+		</select>
+	`);
+	let legacyaspectratio = token == undefined ? undefined : token["data-legacyaspectratio"];
+	// this is explicitly looking for true/false because the default value is undefined
+	if (legacyaspectratio == true) {
+		aspectRatioInput.val("legacy");
+	} else if (legacyaspectratio == false) {
+		aspectRatioInput.val("maintain");
+	} else {
+		aspectRatioInput.val("default");
+	}
+
+	let saveButton = $(`<button class="token-image-modal-add-button" style="width:100%;padding:8px;margin-top:8px;margin-left:0px;">Save Token</button>`);
+	saveButton.click(function(event) {
+		submit_custom_token_form(path);
+		close_token_customization_modal();
+	});
+
+	const selectWrapper = function(labelText, input) {
+		let wrapper = $(`<div class="token-image-modal-footer-select-wrapper"><div class="token-image-modal-footer-title">${labelText}</div></div>`);
+		wrapper.append(input);
+		input.change(function(event) {
+			submit_custom_token_form(path);
+		});
+		return wrapper;
+	};
+
+	inputWrapper.append($(`<div class="token-image-modal-footer-title" style="width:100%;padding-left:0px">Token Name</div>`));
+	inputWrapper.append(nameInput);
+	inputWrapper.append(selectWrapper("Token Size", tokenSizeInput));
+	inputWrapper.append(`<div class="token-image-modal-explanation" style="padding-bottom:6px;">The following will override global settings for this token. Global settings can be changed in the settings tab.</div>`)
+	inputWrapper.append(selectWrapper("Token Shape", tokenTypeInput)); // class token-round
+	inputWrapper.append(selectWrapper("Border Visibility", hideBorderInput)); // border-width: 4
+	inputWrapper.append(selectWrapper("Aspect Ratio", aspectRatioInput)); // class preserve-aspect-ratio
+	inputWrapper.append(saveButton);
+
+	return modalFooter;
+}
+
+function populate_token_from_form(token) {
+	if (token == undefined) {
+		token = {};
+	}
+
+	let inputWrapper = $(".token-image-modal-footer-input-wrapper");
+	if (inputWrapper.length == 0) {
+		// we're probably inside a builtin directory. We remove the footer to avoid users mucking with builtin data, and therefore don't have a form to populate from
+		return token;
+	}
+
+	let tokenSize = inputWrapper.find(`select[name='data-token-size']`)[0].value;
+	if (tokenSize == "custom") {
+		// TODO: this
+	} else {
+		let tokenSizeNumber = parseInt(tokenSize);
+		if (tokenSizeNumber !== undefined && typeof tokenSizeNumber === 'number') {
+			token['data-token-size'] = tokenSizeNumber;
+		} else {
+			delete token['data-token-size'];
+		}
+	}
+
+	let tokenType = inputWrapper.find(`select[name='data-square']`)[0].value;
+	switch (tokenType) {
+		case "square":
+			token['data-square'] = true;
+			break;
+		case "round": 
+			token['data-square'] = false;
+			break;
+		default:
+			delete token['data-square'];
+	}
+
+	let hideBorder = inputWrapper.find(`select[name='data-disableborder']`)[0].value;
+	switch (hideBorder) {
+		case "disabled": 
+			token['data-disableborder'] = true;
+			break;
+		case "enabled":
+			token['data-disableborder'] = false;
+			break;
+		default:
+			delete token['data-disableborder'];
+	}
+
+	let aspectRatio = inputWrapper.find(`select[name='data-legacyaspectratio']`)[0].value;
+	switch (aspectRatio) {
+		case "legacy": 
+			token['data-legacyaspectratio'] = true;
+			break;
+		case "maintain":
+			token['data-legacyaspectratio'] = false;
+			break;
+		default:
+			delete token['data-legacyaspectratio'];
+	}
+
+	return token;
+}
+
+function submit_custom_token_form(path) {
+	if (path === undefined) {
+		console.warn("submit_custom_token_form was called without a path");
+		path = "";
+	}
+	let folder = convert_path(path);
+	if(!folder.tokens) {
+		folder.tokens={};
+	}
+
+	let inputWrapper = $(".token-image-modal-footer-input-wrapper");
+	
+	let nameInput = inputWrapper.find(`input[name='addCustomName']`)[0];
+	let name = nameInput.value;
+	if (name == undefined || name.length == 0) {
+		console.warn("not saving a token with no name");
+		return;
+	}
+	// if the token already exists, the name will be stored here. Use it to find the token object as well as handling name changes
+	let previousName = $(nameInput).attr("data-previous-name");
+	let imageInput = inputWrapper.find(`input[name='addCustomImage']`)[0];
+	let imageUrl = imageInput.value;
+
+	if(imageUrl.startsWith("data:")){
+		alert("You cannot use urls starting with data:");
+		return;
+	}
+
+	let token;
+	if (previousName != undefined && previousName.length > 0 && previousName != 'undefined') {
+		token = folder.tokens[previousName];
+	}
+
+	let isNewToken = token == undefined;
+	let didRename = previousName != name;
+
+	if (didRename) {
+		if (folder.tokens[name] !== undefined) {
+			// prevent them from overwriting an existing token
+			alert(`There is already a token named "${name}"`);
+			return;
+		}
+		// the user renamed this token. Remove the token at the old name. We'll be saving under the new name shortly.
+		delete folder.tokens[previousName];
+	}
+
+	if (isNewToken) {
+		token = { 'data-img': imageUrl };
+	}
+
+	if (token['data-alternative-images'] == undefined) {
+		token['data-alternative-images'] = [];
+	}
+
+	if (imageUrl != undefined && imageUrl.length > 0 && token['data-alternative-images'].at(-1) != imageUrl) {
+		token['data-alternative-images'].push(imageUrl);
+	}
+
+	folder.tokens[name] = populate_token_from_form(token);
+	persist_customtokens();
+	
+	if (isNewToken || didRename) {
+		// redraw the entire modal so we get all the updated information about the token. 
+		// if you submit the same name twice in a row, we seem to get a cached DOM element for some reason
+		// TODO: figure out everything that needs to be updated, and do that instead of redrawing the entire thing
+		display_custom_token_form(path, name, token);
+	} else {
+		redraw_images_in_modal_body($(".token-image-modal-body"), path, name, token);
+	}
+	// just reload the body instead of the entire modal
+	
+	fill_tokenmenu(path);
+	update_modal_images(folder.tokens[name]);
+}
+
+function update_modal_images(token) {
+
+	if (token === undefined) {
+		console.warn("update_modal_images was called without a token");
+		return;
+	}
+
+	let items = $(".token-image-modal-body .custom-token-image-item");
+	console.log(items);
+
+	// use token override if it exists, else fall back to global setting
+	let tokenSquareSetting = token["data-square"];
+	let globalSquareSetting = window.TOKEN_SETTINGS["square"];
+	if (tokenSquareSetting == true) {
+		items.find("img").removeClass("token-round");
+	} else if (tokenSquareSetting == false) {
+		items.find("img").addClass("token-round");
+	} else if (globalSquareSetting == true) {
+		items.find("img").removeClass("token-round");
+	} else {
+		items.find("img").addClass("token-round");
+	}
+
+	let tokenBorderSetting = token["data-disableborder"];
+	let globalBorderSetting = window.TOKEN_SETTINGS["disableborder"];
+	if (tokenBorderSetting == true) {
+		items.find("img").css("border", "0px solid #000")
+	} else if (tokenBorderSetting == false) {
+		items.find("img").css("border", "4px solid #000")
+	} else if (globalBorderSetting == true) {
+		items.find("img").css("border", "0px solid #000")
+	} else {
+		items.find("img").css("border", "4px solid #000")
+	}
+
+	let tokenLegacyaspectratio = token["data-legacyaspectratio"];
+	let globalLegacyaspectratio = window.TOKEN_SETTINGS["legacyaspectratio"];
+	if (tokenLegacyaspectratio == true) {
+		items.find("img").removeClass("preserve-aspect-ratio");
+	} else if (tokenLegacyaspectratio == false) {
+		items.find("img").addClass("preserve-aspect-ratio");
+	} else if (globalLegacyaspectratio == true) {
+		items.find("img").removeClass("preserve-aspect-ratio");
+	} else {
+		items.find("img").addClass("preserve-aspect-ratio");
+	}
+
+	items.attr("data-token-size", token["data-token-size"]);
+}
+
+function random_image_for_token(path, name) {
+	let token = find_token_at_path(path, name);
+	if (token == undefined) {
+		console.warn(`failed to find a token with name ${name}, and path ${path}`);
+		return "";
+	}
+	let images = token['data-alternative-images'];
+	if (images == undefined || images.length == 0) {
+		images = [ token['data-img'] ];
+	}
+	let randomIndex = getRandomInt(0, images.length);
+	let randomImage = images[randomIndex];
+	return parse_img(randomImage);
+}
+
+function place_token_from_modal(path, name, hidden, specificImage, eventPageX, eventPageY) {
+	if (path === undefined) {
+		path = find_best_path(name);
+	}
+	let token = find_token_at_path(path, name);
+	if (token == undefined) {
+		console.warn(`failed to place a token with name ${name}, and path ${path}`);
+		return;
+	}
+
+	let options = {
+		name: name,
+		square: token['data-square'],
+		disableborder: token['data-disableborder'],
+		legacyaspectratio: token['data-legacyaspectratio'],
+		hidden: hidden,
+		tokendatapath: path,
+		tokendataname: name,
+		disablestat: true
+	};
+
+	if (specificImage == undefined) {
+		options.imgsrc = random_image_for_token(path, name);
+	} else {
+		options.imgsrc = specificImage;
+	}
+
+	// set reasonable defaults
+	if (options.square == undefined) {
+		options.square = window.TOKEN_SETTINGS["square"];
+		if (options.square == undefined) {
+			options.square = false;
+		}
+	}
+	if (options.disableborder == undefined) {
+		options.disableborder = window.TOKEN_SETTINGS["disableborder"];
+		if (options.disableborder == undefined) {
+			options.disableborder = false;
+		}
+	}
+	if (options.legacyaspectratio == undefined) {
+		options.legacyaspectratio = window.TOKEN_SETTINGS["legacyaspectratio"];
+		if (options.legacyaspectratio == undefined) {
+			options.legacyaspectratio = false;
+		}
+	}
+
+	let tokenSizeSetting = token['data-token-size'];
+	let tokenSize = parseInt(tokenSizeSetting);
+	if (tokenSizeSetting === undefined || typeof tokenSizeSetting !== 'number') {
+		tokenSize = 1;
+		// TODO: handle custom sizes
+	}
+	options.tokenSize = tokenSize;
+
+	if (eventPageX == undefined || eventPageY == undefined) {
+		place_token_in_center_of_map(options);
+	} else {
+		place_token_under_cursor(options, eventPageX, eventPageY);
+	}
+}
+
+function display_placed_token_customization_modal(placedToken) {
+	if (placedToken == undefined) {
+		console.warn("Attempted to call display_placed_token_customization_modal without a token");
+		return;
+	}
+
+	// close any that are already open. This shouldn't be necessary, but it doesn't hurt just in case
+	close_token_customization_modal();
+
+	let monsterId = placedToken.options.monster;
+	if (monsterId != undefined) {
+		window.StatHandler.getStat(monsterId, function(stat) {
+			display_monster_customization_modal(placedToken, monsterId, placedToken.options.name, stat.data.avatarUrl);
+		});
+		return;
+	}
+
+	let tokenDataPath = placedToken.options.tokendatapath;
+	let tokenDataName = placedToken.options.tokendataname !== undefined ? placedToken.options.tokendataname : placedToken.options.name;
+
+	if (tokenDataPath === undefined) {
+		let matchingPaths = find_token_paths(tokenDataName);
+		if (matchingPaths.length == 1) {
+			tokenDataPath = matchingPaths[0];
+		} else {
+			console.warn(`Failed to find a matching path for token with name ${tokenDataName}`);
+
+
+			// TODO: build token association feature here
+
+
+		}
+	}
+
+	let savedTokenData = find_token_at_path(tokenDataPath, tokenDataName);
+	if (savedTokenData !== undefined) {
+		if (savedTokenData['data-alternative-images'] === undefined) {
+			savedTokenData['data-alternative-images'] = [];
+		}
+	} else {
+		console.warn(`Failed to find a token with path ${tokenDataPath}`);
+	}
+
+	// build the modal header
+	let explanationText = "Click an image below to update your token or enter a new image URL at the bottom.";
+	if (savedTokenData === undefined) {
+		explanationText = "Enter a new image URL at the bottom.";
+	}
+	let modalHeader = build_token_modal_header(placedToken.options.name, explanationText);
+
+	// build the modal body
+	let modalBody = $(`<div class="token-image-modal-body"></div>`);
+	// add all of the tokens images to the body
+	redraw_images_in_modal_body(modalBody, tokenDataPath, tokenDataName, savedTokenData, placedToken);
+
+	// build the modal footer
+	const add_token_customization_image = function(imageUrl) {
+		if(imageUrl.startsWith("data:")){
+			alert("You cannot use urls starting with data:");
+			return;
+		}
+
+		if (savedTokenData === undefined) {
+			// this is an unassociated token. Blindly swap the url and close the modal
+			placedToken.options.imgsrc = parse_img(imageUrl);
+			close_token_customization_modal();
+			placedToken.place_sync_persist();
+		} else {
+			let tokenDataName = placedToken.options.tokendataname !== undefined ? placedToken.options.tokendataname : placedToken.options.name;
+			add_image_to_token_data(imageUrl, tokenDataPath, tokenDataName); // save the image
+			redraw_images_in_modal_body(modalBody, tokenDataPath, tokenDataName, savedTokenData, placedToken);
+		}
+	};
+	
+	let modalFooter = build_token_modal_footer("Enter a new image URL", add_token_customization_image);
+
+	// put it all together
+	let modal = build_modal_container();
+	let modalContent = modal.find(".token-image-modal-content");
+	modalContent.append(modalHeader);
+	modalContent.append(modalBody);
+	modalContent.append(modalFooter);
+
+
+	modalFooter.find(`.token-image-modal-add-button`).remove();
+	// allow them to use the new url for the placed token without saving the url for all future monsters
+	let onlyForThisTokenButton = $(`<button class="token-image-modal-add-button" style="margin:4px;" title="This url will be used for this token only. New tokens will continue to use the images shown above.">Set for this token only</button>`);
+	onlyForThisTokenButton.click(function(event) {
+		let imageUrl = $(`input[name='addCustomImage']`)[0].value;
+		if (imageUrl != undefined && imageUrl.length > 0) {
+			placedToken.options.imgsrc = parse_img(imageUrl);
+			close_token_customization_modal();
+			placedToken.place_sync_persist();
+		}
+	});
+	modalContent.append(onlyForThisTokenButton);	
+
+	if (savedTokenData !== undefined && !is_builtin(tokenDataPath)) {
+		// Only show the add for all button if the placed token has been associated with a saved token object. We can't save what we don't know about
+		let addForAllButton = $(`<button class="token-image-modal-add-button" style="margin:4px;" title="New tokens will use this new image. If you have more than one image, one will be chosen at random when you place a new token.">Add for all future tokens</button>`);
+		addForAllButton.click(function(event) {
+			let imageUrl = $(`input[name='addCustomImage']`)[0].value;
+			if (imageUrl != undefined && imageUrl.length > 0) {
+				add_image_to_token_data(imageUrl, tokenDataPath, placedToken.options.name);
+				display_placed_token_customization_modal(placedToken);	
+			}
+		});
+		modalContent.append(addForAllButton);
+	}
+	modalContent.append($(`<div class="token-image-modal-explanation" style="padding:4px;">You can access this modal from the Tokens tab by clicking the button on the right side of the token row.</div>`));
+
+	// display it
+	$("#VTTWRAPPER").append(modal);
+	update_modal_images(savedTokenData);
+}
+
+function redraw_images_in_modal_body(modalBody, path, name, tokenData, placedToken) {
+	if (tokenData === undefined) {
+		// Don't display any images if we haven't associated a saved token yet. 
+		// We don't want to give the impression that the user could interact with this image. 
+		// Once the placed token has been associated with a saved token, then this will work as expected.
+		return;
+	}
+
+	// clear it out before we fill it up
+	modalBody.empty();
+	
+	let tokenSize = tokenData['data-token-size'];
+	let dataImg = parse_img(tokenData['data-img']);
+
+	// clone our images array instead of using a reference so we don't accidentally change the currently images for all tokens
+	// we also need to parse and compare every image to know if we need to add the placedToken image
+	let images = [];
+	for (let i = 0; i < tokenData['data-alternative-images'].length; i++) {
+		let parsedImage = parse_img(tokenData['data-alternative-images'][i]);
+		images.push(parsedImage);
+	}
+	
+	if (dataImg !== undefined && !images.includes(dataImg)) {
+		// the main image somehow isn't in the list so put it at the front
+		images.unshift(dataImg);
+	}
+
+	if (placedToken !== undefined) {
+		if (placedToken.options.tokenSize !== undefined) {
+			tokenSize = placedToken.options.tokenSize;
+		}
+		if (placedToken.options.name !== undefined && placedToken.options.name != name) {
+			name = placedToken.options.name;
+		}
+		let placedImg = parse_img(placedToken.options.imgsrc);
+		if (placedImg !== undefined && !images.includes(placedImg)) {
+			// the placedToken image has been changed by the user so put it at the front
+			images.unshift(placedImg);
+		}
+	}
+	if (tokenSize === undefined) {
+		tokenSize = 1;
+	}
+
+	
+	for (let i = 0; i < images.length; i++) { 
+		let imageUrl = parse_img(images[i]);
+		let tokenDiv = build_custom_token_item(name, imageUrl, tokenSize, i);
+		if (placedToken !== undefined) {
+			// if they click this image, update the placedToken and close the modal
+			tokenDiv.click(function() {
+				placedToken.options.imgsrc = imageUrl;
+				close_token_customization_modal();
+				placedToken.place_sync_persist();
+			});
+			if (placedToken.options.tokendatapath !== undefined) {
+				tokenDiv.attr("tokendatapath", placedToken.options.tokendatapath);
+			} else {
+				tokenDiv.attr("data-tokendatapath", path);
+			}
+			if (placedToken.options.tokendataname !== undefined) {
+				tokenDiv.attr("data-tokendataname", placedToken.options.tokendataname);
+			} else {
+				tokenDiv.attr("data-tokendataname", name);	
+			}
+		} else {
+			tokenDiv.attr("data-tokendatapath", path);
+			tokenDiv.attr("data-tokendataname", name);
+		}
+		modalBody.append(tokenDiv);
+	}
+}
+
+function find_token_paths(name) {
+
+	let paths = [];
+
+	const checkFolder = function(folder, currentPath) {
+		if (folder == undefined) {
+			// that's as deep as we can go in this folder
+			return;
+		}
+		if (folder.tokens != undefined && folder.tokens[name] != undefined) {
+			// fond at the currentPath so let's add it to the list
+			paths.push(currentPath);
+		}
+		for(let folderName in folder.folders) {
+			// found nested folders, let's look in those as well
+			let folderObject = folder.folders[folderName];
+			checkFolder(folderObject, `${currentPath}/${folderName}`);
+		}
+	};
+
+	checkFolder(tokendata, "");
+
+	return paths;
+}
+
+function find_best_path(name) {
+	let matchingPaths = find_token_paths(name);
+	if (matchingPaths !== undefined && matchingPaths.length == 1) {
+		return matchingPaths[0];
+	} else {
+		console.warn(`find_best_path could not determine the best path for name: ${name}`);
+		return undefined;
+	}
+}
+
+function find_token_at_path(path, name) {
+	if (path === undefined) {
+		// This could be a token that was placed before this feature went live. try to recover if we can
+		path = find_best_path(name);
+		if (path === undefined) {
+			console.warn(`find_token_at_path was called with an invalid path: ${path}`);
+			return undefined;
+		}
+	}
+	if (name === undefined || name.length < 1) {
+		console.warn(`find_token_at_path was called with an invalid name: ${name}`);
+		return undefined;
+	}
+	let folder = convert_path(path);
+	if (folder === undefined) {
+		console.warn(`find_token_at_path could not find a folder at path ${path}`);
+		return undefined;
+	}
+	if (folder.tokens === undefined) {
+		console.warn(`find_token_at_path could not find any tokens at path ${path}`);
+		return undefined;
+	}
+	let token = folder.tokens[name];
+	if (token === undefined) {
+		console.warn(`find_token_at_path could not find a token with the name ${name} at path ${path}`);
+	}
+	return token;
+}
+
+function save_token_data(tokenData, path, name) {
+	let folder = convert_path(path);
+	if (folder === undefined) {
+		console.warn(`failed to save token data at invalid path ${path}`);
+		return;
+	}
+	if (folder.tokens === undefined) {
+		folder.tokens = {};
+	}
+	folder.tokens[name] = tokenData;
+	persist_customtokens();
+}
+
+function add_image_to_token_data(imageUrl, path, name) {
+	if (imageUrl === undefined || imageUrl.length == 0) {
+		return;
+	}
+	if (path === undefined) {
+		path = find_best_path(name);
+		if (path === undefined) {
+			console.warn(`failed to find token with name ${name} at path ${path}`);
+			return;
+		}
+	}
+	let token = find_token_at_path(path, name);
+	if (token === undefined) {
+		console.warn(`failed to find token with name ${name} at path ${path}`);
+		return;
+	}
+	migrate_token_image_data(token);
+	token['data-alternative-images'].push(parse_img(imageUrl));
+	save_token_data(token, path, name);
+}
+
+function remove_image_from_token_data(path, name, index) {
+	if (path == undefined) {
+		path = find_best_path(name);
+		if (path == undefined) {
+			console.warn(`failed to find token with name ${name} at path ${path}`);
+			return;
+		}
+	}
+	let token = find_token_at_path(path, name);
+	if (token == undefined) {
+		console.warn(`failed to find token with name ${name} at path ${path}`);
+		return;
+	}
+	let customImages = token['data-alternative-images'];
+	if (customImages == undefined) {
+		// user is removing the only image
+		token['data-img'] = "";
+	} else if (customImages.length > index) {
+		let imageBeingRemoved = customImages[index];
+		customImages.splice(index, 1);
+		token['data-alternative-images'] = customImages;
+		if (imageBeingRemoved == token['data-img']) {
+			// the user removed the first image. Try to replace it with whatever is first now
+			token['data-img'] = customImages.length > 0 ? customImages[0] : "";
+		}
+	}
+	save_token_data(token, path, name);
+}
+
+function migrate_token_image_data(token) {
+	if (token === undefined) {
+		console.warn("migrate_token_image_data called without a token");
+		return;
+	}
+
+	let dataImg = parse_img(token['data-img']);
+	if (dataImg === undefined) {
+		// nothing to migrate
+		return;
+	}
+
+	if (token['data-alternative-images'] === undefined) {
+		// it's not set at all so we can just set it to the data-img value
+		token['data-alternative-images'] = [ dataImg ];
+	} else {
+		// let's parse all our urls and make sure they resolve properly before comparing them
+		let images = [];
+		for (let i = 0; i < token['data-alternative-images'].length; i++) {
+			let parsedImage = parse_img(token['data-alternative-images'][i]);
+			images.push(parsedImage);
+		}
+		if (!images.includes(dataImg)) {
+			images.unshift(dataImg);
+		}
+		token['data-alternative-images'] = images;
+	}
+}
+
+function delete_folder(path) {
+	if (path === undefined || path == "" || is_builtin(path)) {
+		console.log(`delete_folder called with ${path}`);
+		return;
+	}
+	let parts = path.split("/");
+	let folderName = parts.pop();
+	let leadingPath = parts.join("/");
+	let containingFolder = convert_path(leadingPath);
+	delete containingFolder[folderName];
+}
+
+function containing_folder_path(path) {
+	if (path === undefined || path.length == 0) {
+		return "";
+	}
+	return path.substring(0, path.lastIndexOf("/"));
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -941,9 +941,16 @@ div#scene_properties form > div {
 
 .tokenmenuitem {
 	float: left;
-	height:100px;
-	width: 100px;
+	width: 33%;
     margin-bottom: 20px;
+    position: relative;
+}
+.tokenmenuitem img {
+    position: absolute;
+    top:      0;
+    left:     0;
+    bottom:   0;
+    right:    0;
 }
 
 .panel-warning {
@@ -1264,13 +1271,11 @@ body {
 .token-image-modal {
     position: fixed;
     z-index: 99999;
-    /* display: flex; */
     align-items: center;
     justify-content: center;
     padding: 10px;
     overflow-y: auto;
     background-color: rgb(235, 241, 245);
-    /* background-color: rgba(0,0,0,.5); */
 }
 .token-image-modal-overlay {
     position: absolute;
@@ -1310,12 +1315,10 @@ body {
 .token-image-modal-body {
     position: relative; 
     width:100%; 
-    /* max-height: 90%; */
     overflow-y: auto;
     flex: auto;
 }
 .token-image-modal-footer {
-    height: 52px;
     border-top: 1px solid #d8e1e8;
     display: flex;
     align-items: center;
@@ -1330,6 +1333,31 @@ body {
     color: #738694;
     font-size: 13px;
     line-height: 1.4;
+    margin-top: 6px;
+}
+.token-image-modal-footer input {
+    margin-bottom: 6px;
+    width: auto;
+}
+.token-image-modal-footer-select-wrapper {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 6px;
+}
+.token-image-modal-footer-select-wrapper select {
+    min-width: 30%;
+}
+.token-image-modal-footer-input-wrapper {
+    width: 100%;
+}
+.token-image-modal-url-label-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+.token-image-modal-url-label-add-wrapper {
+    display: flex;
+    flex-direction: row;
 }
 .token-image-modal-remove-all-button {
     appearance: none;
@@ -1363,8 +1391,187 @@ body {
 }
 .custom-token-image-item {
     float: left; 
-    width:30%;
+    width: 33%;
+    position: relative;
 }
 .custom-token-image-item.ui-draggable-dragging {
     width: auto;
+}
+.custom-token-image-item img {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: inline-block;
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
+}
+.token-image-sizing-dummy {
+    /* this allows us to size the img using a 1:1 aspect ratio without having to use js to calculate the height after the felx width has been determined */
+    margin-top: 100%;
+}
+
+.custom-token-list {
+    display: flex;
+    align-items: center;
+    padding: 0px 6px 0px 6px;
+    flex-direction: column;
+    background: rgb(235, 241, 245);
+    height: 100%;
+}
+.custom-token-image-row {
+    padding: 4px;
+    width: 100%;
+    margin: 2px 0px 2px 0px;
+    border: 1px solid #d8e1e8;
+    border-radius: 3px;
+    background-color: #fff;
+}
+.custom-token-image-row-item {
+    display: flex;
+    width: 100%;
+}
+.custom-token-image-row-img {
+    display: flex;
+    flex-basis: 38px;
+    width: 38px;
+    max-width: 38px;
+    height: 38px;
+    max-height: 38px;
+    border-radius: 3px;
+    object-fit: cover;
+    margin-left: 4px;
+}
+.custom-token-image-row-img img {
+    object-fit: contain;
+    width: 38px;
+    max-width: 38px;
+    height: 38px;
+    max-height: 38px;
+}
+.custom-token-image-row-details {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    color: #10161a;
+    flex-grow: 1;
+    margin-left: 4px;
+    margin-right: 4px;
+    line-height: 1.4;
+    font-family: Roboto, "Open Sans", Helvetica, sans-serif;
+    text-align: center;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+.custom-token-image-row-details div {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    justify-content: center;
+}
+.custom-token-image-row-details-title {
+    font-size: 13px;
+    font-weight: 700;
+}
+.custom-token-image-row-details-subtitle {
+    color: #738694;
+    font-size: 10px;
+}
+.custom-token-image-row-add {
+    margin-left: auto;
+    display: flex;
+    flex-basis: 38px;
+    width: 38px;
+    max-width: 38px;
+    height: 38px;
+    max-height: 38px;
+    border-radius: 3px;
+    object-fit: cover;
+    background: #fff;
+    border: 1px solid #d8e1e8;
+    cursor: pointer;
+}
+.custom-token-image-row-add svg {
+    width: 100%;
+    height: 100%;
+    fill: #1b9af0;
+}
+.custom-token-image-row-handle {
+    background-color: #d8e1e8;
+    display: flex;
+    width: 38px;
+    max-width: 38px;
+    object-fit: cover;
+    padding: 13px;
+    border-top-right-radius: 3px;
+    border-bottom-right-radius: 3px;
+    background-color: #f2f6f8;
+    align-self: stretch;
+    border-left: 1px solid #d8e1e8;
+    margin: -4px -4px -4px 8px;
+    cursor: pointer;
+}
+.custom-token-image-row-handle svg {
+    width: 100%;
+    height: 100%;
+    fill: #738694;
+}
+
+#tokens-panel {
+    align-items: center;
+    justify-content: center;
+    overflow-y: auto;
+    background-color: rgb(235, 241, 245);
+    height: 100%;
+}
+#tokens-panel .token-image-modal-content {
+    height: 100%;
+}
+#tokens-panel-data {
+    background-color: rgb(235, 241, 245);
+    position: relative; 
+    width:100%; 
+    overflow-y: auto;
+    flex: auto;
+}
+.tokens-panel-back-button {
+    background-image: url(https://media-waterdeep.cursecdn.com/file-attachments/0/737/chevron-left-green.svg);
+    background-repeat: no-repeat;
+    background-position: left;
+    padding: 4px;
+    cursor: pointer;
+}
+.tokens-panel-back-button div {
+    padding-left: 20px;
+    color: #878787;
+    text-transform: uppercase;
+    font-family: "Roboto Condensed", Roboto, Helvetica, sans-serif;
+    font-weight: bold;
+}
+#tokens-panel-header {
+    background-color: rgb(235, 241, 245);
+    padding: 8px;
+}
+#tokens-panel-footer {
+    display: flex;
+    padding: 8px;
+    background-color: rgb(235, 241, 245);
+}
+#tokens-panel-footer button {
+    appearance: none;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    background: #1b9af0;
+    border: none;
+    color: #fff;
+    align-self: stretch;
+    margin: 0px 4px 0px 4px;
+    padding: 10px;
+    flex-grow: 1;
+    text-align: center;
 }


### PR DESCRIPTION
# Features

## UI
* Complete rebuild of the tokens pane to mimic the monsters pane UI
<img height="500" alt="Screen Shot 2021-12-02 at 7 08 05 AM" src="https://user-images.githubusercontent.com/584771/144428323-6499fe92-90fe-469b-8bf0-fbba99c1cf80.png">

## CRUD
* Custom tokens can now be edited
* Custom tokens now support a specified size
* Custom tokens now support multiple images just like monsters do
![avtt-custom-token-create](https://user-images.githubusercontent.com/584771/144439957-84e6c896-513b-40b5-b36d-f77d04a5241d.gif)


## Tokens Pane UX
* Placing a custom token that has multiple images will choose one of the images at random
* Custom tokens can be drag and dropped from the list to the map
* Custom token images can be drag and dropped from the customization modal to the map
* Custom tokens and their images both have context menus for edit, delete, and placing options
* Folders can be renamed
![avtt-custom-token-placement](https://user-images.githubusercontent.com/584771/144438576-3ed0cd6e-25ef-4628-80cf-5738eee38ba9.gif)
![avtt-custom-token-contextmenu](https://user-images.githubusercontent.com/584771/144443643-95cb8576-6948-49fc-9027-df89e1a5f7fd.gif)



## Placed Tokens UX
* The context menu for a placed token have a "Change Image" option instead of an inline url input. This opens a simplified token customization modal.
* The simplified customization modal allows adding a url for just the placed token as well as adding to the custom token as a whole.
![avtt-custom-placed-token-image-change](https://user-images.githubusercontent.com/584771/144447224-89e45a41-f8ba-4ed9-bed7-b14247255e27.gif)


## Built-In Tokens
* Built in tokens cannot be edited so UI to do so is removed
* Built in tokens use multiple images instead of being separate tokens
![avtt-builtin-tokens-mulit-image](https://user-images.githubusercontent.com/584771/144453438-e82b4464-ae69-4aef-a820-8d855077bf8c.gif)


# File changes explained

**KeypressHandler.js**
* bugfix: shift + arrow keys didn't persist to other players

**MonsterPanel.js**
* refactor how monster token modals are built to allow for reusability with the new custom token modals
* change how tokens are placed. stop using `token_button` function and new functions that don't rely on hijacking `event.target`

**Token.js**
* create new token placing functions `place_token_in_center_of_map` and `place_token_under_cursor` to simplify token placing
* present new token customization modal for custom tokens that have been placed on the map

**TokenMenu.js**
* update builtin tokens to use multiple images instead of being separate tokens
* completely rebuild the tokens pane while maintaining backwards compatibility

**abovevtt.css**
* added styling for token customization modals. 
* some refactoring for reusability
