### PR TITLE
update sounds panel to use SidebarPanel

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -392,7 +392,7 @@ function init_controls() {
 	$(".sidebar__controls").append(hider);
 
 
-	b1 = $("<button id='switch_gamelog' class='tab-btn selected-tab hasTooltip button-icon' data-name='Gamelog' data-target='.glc-game-log'></button>").click(switch_control);
+	b1 = $("<button id='switch_gamelog' class='tab-btn selected-tab hasTooltip button-icon leading-edge' data-name='Gamelog' data-target='.glc-game-log'></button>").click(switch_control);
 	b1.append('<svg class="gamelog-button__icon" width="18" height="18" viewBox="0 0 18 18"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 10C15 10.551 14.551 11 14 11H9C8.735 11 8.48 11.105 8.293 11.293L6 13.586V12C6 11.447 5.552 11 5 11H4C3.449 11 3 10.551 3 10V4C3 3.449 3.449 3 4 3H14C14.551 3 15 3.449 15 4V10ZM14 1H4C2.346 1 1 2.346 1 4V10C1 11.654 2.346 13 4 13V16C4 16.404 4.244 16.77 4.617 16.924C4.741 16.975 4.871 17 5 17C5.26 17 5.516 16.898 5.707 16.707L9.414 13H14C15.654 13 17 11.654 17 10V4C17 2.346 15.654 1 14 1ZM12 6H6C5.448 6 5 6.447 5 7C5 7.553 5.448 8 6 8H12C12.552 8 13 7.553 13 7C13 6.447 12.552 6 12 6Z" fill="currentColor"></path></svg>');
 	$(".sidebar__controls").append(b1);
 
@@ -401,7 +401,7 @@ function init_controls() {
 	$(".sidebar__controls").append(b2);
 	if (DM) {
 
-		b3 = $("<button id='switch_panel' class='tab-btn hasTooltip button-icon' data-name='Monsters' data-target='#monster-panel'></button>").click(switch_control);
+		b3 = $("<button id='switch_monsters' class='tab-btn hasTooltip button-icon' data-name='Monsters' data-target='#monster-panel'></button>").click(switch_control);
 
 		b3.append("<img src='"+window.EXTENSION_PATH + "assets/icons/mimic-chest.svg' height='100%;'>");
 		$(".sidebar__controls").append(b3);
@@ -413,7 +413,7 @@ function init_controls() {
 
 	}
 
-	b6 = $("<button id='switch_tokens' class='tab-btn hasTooltip button-icon' data-name='Sounds' data-target='#sounds-panel'></button>");
+	b6 = $("<button id='switch_sounds' class='tab-btn hasTooltip button-icon' data-name='Sounds' data-target='#sounds-panel'></button>");
 	b6.append("<img src='" + window.EXTENSION_PATH + "assets/icons/speaker.svg' height='100%;'>");
 	b6.click(switch_control);
 	$(".sidebar__controls").append(b6);
@@ -428,7 +428,7 @@ function init_controls() {
 	$(".sidebar__controls").append(b4);*/
 
 	if (DM) {
-		b7 = $("<button id='switch_tokens' class='tab-btn hasTooltip button-icon' data-name='Settings' data-target='#settings-panel'></button>");
+		b7 = $("<button id='switch_settings' class='tab-btn hasTooltip button-icon trailing-edge' data-name='Settings' data-target='#settings-panel'></button>");
 		b7.append("<img src='" + window.EXTENSION_PATH + "assets/icons/cog.svg' height='100%;'>");
 		b7.click(switch_control);
 		$(".sidebar__controls").append(b7);

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -9,6 +9,10 @@ function init_sidebar_tabs() {
   $(".sidebar__pane-content").append(tokensPanel.build());
   tokensPanel.hide();
   
+  soundsPanel = new SidebarPanel("sounds-panel", false);
+  $(".sidebar__pane-content").append(soundsPanel.build());
+  soundsPanel.hide();
+
   // sounds doesn't use it yet
   // journal doesn't use it yet
   // settings doesn't use it yet

--- a/SoundPad.js
+++ b/SoundPad.js
@@ -360,11 +360,8 @@ function init_audio(){
 	if(!("DEMO" in window.SOUNDPADS)){
 		 window.SOUNDPADS['DEMO']=demo_soundpad;
 	}
-	
-	sounds_panel = $("<div id='sounds-panel' class='sidepanel-content'/>");
-	sounds_panel.hide();
-	$(".sidebar__pane-content").append(sounds_panel);
-	sounds_panel.append("<div class='panel-warning'>EXPERIMENTAL FEATURE (still ugly but should work)</div>");
+
+	soundsPanel.header.append("<div class='panel-warning'>EXPERIMENTAL FEATURE (still ugly but should work)</div>");
 	
 	
 	youtube_section=$("<div class='youtube_section'/>");;
@@ -374,7 +371,7 @@ function init_audio(){
 	youtube_section.append(youtube_volume);
 	
 	
-	sounds_panel.append(youtube_section);
+	soundsPanel.body.append(youtube_section);
 
 	youtube_volume.on("change", function() {
 		if (window.YTPLAYER) {
@@ -406,7 +403,7 @@ function init_audio(){
 		
 		btn_addsoundpad=$("<button class='soundpad_add'>NEW</button>");
 		selector_section.append(btn_addsoundpad);
-		sounds_panel.append(selector_section);
+		soundsPanel.body.append(selector_section);
 		
 		btn_addsoundpad.click(function(){
 			var newname=prompt("New Soundpad Name");
@@ -451,10 +448,10 @@ function init_audio(){
 	}
 	
 	soundpad_element=$("<div id='soundpad'>");
-	sounds_panel.append(soundpad_element);
+	soundsPanel.body.append(soundpad_element);
 	if(!window.DM){
 		soundpad_element.hide();
-		sounds_panel.append("Music is entirely controlled by the DM. As a player you'll find a master volume control here... but sorry.. it's not ready :('");
+		soundsPanel.body.append("Music is entirely controlled by the DM. As a player you'll find a master volume control here... but sorry.. it's not ready :('");
 		
 	}
 	

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -808,7 +808,6 @@ div#scene_properties form > div {
 .sidebar__controls {
     position: relative;
     margin: 0 !important;
-    left: -2px;
     z-index: 20;
     /* width: 340px; moved to init_ui */
 }
@@ -833,13 +832,20 @@ div#scene_properties form > div {
     border-color: lightgray;
     transition: all 0.2s ease-in-out;
     font-weight: 400;
-    max-width: 40px;
-    width: 40px;
     height: 22px;
+    flex-grow: 1;
 }
 
 .sidebar__controls .tab-btn.selected-tab {
     background-color: #fff;
+}
+
+.sidebar__controls .tab-btn.leading-edge {
+    margin-left: 0px;
+}
+
+.sidebar__controls .tab-btn.trailing-edge {
+    margin-right: 0px;
 }
 
 #chat-text {


### PR DESCRIPTION
This nests the sounds tab content inside of a `SidebarPanel`. It also cleans up a few id collisions with the tabs, and a little CSS for the tabs.

<img width="342" alt="Screen Shot 2021-12-15 at 10 21 59 AM" src="https://user-images.githubusercontent.com/584771/146224370-a6096554-a31a-4058-a18c-872afe7a024c.png">
