### PR TITLE
always queue token animations, and speed them up instead of interrupting them

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -524,14 +524,15 @@ class Token {
 				
 				remove_selected_token_bounding_box();
 				if(old.is(':animated')){
-					this.stopAnimation();
+					// this token is being moved quickly, speed up the animation
+					animationDuration = 100;
 				}
 				
 				old.animate(
 					{
 						left: this.options.left,
 						top: this.options.top,
-					}, { duration: animationDuration, queue: false, complete: function() {
+					}, { duration: animationDuration, queue: true, complete: function() {
 						draw_selected_token_bounding_box();
 					} });
 				


### PR DESCRIPTION
## Discussion
`update_from_page` still stops animations which prevents other issues. This _should_ just change the way that multiple consecutive animations are handled. The biggest thing this improves is token movement when using arrow keys. Before this change, the token animation would get cancelled, and the token would jump around in an ugly way. Now the animations are queued and sped up which provides a smoother experience.

## Demo
![avtt-queued-movement-animations](https://user-images.githubusercontent.com/584771/145428574-55ca44c0-b7fd-42f8-9a47-97164697106e.gif)

