### PR TITLE
quick sidebar CSS tweak

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -396,29 +396,29 @@ function init_controls() {
 	b1.append('<svg class="gamelog-button__icon" width="18" height="18" viewBox="0 0 18 18"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 10C15 10.551 14.551 11 14 11H9C8.735 11 8.48 11.105 8.293 11.293L6 13.586V12C6 11.447 5.552 11 5 11H4C3.449 11 3 10.551 3 10V4C3 3.449 3.449 3 4 3H14C14.551 3 15 3.449 15 4V10ZM14 1H4C2.346 1 1 2.346 1 4V10C1 11.654 2.346 13 4 13V16C4 16.404 4.244 16.77 4.617 16.924C4.741 16.975 4.871 17 5 17C5.26 17 5.516 16.898 5.707 16.707L9.414 13H14C15.654 13 17 11.654 17 10V4C17 2.346 15.654 1 14 1ZM12 6H6C5.448 6 5 6.447 5 7C5 7.553 5.448 8 6 8H12C12.552 8 13 7.553 13 7C13 6.447 12.552 6 12 6Z" fill="currentColor"></path></svg>');
 	$(".sidebar__controls").append(b1);
 
-	b2 = $("<button id='switch_characters' class='tab-btn hasTooltip button-icon' data-name='Players' data-target='#players-panel'></button>").click(switch_control);
+	b2 = $("<button id='switch_characters' class='tab-btn hasTooltip button-icon blue-tab' data-name='Players' data-target='#players-panel'></button>").click(switch_control);
 	b2.append("<img src='"+window.EXTENSION_PATH + "assets/icons/character.svg' height='100%;'>");
 	$(".sidebar__controls").append(b2);
 	if (DM) {
 
-		b3 = $("<button id='switch_monsters' class='tab-btn hasTooltip button-icon' data-name='Monsters' data-target='#monster-panel'></button>").click(switch_control);
+		b3 = $("<button id='switch_monsters' class='tab-btn hasTooltip button-icon blue-tab' data-name='Monsters' data-target='#monster-panel'></button>").click(switch_control);
 
 		b3.append("<img src='"+window.EXTENSION_PATH + "assets/icons/mimic-chest.svg' height='100%;'>");
 		$(".sidebar__controls").append(b3);
 		init_tokenmenu();
-		b5=$("<button id='switch_tokens' class='tab-btn hasTooltip button-icon' data-name='Tokens' data-target='#tokens-panel'></button>");
+		b5=$("<button id='switch_tokens' class='tab-btn hasTooltip button-icon blue-tab' data-name='Tokens' data-target='#tokens-panel'></button>");
 		b5.append("<img src='"+window.EXTENSION_PATH + "assets/icons/photo.svg' height='100%;'>");
 		b5.click(switch_control);
 		$(".sidebar__controls").append(b5);
 
 	}
 
-	b6 = $("<button id='switch_sounds' class='tab-btn hasTooltip button-icon' data-name='Sounds' data-target='#sounds-panel'></button>");
+	b6 = $("<button id='switch_sounds' class='tab-btn hasTooltip button-icon blue-tab' data-name='Sounds' data-target='#sounds-panel'></button>");
 	b6.append("<img src='" + window.EXTENSION_PATH + "assets/icons/speaker.svg' height='100%;'>");
 	b6.click(switch_control);
 	$(".sidebar__controls").append(b6);
 
-	b4 = $("<button id='switch_journal' class='tab-btn hasTooltip button-icon' data-name='Journal' data-target='#journal-panel'></button>");
+	b4 = $("<button id='switch_journal' class='tab-btn hasTooltip button-icon blue-tab' data-name='Journal' data-target='#journal-panel'></button>");
 	b4.append("<img src='" + window.EXTENSION_PATH + "assets/conditons/note.svg' height='100%;'>");
 	b4.click(switch_control);
 	$(".sidebar__controls").append(b4);
@@ -428,7 +428,7 @@ function init_controls() {
 	$(".sidebar__controls").append(b4);*/
 
 	if (DM) {
-		b7 = $("<button id='switch_settings' class='tab-btn hasTooltip button-icon trailing-edge' data-name='Settings' data-target='#settings-panel'></button>");
+		b7 = $("<button id='switch_settings' class='tab-btn hasTooltip button-icon trailing-edge blue-tab' data-name='Settings' data-target='#settings-panel'></button>");
 		b7.append("<img src='" + window.EXTENSION_PATH + "assets/icons/cog.svg' height='100%;'>");
 		b7.click(switch_control);
 		$(".sidebar__controls").append(b7);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -846,6 +846,10 @@ div#scene_properties form > div {
     background-color: #fff;
 }
 
+.sidebar__controls .tab-btn.selected-tab.blue-tab {
+    background-color: rgb(235, 241, 245);
+}
+
 .sidebar__controls .tab-btn.leading-edge {
     margin-left: 0px;
 }
@@ -1336,8 +1340,6 @@ body {
     justify-content: stretch;
     position: relative;
     overflow-y: auto;
-    border-radius: 3px;
-    border: 1px solid #d8e1e8;
     background-color: #fff;
 }
 .sidebar-panel-header {
@@ -1363,6 +1365,7 @@ body {
     width:100%; 
     overflow-y: auto;
     flex: auto;
+    padding: 8px;
 }
 .sidebar-panel-footer {
     border-top: 1px solid #d8e1e8;
@@ -1474,7 +1477,7 @@ body {
 .custom-token-list {
     display: flex;
     align-items: center;
-    padding: 0px 6px 0px 6px;
+    padding: 0px;
     flex-direction: column;
     background: rgb(235, 241, 245);
     height: 100%;


### PR DESCRIPTION
* Remove a weird border from the SidebarPanel. Not sure how I missed that before, but it's gone now.
* Add a bit of padding to the `SidebarPanel.body` so things aren't right up against the edge.
* Color the tab button to match the background color (white for gamelog, blue for the rest)

## Before
<img width="341" alt="Screen Shot 2021-12-15 at 11 30 06 AM" src="https://user-images.githubusercontent.com/584771/146235771-72fa8681-8945-4ca9-b457-1cecc0be255f.png">


## After
<img width="341" alt="Screen Shot 2021-12-15 at 11 29 18 AM" src="https://user-images.githubusercontent.com/584771/146235797-d9adfe9a-eb92-4c2c-b541-20dd6b6e82bb.png">

