### PR TITLE
add SidebarPanel.js and refactor tokens pane and all modals to use it

### DIFF
--- a/Load.js
+++ b/Load.js
@@ -4,7 +4,7 @@ l.setAttribute("id", "extensionpath");
 l.setAttribute("data-path", chrome.runtime.getURL("/"));
 (document.body || document.documentElement).appendChild(l);
 
-["DnDBeyond/DDBCharacterData.js","jquery.magnific-popup.min.js","purify.min.js","Journal.js","Settings.js","SoundPad.js","color-picker.js","AOETemplates.js","SceneData.js", "jquery.ui.touch-punch.js", "CombatTracker.js", "StatHandler.js", "rpg-dice-roller.bundle.min.js", "MonsterDice.js", "Fog.js", "TokenMenu.js", "jquery.contextMenu.js", "PlayerPanel.js", "Token.js", "Jitsi.js", "jitsi_external_api.js","MessageBroker.js", "ScenesHandler.js", "MonsterPanel.js", "ScenesPanel.js", "Main.js", "mousetrap.1.6.5.min.js", "KeypressHandler.js"].forEach(function(value, index, array) {
+["DnDBeyond/DDBCharacterData.js","jquery.magnific-popup.min.js","purify.min.js","SidebarPanel.js","Journal.js","Settings.js","SoundPad.js","color-picker.js","AOETemplates.js","SceneData.js", "jquery.ui.touch-punch.js", "CombatTracker.js", "StatHandler.js", "rpg-dice-roller.bundle.min.js", "MonsterDice.js", "Fog.js", "TokenMenu.js", "jquery.contextMenu.js", "PlayerPanel.js", "Token.js", "Jitsi.js", "jitsi_external_api.js","MessageBroker.js", "ScenesHandler.js", "MonsterPanel.js", "ScenesPanel.js", "Main.js", "mousetrap.1.6.5.min.js", "KeypressHandler.js"].forEach(function(value, index, array) {
 	var s = document.createElement('script');
 
 	s.src = chrome.runtime.getURL(value);

--- a/Main.js
+++ b/Main.js
@@ -234,6 +234,8 @@ function switch_control(e) {
 	if (window.BLOCKCONTROLS)
 		return;
 	$(".sidepanel-content").hide();
+	$(".sidebar-panel-content").hide();
+	close_sidebar_modal();
 	$($(e.currentTarget).attr("data-target")).show();
 
 
@@ -355,6 +357,8 @@ function load_monster_stat(monsterid) {
 
 
 function init_controls() {
+	init_sidebar_tabs();
+
 	$(".sidebar").css("top", "10px");
 	$(".sidebar").css("height", "calc(100vh - 45px)");
 
@@ -1571,10 +1575,10 @@ function init_ui() {
 		if (event.target.tagName.toLowerCase() !== 'a') {
 			$("#splash").remove(); // don't remove the splash screen if clicking an anchor tag otherwise the browser won't follow the link
 		}
-		if (token_customization_modal_is_open() && event.which == 1) {
-			// if the click was outside the customization modal, close the modal, but allow right clicking because contextMenu events are outside the modal
-			if (event.target.closest(".token-image-modal") == undefined) {
-				close_token_customization_modal();
+		if (sidebar_modal_is_open() && event.which == 1) {
+			let modal = event.target.closest(".sidebar-modal");
+			if (modal === undefined || modal == null) {
+				close_sidebar_modal();
 			}
 		}
 	}

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -207,24 +207,18 @@ function register_custom_monster_image_context_menu() {
 	});
 }
 
-function token_customization_modal_is_open() {
-	return $("#VTTWRAPPER .token-image-modal").length > 0;
-}
-
-function close_token_customization_modal() {
-	$("#VTTWRAPPER .token-image-modal").remove();
-}
-
-
 function display_monster_customization_modal(placedToken, monsterId, monsterName, defaultImg) {
 
 	// close any that are already open. This shouldn't be necessary, but it doesn't hurt just in case
-	close_token_customization_modal();
+	close_sidebar_modal();
 	
 	if (monsterId == undefined || monsterName == undefined || defaultImg == undefined) {
 		console.warn(`Failed to display monster customization modal; monsterId = ${monsterId}, monsterName = ${monsterName}, defaultImg = ${defaultImg}`)
 		return
 	}
+
+	let sidebarPanel = new SidebarPanel("monster-token-customization-modal");
+	display_sidebar_modal(sidebarPanel);
 
 	let customImages = get_custom_monster_images(monsterId);
 
@@ -234,7 +228,7 @@ function display_monster_customization_modal(placedToken, monsterId, monsterName
 		// the user is updating a token that has already been placed. Add some explanation text to help them figure out how to use this in case it's their first time here.
 		explanationText = "Click an image below to update your token or enter a new image URL at the bottom.";
 	}
-	let modalHeader = build_token_modal_header(monsterName, explanationText);
+	sidebarPanel.updateHeader(monsterName, "Token Images", explanationText)
 
 	const determineLabelText = function() {
 		if (placedToken != undefined) {
@@ -246,32 +240,7 @@ function display_monster_customization_modal(placedToken, monsterId, monsterName
 		}
 	}
 
-	// build the modal body
-	let modalBody = $(`<div class="token-image-modal-body"></div>`);
-	let removeAllButton = $(`<button class="token-image-modal-remove-all-button" data-monster-id="${monsterId}" title="Reset this monster back to the default image.">Remove All Custom Images</button><`);
-	removeAllButton.click(function(event) {
-		let monsterId = $(event.target).attr("data-monster-id");
-		if (window.confirm(`Are you sure you want to remove all custom images for ${monsterName}?\nThis will reset the monster images back to the default`)) {
-			remove_all_custom_monster_images(monsterId);
-			display_monster_customization_modal(placedToken);
-			footerLabel.text(determineLabelText());
-		}
-	})
-
-	if (customImages != undefined && customImages.length > 0) {
-		for (let i = 0; i < customImages.length; i++) { 
-			let imageUrl = parse_img(customImages[i]);
-			let tokenDiv = build_monster_customization_item(monsterId, monsterName, imageUrl, i, placedToken);
-			modalBody.append(tokenDiv);
-		}
-		removeAllButton.show();
-	} else {
-		let tokenDiv = build_monster_customization_item(monsterId, monsterName, defaultImg, -1, placedToken);
-		modalBody.append(tokenDiv);
-		removeAllButton.hide();
-	}
-
-	// build the modal footer
+	// configure the footer first so we can grab the input label. We'll be updating that based on interactions in the body
 	const add_token_customization_image = function(imageUrl) {
 		if(imageUrl.startsWith("data:")){
 			alert("You cannot use urls starting with data:");
@@ -289,126 +258,67 @@ function display_monster_customization_modal(placedToken, monsterId, monsterName
 		modalBody.append(tokenDiv);	
 		footerLabel.text(determineLabelText())
 	};
-	let modalFooter = build_token_modal_footer(determineLabelText(), add_token_customization_image);
-	modalFooter.find(`input[name='addCustomImage']`).attr("data-monster-id", monsterId);
-	modalFooter.find(`.token-image-modal-add-button`).attr("data-monster-id", monsterId);
+	let imageUrlInput = sidebarPanel.build_image_url_input(determineLabelText(), add_token_customization_image);
+	imageUrlInput.find(`input[name='addCustomImage']`).attr("data-monster-id", monsterId);
+	imageUrlInput.find(`.token-image-modal-add-button`).attr("data-monster-id", monsterId);
+	sidebarPanel.inputWrapper.append(imageUrlInput);
+	let footerLabel = imageUrlInput.find("div.token-image-modal-footer-title");
 
+	// configure the modal body
+	let modalBody = sidebarPanel.body;
 
+	// add a "remove all" button between the body and the footer
+	let removeAllButton = $(`<button class="token-image-modal-remove-all-button" data-monster-id="${monsterId}" title="Reset this monster back to the default image.">Remove All Custom Images</button><`);
+	modalBody.after(removeAllButton);
+	removeAllButton.click(function(event) {
+		let monsterId = $(event.target).attr("data-monster-id");
+		if (window.confirm(`Are you sure you want to remove all custom images for ${monsterName}?\nThis will reset the monster images back to the default`)) {
+			remove_all_custom_monster_images(monsterId);
+			display_monster_customization_modal(placedToken);
+			footerLabel.text(determineLabelText());
+		}
+	})
 
-	// put it all together
-	let modal = build_modal_container();
-	let modalContent = modal.find(".token-image-modal-content");
-	modalContent.append(modalHeader);
-	modalContent.append(modalBody);
-	modalContent.append(removeAllButton);
-	modalContent.append(modalFooter);
+	// add a token image for every custom image
+	if (customImages != undefined && customImages.length > 0) {
+		for (let i = 0; i < customImages.length; i++) { 
+			let imageUrl = parse_img(customImages[i]);
+			let tokenDiv = build_monster_customization_item(monsterId, monsterName, imageUrl, i, placedToken);
+			modalBody.append(tokenDiv);
+		}
+		removeAllButton.show();
+	} else {
+		let tokenDiv = build_monster_customization_item(monsterId, monsterName, defaultImg, -1, placedToken);
+		modalBody.append(tokenDiv);
+		removeAllButton.hide();
+	}
 
 	if (placedToken) {
-		modalFooter.find(`.token-image-modal-add-button`).remove();
+		let inputWrapper = sidebarPanel.inputWrapper;
+		sidebarPanel.footer.find(`.token-image-modal-add-button`).remove();
 		// allow them to use the new url for the placed token without saving the url for all future monsters
-		let onlyForThisTokenButton = $(`<button class="token-image-modal-add-button" style="margin:4px;" data-monster-id="${monsterId}" title="This url will be used for this token only. New tokens will continue to use the images shown above.">Set for this token only</button>`);
+		let onlyForThisTokenButton = $(`<button class="sidebar-panel-footer-button" data-monster-id="${monsterId}" title="This url will be used for this token only. New tokens will continue to use the images shown above.">Set for this token only</button>`);
 		onlyForThisTokenButton.click(function(event) {
 			let imageUrl = $(`input[name='addCustomImage']`)[0].value;
 			if (imageUrl != undefined && imageUrl.length > 0) {
 				placedToken.options.imgsrc = parse_img(imageUrl);
-				close_token_customization_modal();
+				close_sidebar_modal();
 				placedToken.place_sync_persist();
 			}
 		});
-		modalContent.append(onlyForThisTokenButton);	
-		let addForAllButton = $(`<button class="token-image-modal-add-button" style="margin:4px;" data-monster-id="${monsterId}" title="New tokens will use this new image instead of the default image. If you have more than one custom image, one will be chosen at random when you place a new token.">Add for all future tokens</button>`);
+		inputWrapper.append(onlyForThisTokenButton);	
+		let addForAllButton = $(`<button class="sidebar-panel-footer-button" data-monster-id="${monsterId}" title="New tokens will use this new image instead of the default image. If you have more than one custom image, one will be chosen at random when you place a new token.">Add for all future tokens</button>`);
 		addForAllButton.click(function(event) {
 			let imageUrl = $(`input[name='addCustomImage']`)[0].value;
 			if (imageUrl != undefined && imageUrl.length > 0) {
 				add_token_customization_image(imageUrl);
 			}
 		});
-		modalContent.append(addForAllButton);
-		modalContent.append($(`<div class="token-image-modal-explanation" style="padding:4px;">You can access this modal from the Monsters tab by clicking the button on the right side of the monster row.</div>`));
+		inputWrapper.append(addForAllButton);
+		inputWrapper.append($(`<div class="sidebar-panel-header-explanation" style="padding:4px;">You can access this modal from the Monsters tab by clicking the button on the right side of the monster row.</div>`));
 	}
-
-	// display it
-	$("#VTTWRAPPER").append(modal);
 }
 
-function build_modal_container() {
-	let sidebarContent = $(".sidebar__pane-content");
-	let width = parseInt(sidebarContent.width());
-	let top = parseInt(sidebarContent.position().top) + 10;
-	let height = parseInt(sidebarContent.height());
-	let modalContent = $(`<div class="token-image-modal-content" style="height:${height-20}px;"></div>`); // remove 20px to account for the padding on .token-image-modal
-	let modal = $(`<div class="token-image-modal" style="width:${width}px;top:${top}px;right:0px;left:auto;height:${height}px;position:fixed;"></div>`);
-	let overlay = $(`<div class="token-image-modal-overlay"></div>`)
-	modal.append(overlay);
-	modal.append(modalContent);
-	return modal;
-}
-
-function build_token_modal_header(headerTitle, explanationText) {
-	let closeButton = $(`<button class="ddbeb-modal__close-button qa-modal_close" title="Close Modal"><svg class="" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"><g transform="rotate(-45 50 50)"><rect x="0" y="45" width="100" height="10"></rect></g><g transform="rotate(45 50 50)"><rect x="0" y="45" width="100" height="10"></rect></g></svg></button>`); 
-	closeButton.click(close_token_customization_modal);
-	let modalHeader = $(`
-		<div class="token-image-modal-header">
-			<div class="token-image-modal-header-title">${headerTitle}</div>
-			<div class="token-image-modal-header-subtitle">Token Images</div>
-			<div class="token-image-modal-explanation">${explanationText}</div>
-		</div>
-	`);
-	modalHeader.prepend(closeButton);
-	return modalHeader;
-}
-
-// imageUrlEntered is a function that takes a string in the form of a url
-function build_token_modal_footer(footerLabelText, imageUrlEntered) {
-	if (typeof imageUrlEntered !== 'function') {
-		imageUrlEntered = function(newImageUrl) {
-			console.warn(`Failed to provide a valid function to handle ${newImageUrl}`);
-		};
-	}
-	
-	let footerLabel = $(`<div class="token-image-modal-footer-title">${footerLabelText}</div>`)
-	// inputWrapper.append(footerLabel);
-	let urlInput = $(`<input title="${footerLabelText}" placeholder="https://..." name="addCustomImage" type="text" />`);
-	urlInput.on('keyup', function(event) {
-		let imageUrl = event.target.value;
-		if (event.key == "Enter" && imageUrl != undefined && imageUrl.length > 0) {
-			if(imageUrl.startsWith("data:")){
-				alert("You cannot use urls starting with data:");
-				return;
-			}	
-			imageUrlEntered(imageUrl);
-		}
-	});
-
-	let addButton = $(`<button class="token-image-modal-add-button">Add</button>`);
-	addButton.click(function(event) {
-		let imageUrl = $(`.token-image-modal-footer-input-wrapper input[name="addCustomImage"]`)[0].value;
-		if (imageUrl != undefined && imageUrl.length > 0) {
-			if(imageUrl.startsWith("data:")){
-				alert("You cannot use urls starting with data:");
-				return;
-			}	
-			imageUrlEntered(imageUrl);
-		}
-	});
-
-	// input wrapper is where all inputs should go. token menus add more inputs for example
-	let inputWrapper = $(`<div class="token-image-modal-footer-input-wrapper"></div>`);
-	
-
-	let labelAndUrlWrapper = $(`<div class="token-image-modal-url-label-wrapper"></div>`); // this is to keep the label and input stacked vertically
-	let addButtonAndLabelUrlWrapper = $(`<div class="token-image-modal-url-label-add-wrapper"></div>`); // this is to keep the add button on the right side of the label and input
-		
-	inputWrapper.append(addButtonAndLabelUrlWrapper);       // outer most wrapper
-	addButtonAndLabelUrlWrapper.append(labelAndUrlWrapper); // label/input on the left
-	addButtonAndLabelUrlWrapper.append(addButton);          // add button on the right
-	labelAndUrlWrapper.append(footerLabel);                 // label above input
-	labelAndUrlWrapper.append(urlInput);                    // input below label
-
-	let modalFooter = $(`<div class="token-image-modal-footer"></div>`);
-	modalFooter.append(inputWrapper);
-	return modalFooter;
-}
 
 function build_monster_customization_item(monsterId, monsterName, imageUrl, customImgIndex, placedToken) {
 	let tokenDiv = build_custom_token_item(monsterName, imageUrl, undefined, customImgIndex, placedToken);
@@ -433,7 +343,7 @@ function build_custom_token_item(name, imageUrl, tokenSize, customImgIndex, plac
 		// we don't want to allow drag and drop from this modal
 		tokenDiv.click(function() {
 			placedToken.options.imgsrc = parse_img(imageUrl);
-			close_token_customization_modal();
+			close_sidebar_modal();
 			placedToken.place_sync_persist();
 		});
 	}
@@ -491,8 +401,6 @@ function build_custom_token_item(name, imageUrl, tokenSize, customImgIndex, plac
 
 	return tokenDiv;
 }
-
-
 
 function place_custom_token_at_point(htmlElement, hidden, eventPageX, eventPageY) {
 

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1,0 +1,187 @@
+
+function init_sidebar_tabs() {
+  // gamelog doesn't use it yet, maybe never
+  // players doesn't use it yet
+  // monsters doesn't use it yet, maybe never
+  // scenesPanel = SidebarPanel("#scenes-panel", false);
+  
+  tokensPanel = new SidebarPanel("tokens-panel", false);
+  $(".sidebar__pane-content").append(tokensPanel.build());
+  tokensPanel.hide();
+  
+  // sounds doesn't use it yet
+  // journal doesn't use it yet
+  // settings doesn't use it yet
+
+}
+
+function sidebar_modal_is_open() {
+	return $("#VTTWRAPPER .sidebar-modal").length > 0;
+}
+
+function close_sidebar_modal() {
+	$("#VTTWRAPPER .sidebar-modal").remove();
+}
+
+function display_sidebar_modal(sidebarPanel) {
+  $("#VTTWRAPPER").append(sidebarPanel.build());
+}
+
+function current_modal() {
+  $("#VTTWRAPPER .sidebar-modal");
+}
+
+class SidebarPanel {
+
+  //#region Class construction and variables
+
+  id = "#unknown_panel"; // String: the unique element id of this panel. Examples: #player_panel, #monsters_panel, etc
+  is_modal = true;       // Boolean: true if this panel will be displayed as a modal, false if this panel will be permanently fixed in a sidebar tab
+
+  constructor(id, is_modal) {
+    this.id = id.startsWith("#") ? id.substring(1) : id;
+    if (is_modal == false) {
+      // this.is_modal defaults to true. If anything other than false is passed in (such as undefined), just leave it as the default. 
+      this.is_modal = is_modal;
+    }
+  }
+
+  get container() {
+    return $(`#${this.id}`);
+  }
+
+  get header() {
+    return $(`#${this.id} .sidebar-panel-header`);
+  }
+
+  get body() {
+    return $(`#${this.id} .sidebar-panel-body`);
+  }
+
+  get footer() {
+    return $(`#${this.id} .sidebar-panel-footer`);
+  }
+
+  // input wrapper is where all inputs should go. When building a sidebar panel with inputs, be sure to add them here
+  // inputWrapper stacks everything vertically so if you need things side by side, wrap them in a div, and do that there. See build_image_url_input for an example.
+  get inputWrapper() {
+    return $(`#${this.id} .sidebar-panel-footer .footer-input-wrapper`);
+  }
+
+  //#endregion Class construction and variables
+  //#region Class functions
+
+  hide() {
+    this.container.hide();
+  }
+
+  show() {
+    this.container.show();
+  }
+
+  updateHeader(title = "", subtitle = "", explanationText = "") {
+    let header = this.header;
+    header.find(".sidebar-panel-header-title").text(title);
+    header.find(".sidebar-panel-header-subtitle").text(subtitle);
+    header.find(".sidebar-panel-header-explanation").text(explanationText);
+  }
+
+  //#endregion Class functions
+  //#region UI Construction
+
+  build() {
+    let panelContainer = $(`
+      <div id='${this.id}' class='sidebar-panel-content'>
+        <div class="sidebar-panel-header">
+          <div class="sidebar-panel-header-title"></div>
+          <div class="sidebar-panel-header-subtitle"></div>
+          <div class="sidebar-panel-header-explanation"></div>
+        </div>
+        <div class="sidebar-panel-body"></div>
+        <div class="sidebar-panel-footer">
+          <div class="footer-input-wrapper"></div>
+        </div>      
+      </div>
+    `);
+
+    if (this.is_modal) {
+      let closeButton = $(`<button class="ddbeb-modal__close-button qa-modal_close" title="Close Modal"><svg class="" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"><g transform="rotate(-45 50 50)"><rect x="0" y="45" width="100" height="10"></rect></g><g transform="rotate(45 50 50)"><rect x="0" y="45" width="100" height="10"></rect></g></svg></button>`); 
+      closeButton.click(close_sidebar_modal);
+      panelContainer.find(".sidebar-panel-header").prepend(closeButton);
+
+      let modalWrapper = this.build_modal_wrapper();
+      modalWrapper.append(panelContainer)
+
+      return modalWrapper;
+    } else {
+      return panelContainer;
+    }
+  }
+
+  build_modal_wrapper() {
+    let sidebarContent = $(".sidebar__pane-content");
+    let width = parseInt(sidebarContent.width());
+    let top = parseInt(sidebarContent.position().top) + 10;
+    let height = parseInt(sidebarContent.height());
+    return $(`
+      <div class="sidebar-modal" style="width:${width}px;top:${top}px;right:0px;left:auto;height:${height}px;position:fixed;">
+        <div class="sidebar-modal-background"></div>
+      </div>
+    `);
+  }
+
+  // imageUrlEntered is a function that takes a string in the form of a url
+  build_image_url_input(titleText, imageUrlEntered) {
+
+    /* This is the general layout of what we're building. A label above an input, both of which are to the left of an "Add" button that spans the entire height
+      |--------------------|
+      | Label     |  Add   |
+      | Input     | Button |
+      |--------------------|
+    */
+
+    if (typeof imageUrlEntered !== 'function') {
+      imageUrlEntered = function(newImageUrl) {
+        console.warn(`Failed to provide a valid function to handle ${newImageUrl}`);
+      };
+    }
+    
+    let inputLabel = $(`<div class="token-image-modal-footer-title">${titleText}</div>`)
+    let urlInput = $(`<input title="${titleText}" placeholder="https://..." name="addCustomImage" type="text" />`);
+    urlInput.on('keyup', function(event) {
+      let imageUrl = event.target.value;
+      if (event.key == "Enter" && imageUrl != undefined && imageUrl.length > 0) {
+        if(imageUrl.startsWith("data:")){
+          alert("You cannot use urls starting with data:");
+          return;
+        }	
+        imageUrlEntered(imageUrl);
+      }
+    });
+  
+    let addButton = $(`<button class="sidebar-panel-footer-button token-image-modal-add-button">Add</button>`);
+    addButton.click(function(event) {
+      let imageUrl = $(event.target).closest(".token-image-modal-url-label-add-wrapper").find(`input[name="addCustomImage"]`)[0].value;
+      if (imageUrl != undefined && imageUrl.length > 0) {
+        if(imageUrl.startsWith("data:")){
+          alert("You cannot use urls starting with data:");
+          return;
+        }	
+        imageUrlEntered(imageUrl);
+      }
+    });
+
+    
+    let labelAndUrlWrapper = $(`<div class="token-image-modal-url-label-wrapper"></div>`); // this is to keep the label and input stacked vertically
+    labelAndUrlWrapper.append(inputLabel);                  // label above input
+    labelAndUrlWrapper.append(urlInput);                    // input below label
+    
+    let addButtonAndLabelUrlWrapper = $(`<div class="token-image-modal-url-label-add-wrapper"></div>`); // this is to keep the add button on the right side of the label and input
+    addButtonAndLabelUrlWrapper.append(labelAndUrlWrapper); // label/input on the left
+    addButtonAndLabelUrlWrapper.append(addButton);          // add button on the right
+    
+    return addButtonAndLabelUrlWrapper;
+  }
+
+  //#endregion UI Construction
+}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -955,6 +955,7 @@ div#scene_properties form > div {
 
 .panel-warning {
 	background:red;
+    margin-bottom: 10px;
 }
 
 .sidebar__controls button{
@@ -1237,20 +1238,6 @@ body {
     display: inline-block;
     margin: 0 0 0 5px;
 }
-.custom-token-image-menu-item-img{
-    width: 38px;
-    max-width: 38px;
-    height: 38px;
-    max-height: 38px;
-    border-radius: 3px;
-    object-fit: cover;
-    margin-bottom: 4px;
-}
-
-.custom-token-image-menu-item-remove-button{
-    margin-left: 8px;
-    vertical-align: baseline;
-}
 
 .label-one-line {
     white-space: nowrap;
@@ -1268,7 +1255,7 @@ body {
     object-fit: contain;
 }
 
-.token-image-modal {
+.sidebar-modal {
     position: fixed;
     z-index: 99999;
     align-items: center;
@@ -1277,14 +1264,27 @@ body {
     overflow-y: auto;
     background-color: rgb(235, 241, 245);
 }
-.token-image-modal-overlay {
+.sidebar-modal-background {
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
 }
-.token-image-modal-content {
+
+/* Make a few adjustments for when it's a modal because we nest it inside or .sidebar-modal and change the UI slightly  */
+.sidebar-modal .sidebar-panel-content,
+.sidebar-modal .sidebar-panel-content .sidebar-panel-header,
+.sidebar-modal .sidebar-panel-content .sidebar-panel-body,
+.sidebar-modal .sidebar-panel-content .sidebar-panel-footer {
+    background-color: #fff;
+}
+.sidebar-modal .sidebar-panel-content .sidebar-panel-header,
+.sidebar-modal .sidebar-panel-content .sidebar-panel-footer {
+    padding: 4px;
+}
+
+.sidebar-panel-content {
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -1295,10 +1295,11 @@ body {
     border: 1px solid #d8e1e8;
     background-color: #fff;
 }
-.token-image-modal-header {
+.sidebar-panel-header {
     padding: 4px;
+    width: 100%;
 }
-.token-image-modal-header-title {
+.sidebar-panel-header-title {
     text-transform: uppercase;
     font-size: 16px;
     font-weight: 700;
@@ -1306,19 +1307,19 @@ body {
     display: flex;
     align-items: center;
 }
-.token-image-modal-header-subtitle {
+.sidebar-panel-header-subtitle {
     font-size: 12px;
     font-weight: 700;
     color: #738694;
     line-height: 1.4;
 }
-.token-image-modal-body {
+.sidebar-panel-body {
     position: relative; 
     width:100%; 
     overflow-y: auto;
     flex: auto;
 }
-.token-image-modal-footer {
+.sidebar-panel-footer {
     border-top: 1px solid #d8e1e8;
     display: flex;
     align-items: center;
@@ -1335,19 +1336,25 @@ body {
     line-height: 1.4;
     margin-top: 6px;
 }
+.sidebar-panel-footer input,
 .token-image-modal-footer input {
     margin-bottom: 6px;
     width: auto;
 }
+.sidebar-panel-footer-horizontal-wrapper,
 .token-image-modal-footer-select-wrapper {
     display: flex;
     flex-direction: row;
     margin-bottom: 6px;
+    width: 100%;
+}
+.sidebar-panel-footer-horizontal-wrapper .sidebar-panel-footer-button {
+    margin: 0px 4px 0px 4px;
 }
 .token-image-modal-footer-select-wrapper select {
     min-width: 30%;
 }
-.token-image-modal-footer-input-wrapper {
+.footer-input-wrapper {
     width: 100%;
 }
 .token-image-modal-url-label-wrapper {
@@ -1372,7 +1379,7 @@ body {
     padding: 4px;
     margin: 10px;
 }
-.token-image-modal-add-button {
+.sidebar-panel-footer-button {
     appearance: none;
     font-weight: 700;
     text-transform: uppercase;
@@ -1381,10 +1388,16 @@ body {
     border: none;
     color: #fff;
     align-self: stretch;
-    margin: 0px 4px 0px 4px;
+    margin: 4px 0px 4px 0px;
     padding: 10px;
+    width: 100%;
+    flex-grow: 0;
 }
-.token-image-modal-explanation {
+.token-image-modal-add-button {
+    margin: 0px 4px 0px 4px;
+    width: auto;
+}
+.sidebar-panel-header-explanation {
     font-size: 14px;
     color: #979AA4;
     font-family: "Roboto Condensed",Roboto,Helvetica,sans-serif;
@@ -1521,17 +1534,17 @@ body {
     fill: #738694;
 }
 
-#tokens-panel {
+.sidebar-panel-content {
     align-items: center;
     justify-content: center;
     overflow-y: auto;
     background-color: rgb(235, 241, 245);
     height: 100%;
 }
-#tokens-panel .token-image-modal-content {
+.sidebar-panel-content .sidebar-panel-body {
     height: 100%;
 }
-#tokens-panel-data {
+.sidebar-panel-content .sidebar-panel-body {
     background-color: rgb(235, 241, 245);
     position: relative; 
     width:100%; 
@@ -1552,26 +1565,16 @@ body {
     font-family: "Roboto Condensed", Roboto, Helvetica, sans-serif;
     font-weight: bold;
 }
-#tokens-panel-header {
+.sidebar-panel-content .sidebar-panel-header {
     background-color: rgb(235, 241, 245);
     padding: 8px;
 }
-#tokens-panel-footer {
+.sidebar-panel-content .sidebar-panel-footer {
     display: flex;
+    flex-direction: column;
     padding: 8px;
     background-color: rgb(235, 241, 245);
+    width: 100%;
+    align-items: center;
 }
-#tokens-panel-footer button {
-    appearance: none;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    background: #1b9af0;
-    border: none;
-    color: #fff;
-    align-self: stretch;
-    margin: 0px 4px 0px 4px;
-    padding: 10px;
-    flex-grow: 1;
-    text-align: center;
-}
+

--- a/manifest.json
+++ b/manifest.json
@@ -47,6 +47,7 @@
 	"magnific-popup.css",
 	"Journal.js",
 	"DnDBeyond/DDBCharacterData.js",
+	"SidebarPanel.js",
 	"assets/*"
 	]
 }


### PR DESCRIPTION
This is functionally equivalent to the `main` branch. I added `SidebarPanel.js` which drastically cleans up token modal construction. I also updated the tokens tab to use it since it already had the same structure. As we start to clean up the other sidebar tabs, we can migrate them to use `SidebarPanel` as well. Then all of our sidebar tabs will have a similar structure and look. I didn't update any tabs in the PR because I wanted the scope of this PR to be a refactoring of those that already use this structure.