### PR TITLE
update settings tab to use SidebarPanel

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -38,11 +38,9 @@ function download(data, filename, type) {
 
 
 function init_settings(){
-	settings_panel = $("<div id='settings-panel' class='sidepanel-content'/>");
-	settings_panel.hide();
-	$(".sidebar__pane-content").append(settings_panel);
-	settings_panel.append(`
-		<div class='panel-warning'>EXPERIMENTAL FEATURE ( again?!?!) )</div>
+	
+	settingsPanel.header.append(`<div class='panel-warning'>EXPERIMENTAL FEATURE ( again?!?!) )</div>`);
+	settingsPanel.body.append(`
 		<p>
 		This is still alpha. Use at your risk. The next version will include an import/export wizard.
 		</p>
@@ -95,7 +93,7 @@ function init_settings(){
 		}
 	];
 
-	settings_panel.append(`
+	settingsPanel.body.append(`
 		<div>
 			<h6>Default Options for newly created Monsters</h6>
 			<div>

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -20,6 +20,10 @@ function init_sidebar_tabs() {
   journalPanel.hide();  
 
   // settings doesn't use it yet
+  settingsPanel = new SidebarPanel("settings-panel", false);
+  $(".sidebar__pane-content").append(settingsPanel.build());
+  settingsPanel.hide();
+
 
 }
 


### PR DESCRIPTION
This nests the settings tab content inside of a `SidebarPanel`

<img width="344" alt="Screen Shot 2021-12-15 at 10 42 19 AM" src="https://user-images.githubusercontent.com/584771/146227814-d2163ec5-0ea5-4289-9610-274906eb0ecc.png">

