### PR TITLE
Add player token customization

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1512,6 +1512,7 @@ function init_ui() {
 
 	token_menu();
 	load_custom_monster_image_mapping();
+	register_player_token_customization_context_menu();
 
 
 	window.WaypointManager=new WaypointManagerClass();

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -160,10 +160,15 @@ function register_custom_monster_image_context_menu() {
 			remove: { 
 				name: "Remove",
 				callback: function(itemKey, opt, originalEvent) {
+					let selectedItem = $(opt.$trigger[0]);
+					let imgIndex = parseInt(selectedItem.attr("data-custom-img-index"));
+					if (imgIndex < 0) {
+						alert("This token is only set on the current token. Click a different image to change the token image.");
+						return;
+					}
 					if (window.confirm("Are you sure you want to remove this custom image?")) {
-						let selectedItem = $(opt.$trigger[0]);
-						let imgIndex = parseInt(selectedItem.attr("data-custom-img-index"));
 						let monsterId = selectedItem.attr("data-monster");
+						let playerId = selectedItem.attr("data-player-id");
 						let name = selectedItem.attr("data-name");
 						if (monsterId != undefined) {
 							// removing from the monsters pane
@@ -173,6 +178,11 @@ function register_custom_monster_image_context_menu() {
 								// the user removed the last custom image. redraw the modal so the default image shows up
 								display_monster_customization_modal();
 							}
+						} else if (playerId !== undefined) {
+							// removing from the players pane
+							remove_player_image_mapping(playerId, imgIndex);
+							selectedItem.remove();
+							display_player_token_customization_modal(playerId);
 						} else if (name != undefined) {
 							// removing from the tokens pane
 							let tokenDataPath = selectedItem.attr("data-tokendatapath");
@@ -220,7 +230,7 @@ function display_monster_customization_modal(placedToken, monsterId, monsterName
 
 	// build the modal header
 	let explanationText = "When placing tokens, one of these images will be chosen at random. Right-click an image for more options.";
-	if (placedToken != undefined) {
+	if (placedToken !== undefined) {
 		// the user is updating a token that has already been placed. Add some explanation text to help them figure out how to use this in case it's their first time here.
 		explanationText = "Click an image below to update your token or enter a new image URL at the bottom.";
 	}
@@ -487,12 +497,16 @@ function build_custom_token_item(name, imageUrl, tokenSize, customImgIndex, plac
 function place_custom_token_at_point(htmlElement, hidden, eventPageX, eventPageY) {
 
 	let monsterId = htmlElement.attr("data-monster");
+	let playerId = htmlElement.attr("data-player-id");
 	let name = htmlElement.attr("data-name");
 	let tokenSize = htmlElement.attr("data-token-size");
 	let imgSrc = htmlElement.find("img").attr("src");
 	if (monsterId !== undefined) {
 		// placing from the monster pane
 		place_monster_at_point(htmlElement, monsterId, name, imgSrc, tokenSize, hidden, eventPageX, eventPageY);
+	} else if (playerId !== undefined) {
+		// placing from the players pane
+		place_player_token(playerId, hidden, imgSrc, eventPageX, eventPageY);
 	} else if (name !== undefined) {
 		// placing from the tokens pane
 		let tokenDataPath = htmlElement.attr("data-tokendatapath");

--- a/Token.js
+++ b/Token.js
@@ -1491,9 +1491,11 @@ function menu_callback(key, options, event) {
 			return;
 		}
 		let tok = window.TOKEN_OBJECTS[id];
-		let monsterId = $(options.$trigger).data("monster");
+		let monsterId = $(options.$trigger).attr("data-monster");
 		let name = $(options.$trigger).data("name");
-		if (monsterId != undefined) {
+		if (tok.isPlayer()) {
+			display_player_token_customization_modal(id, tok);
+		} else if (monsterId !== undefined) {
 			window.StatHandler.getStat(monsterId, function(stat) {
 				display_monster_customization_modal(tok, monsterId, name, stat.data.avatarUrl);
 			});
@@ -2014,16 +2016,6 @@ function token_menu() {
 								}
 							}
 						},
-						imgsrc: {
-							type: 'text',
-							name: 'Custom Image',
-							value: window.TOKEN_OBJECTS[id].options.imgsrc,
-							events: {
-								click: function(e) {
-									$(e.target).select();
-								}
-							}
-						},
 						sep3: '----------',
 						imgsrcSelect: {
 							name: "Change Image",
@@ -2041,7 +2033,6 @@ function token_menu() {
 				if (is_monster) {
 					delete ret.items.options.items.token_hidestat;
 					delete ret.items.helptext;
-					delete ret.items.imgsrc;
 				}
 				else {
 					delete ret.items.sep1;
@@ -2049,14 +2040,6 @@ function token_menu() {
 					delete ret.items.max_hp;
 					delete ret.items.token_cond;
 					delete ret.items.options.items.token_revealname;
-					if (window.TOKEN_OBJECTS[id].isPlayer()) {
-						// players don't use the new modal yet
-						delete ret.items.sep3;
-						delete ret.items.imgsrcSelect;
-					} else {
-						// custom tokens use the new modal now
-						delete ret.items.imgsrc;
-					}
 					delete ret.items.ac;
 				}
 				
@@ -2079,9 +2062,11 @@ function token_menu() {
 					delete ret.items.note_menu;
 					delete ret.items.name;
 					delete ret.items.sep2;
-					delete ret.items.sep3;
-					delete ret.items.imgsrcSelect;
 					delete ret.items.ac;
+					if (!id.endsWith(window.PLAYER_ID)) {
+						delete ret.items.sep3;
+						delete ret.items.imgsrcSelect;
+					}
 				}
 
 				return ret;
@@ -2219,7 +2204,7 @@ function load_custom_monster_image_mapping() {
 function save_custom_monster_image_mapping() {
 	let customMappingData = JSON.stringify(window.CUSTOM_TOKEN_IMAGE_MAP);
 	localStorage.setItem("CustomDefaultTokenMapping", customMappingData);
-	// The JSON structure for CUSTOM_TOKEN_IMAGE_MAP looks like this { "17100": [ "some.url.com/img1.png", "some.url.com/img2.png" ] }	
+	// The JSON structure for CUSTOM_TOKEN_IMAGE_MAP looks like this { 17100: [ "some.url.com/img1.png", "some.url.com/img2.png" ] }	
 }
 
 function copy_to_clipboard(text) {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1233,12 +1233,12 @@ function update_modal_images(token) {
 
 function random_image_for_token(path, name) {
 	let token = find_token_at_path(path, name);
-	if (token == undefined) {
+	if (token === undefined) {
 		console.warn(`failed to find a token with name ${name}, and path ${path}`);
 		return "";
 	}
 	let images = token['data-alternative-images'];
-	if (images == undefined || images.length == 0) {
+	if (images === undefined || images.length == 0) {
 		images = [ token['data-img'] ];
 	}
 	let randomIndex = getRandomInt(0, images.length);
@@ -1251,7 +1251,7 @@ function place_token_from_modal(path, name, hidden, specificImage, eventPageX, e
 		path = find_best_path(name);
 	}
 	let token = find_token_at_path(path, name);
-	if (token == undefined) {
+	if (token === undefined) {
 		console.warn(`failed to place a token with name ${name}, and path ${path}`);
 		return;
 	}
@@ -1267,26 +1267,26 @@ function place_token_from_modal(path, name, hidden, specificImage, eventPageX, e
 		disablestat: true
 	};
 
-	if (specificImage == undefined) {
+	if (specificImage === undefined) {
 		options.imgsrc = random_image_for_token(path, name);
 	} else {
 		options.imgsrc = specificImage;
 	}
 
 	// set reasonable defaults
-	if (options.square == undefined) {
+	if (options.square === undefined) {
 		options.square = window.TOKEN_SETTINGS["square"];
 		if (options.square == undefined) {
 			options.square = false;
 		}
 	}
-	if (options.disableborder == undefined) {
+	if (options.disableborder === undefined) {
 		options.disableborder = window.TOKEN_SETTINGS["disableborder"];
 		if (options.disableborder == undefined) {
 			options.disableborder = false;
 		}
 	}
-	if (options.legacyaspectratio == undefined) {
+	if (options.legacyaspectratio === undefined) {
 		options.legacyaspectratio = window.TOKEN_SETTINGS["legacyaspectratio"];
 		if (options.legacyaspectratio == undefined) {
 			options.legacyaspectratio = false;
@@ -1301,7 +1301,7 @@ function place_token_from_modal(path, name, hidden, specificImage, eventPageX, e
 	}
 	options.tokenSize = tokenSize;
 
-	if (eventPageX == undefined || eventPageY == undefined) {
+	if (eventPageX === undefined || eventPageY === undefined) {
 		place_token_in_center_of_map(options);
 	} else {
 		place_token_under_cursor(options, eventPageX, eventPageY);
@@ -1446,9 +1446,11 @@ function redraw_images_in_modal_body(modalBody, path, name, tokenData, placedTok
 		images.push(parsedImage);
 	}
 	
+	let indexOffset = 0;
 	if (dataImg !== undefined && !images.includes(dataImg)) {
 		// the main image somehow isn't in the list so put it at the front
 		images.unshift(dataImg);
+		indexOffset++;
 	}
 
 	if (placedToken !== undefined) {
@@ -1462,6 +1464,7 @@ function redraw_images_in_modal_body(modalBody, path, name, tokenData, placedTok
 		if (placedImg !== undefined && !images.includes(placedImg)) {
 			// the placedToken image has been changed by the user so put it at the front
 			images.unshift(placedImg);
+			indexOffset++;
 		}
 	}
 	if (tokenSize === undefined) {
@@ -1471,7 +1474,7 @@ function redraw_images_in_modal_body(modalBody, path, name, tokenData, placedTok
 	
 	for (let i = 0; i < images.length; i++) { 
 		let imageUrl = parse_img(images[i]);
-		let tokenDiv = build_custom_token_item(name, imageUrl, tokenSize, i);
+		let tokenDiv = build_custom_token_item(name, imageUrl, tokenSize, i - indexOffset);
 		if (placedToken !== undefined) {
 			// if they click this image, update the placedToken and close the modal
 			tokenDiv.click(function() {


### PR DESCRIPTION
## Trello Card

https://trello.com/c/XCPdCfm2

## Features

This adds custom token images for player tokens. Player tokens can be customized by right-clicking the token image in the Players pane. 

### Players Pane Updates

**Token Context Menu**
If the player token has not been placed, the context menu has four options: "Place Token", "Place Hidden token", "Copy Url", and "Customize". Once a token has been placed, the place token options are replaced with "Locate Placed Token".

**Drag and Drop Token Placement**
Player tokens can now be placed on a scene, by dragging the player token image onto a scene and dropping it where you want it placed. If a token has already been placed on a scene, the token will not be placed, but instead will highlight the already placed token.

![avtt-player-token-context-menu](https://user-images.githubusercontent.com/584771/144935662-b375ec9e-bfb5-4277-afca-c4a5b4ea7938.gif)


### Player Token Customization Modal
Just like the monsters modal, player tokens now support multiple images. Right-click the token in the players pane, and select "Customize" will open the customization modal. 

**Image list**
If there are no images, the modal displays the character portrait, and has a form at the bottom to replace the current image.

**Defaulting back to the portrait**
If there are one or more custom images, the form also includes a "Remove All Custom Images" button which will reset back to using the character portrait.

**Drag and Drop**
Each custom image can be drag and dropped onto the scene as long as there isn't already a player token in the scene. If there is, the already placed token will be highlighted.

![avtt-player-token-customize](https://user-images.githubusercontent.com/584771/144935692-0e524265-5ba4-4be5-9b67-ed59fab9b4f2.gif)


### Changing the image of an already placed token

Right-clicking a placed token provides an option to "Change Image" which will open the customization modal. This modal acts exactly like the modal accessed via the Players Pane with one notable exception.

**Set For This Token Only**
At the bottom of the modal is a new button titled "Set For This Token Only" which allows the image to be set on the token without saving it for future use.

![avtt-player-token-placed-image-change](https://user-images.githubusercontent.com/584771/144935724-066d9de8-101a-4808-aa82-531e93295a84.gif)


