### PR TITLE
Add alert message indicating players/DM aren't running latest version

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1,3 +1,4 @@
+var abovevtt_version = '0.64';
 
 function parse_img(url){
 	if (url === undefined) {
@@ -477,7 +478,7 @@ function init_splash() {
 	cont = $("<div id='splash'></div>");
 	cont.css('background', "url('/content/1-0-1487-0/skins/waterdeep/images/mon-summary/paper-texture.png')");
 
-	cont.append("<h1 style='padding-bottom:2px;margin-bottom:2px; text-align:center'><img width='250px' src='" + window.EXTENSION_PATH + "assets/logo.png'><div style='margin-left:20px; display:inline;vertical-align:bottom;'>0.64</div></h1>");
+	cont.append("<h1 style='padding-bottom:2px;margin-bottom:2px; text-align:center'><img width='250px' src='" + window.EXTENSION_PATH + "assets/logo.png'><div style='margin-left:20px; display:inline;vertical-align:bottom;'>"+abovevtt_version+"</div></h1>");
 	cont.append("<div style='font-style: italic;padding-left:80px;font-size:20px;margin-bottom:10px;margin-top:2px; margin-left:50px;'>Fine.. We'll do it ourselves..</div>");
 
 	s=$("<div/>");
@@ -1142,6 +1143,37 @@ function close_player_sheet(sheet_url, hide_container = true)
 	}
 }
 
+function notify_player_join() {
+	var playerdata = {
+		abovevtt_version: abovevtt_version,
+		player_id: window.PLAYER_ID
+	};
+
+	console.log("Sending playerjoin msg, abovevtt version: " + playerdata.abovevtt_version + ", sheet ID:" + window.PLAYER_ID);
+	window.MB.sendMessage("custom/myVTT/playerjoin", playerdata);
+}
+
+function check_versions_match() {
+	var latestVersionSeen = 0.0;
+	var oldestVersionSeen = 1000.0;
+	
+	$.each(window.CONNECTED_PLAYERS, function(key, value) {
+		latestVersionSeen = Math.max(latestVersionSeen, value);
+		oldestVersionSeen = Math.min(oldestVersionSeen, value);
+	});
+
+	if (latestVersionSeen != oldestVersionSeen) {
+		var alertMsg = 'Not all players connected to your session have the same AboveVTT version (highest seen v' + latestVersionSeen + ', lowest seen v' + oldestVersionSeen + ').\nFor best experience, it is recommended all connected players and the DM run the latest AboveVTT version.\n\n';		
+		for (const [key, value] of Object.entries(window.CONNECTED_PLAYERS)) {
+			alertMsg += (key == 0 ? "The DM" : "Player DDB character ID " + key) + " is running AboveVTT v" + value + "\n";
+		}
+
+		alert(alertMsg);
+	}
+
+	return latestVersionSeen;
+}
+
 function init_ui() {
 	window.STARTING = true;
 	var gameid = $("#message-broker-client").attr("data-gameId");
@@ -1152,6 +1184,7 @@ function init_ui() {
 	window.MONSTERPANEL_LOADED = false;
 	window.BLOCKCONTROLS = false;
 	window.PLAYER_STATS = {};
+	window.CONNECTED_PLAYERS = {};
 	window.TOKEN_SETTINGS = $.parseJSON(localStorage.getItem('TokenSettings' + gameid)) || {};
 	window.CURRENTLY_SELECTED_TOKENS = [];
 	window.TOKEN_PASTE_BUFFER = [];
@@ -1171,6 +1204,7 @@ function init_ui() {
 
 
 	if (DM) {
+		window.CONNECTED_PLAYERS['0'] = abovevtt_version; // ID==0 is DM
 		window.ScenesHandler = new ScenesHandler(gameid);
 		init_scene_selector();
 	}
@@ -1447,7 +1481,7 @@ function init_ui() {
 	if (!DM) {
 		setTimeout(function() {
 			window.MB.sendMessage("custom/myVTT/syncmeup");
-			window.MB.sendMessage("custom/myVTT/playerjoin");
+			notify_player_join();
 		}, 5000);
 	}
 
@@ -1462,7 +1496,7 @@ function init_ui() {
 	{
 		setTimeout(function() {
 			window.MB.sendMessage("custom/myVTT/syncmeup");
-			window.MB.sendMessage("custom/myVTT/playerjoin");
+			notify_player_join();
 			init_player_sheet(window.PLAYER_SHEET);
 			report_connection();
 			//open_player_sheet(window.PLAYER_SHEET, false);


### PR DESCRIPTION
1. On 'playerjoin' message, players will now send their AboveVTT version as well
   and character ID.
2. The DM will save all of these, and alert in case it detects some players
   are running a version older than the newest one seen yet (message broker
   doesn't send us the latest available version, so we can't use that).

Backwards compatibility is handled by popping up a message saying
a player connected with an older version than 0.64 (as 0.65 will include
this change) and avoid popping up messages too fast (interval 3 seconds).

In addition, we don't re-pop alert message if the same player reconnected
without any change to its AboveVTT version.