### PR TITLE
update settings panel UI with example tokens

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -251,7 +251,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 		this.persist();
 
-
+		// some things can't be done correctly until after the scene finishes loading
+		redraw_settings_panel_token_examples();
 
 	}
 

--- a/Settings.js
+++ b/Settings.js
@@ -39,84 +39,254 @@ function download(data, filename, type) {
 
 function init_settings(){
 	
-	settingsPanel.header.append(`<div class='panel-warning'>EXPERIMENTAL FEATURE ( again?!?!) )</div>`);
-	settingsPanel.body.append(`
-		<p>
-		This is still alpha. Use at your risk. The next version will include an import/export wizard.
-		</p>
-		<p>
-		Press <button onclick='export_file();'>EXPORT</button> to save to file all your scenes, custom token library and soundpads
-		</p>
-		<p>
-		Press <button onclick='import_openfile();'>IMPORT</button> to import everything from one file. Scenes from that file will be appended to the one that already are in this campaign..
-		</p>
-		
-	<input accept='.abovevtt' id='input_file' type='file' style='display: none' />
+	let body = settingsPanel.body;
+
+	body.append(`
+		<h5 class="token-image-modal-footer-title">Import / Export</h5>
+		<div class="sidebar-panel-header-explanation">
+			<p><b>WARNING</b>: The import / export feature is expirimental. Use at your own risk. A future version will include an import/export wizard.</p>
+			<p>Export will download a file containing all of your scenes, custom tokens, and soundpads. 
+			Import will allow you to upload an exported file. Scenes from that file will be added to the scenes in this campaign.</p>
+			<div class="sidebar-panel-footer-horizontal-wrapper">
+			<button onclick='import_openfile();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="Upload a file containing scenes, custom tokens, and soundpads. This will not overwrite your existing scenes. Any scenes found in the uploaded file will be added to your current list scenes">IMPORT</button>
+			<button onclick='export_file();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="Download a file containing all of your scenes, custom tokens, and soundpads">EXPORT</button>
+				<input accept='.abovevtt' id='input_file' type='file' style='display: none' />
+			<div>
+		</div>
 	`);
 	$("#input_file").change(import_readfile);
+	
+	body.append(`
+		<br />
+		<h5 class="token-image-modal-footer-title">Default Options when placing tokens</h5>
+		<div class="sidebar-panel-header-explanation">Every time you place a token on the scene, these settings will be used. Custom tokens allow you to override these settings on a per-token basis.</div>
+	`);
+
 	const token_settings = [
 		{
 			name: 'hidden',
-			label: 'Hide'
+			label: 'Hide',
+			enabledDescription: 'New tokens will be hidden from players when placed on the scene',
+			disabledDescription: 'New tokens will be visible to players when placed on the scene'
 		},
 		{
 			name: 'square',
-			label: 'Square Token'
+			label: 'Square Token',
+			enabledDescription: 'New tokens will be square',
+			disabledDescription: 'New tokens will be round'
 		},
 		{
 			name: 'locked',
-			label: 'Lock Token in Position'
+			label: 'Lock Token in Position',
+			enabledDescription: 'New tokens will not be movable',
+			disabledDescription: 'New tokens will be movable'
 		},
 		{
 			name: 'disablestat',
-			label: 'Disable HP/AC'
+			label: 'Disable HP/AC',
+			enabledDescription: 'New tokens will not have HP/AC shown to either the DM or the players. This is most useful for tokens that represent terrain, vehicles, etc.',
+			disabledDescription: 'New tokens will have HP/AC shown to only the DM.'
 		},
 		{
 			name: 'hidestat',
-			label: 'Hide HP/AC from players'
+			label: 'Hide HP/AC from players',
+			enabledDescription: "New player tokens will have their HP/AC hidden from other players. Each player will be able to see their own HP/AC, but won't be able to see the HP/AC of other players.",
+			disabledDescription: "New player tokens will have their HP/AC visible to other players. Each player will be able to see their own HP/AC as well as HP/AC of other players."
 		},
 		{
 			name: 'disableborder',
-			label: 'Disable Border'
+			label: 'Disable Border',
+			enabledDescription: 'New tokens will not have a border around them',
+			disabledDescription: 'New tokens will have a border around them'
 		},
 		{
 			name: 'disableaura',
-			label: 'Disable Aura'
+			label: 'Disable Aura',
+			enabledDescription: 'New tokens will not have an aura around them that represents their current health',
+			disabledDescription: 'New tokens will have an aura around them that represents their current health'
 		},
 		{
 			name: 'revealname',
-			label: 'Show name to players'
+			label: 'Show name to players',
+			enabledDescription: 'New tokens will have their name visible to players',
+			disabledDescription: 'New tokens will have their name hidden from players'
 		},
 		{
 			name: 'legacyaspectratio',
-			label: 'Stretch non-square token images by default'
+			label: 'Ignore Image Aspect Ratio',
+			enabledDescription: 'New tokens will stretch non-square images to fill the token space',
+			disabledDescription: 'New tokens will respect the aspect ratio of the image provided'
 		}
 	];
 
-	settingsPanel.body.append(`
-		<div>
-			<h6>Default Options for newly created Monsters</h6>
-			<div>
-				${token_settings.map(setting => (
-					`
-						<div>
-							<input type='checkbox' name='${setting.name}' ${window.TOKEN_SETTINGS[setting.name] && 'checked'}>
-							<label for='${setting.name}' style='display: inline-block;'>${setting.label}<label/>
-						</div>
-					`
-				)).join('')}
-			</div>
-		</div>
-	`);
-
-	const tokenSettingsHandler = (e) => {
-		const $el = $(e.target);
-		window.TOKEN_SETTINGS[$el.attr('name')] = $el.is(":checked");
-		persist_token_settings(window.TOKEN_SETTINGS);
+	for(let i = 0; i < token_settings.length; i++) {
+		let setting = token_settings[i];
+		let currentValue = window.TOKEN_SETTINGS[setting.name];
+		let inputWrapper = settingsPanel.build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
+			console.log(`${name} setting is now ${newValue}`);
+			window.TOKEN_SETTINGS[name] = newValue;
+			persist_token_settings(window.TOKEN_SETTINGS);
+			redraw_settings_panel_token_examples();
+		});
+		body.append(inputWrapper);
 	}
-	token_settings.forEach(setting => {
-		$(`#settings-panel input[name='${setting.name}']`).change(tokenSettingsHandler);
-	});	
+
+	// Build example tokens to show the settings changes
+	body.append(`<div class="token-image-modal-footer-title">Example Tokens</div>`);
+	let tokenExamplesWrapper = $(`<div class="example-tokens-wrapper"></div>`);
+	// not square image to show aspect ratio
+	let example1 = build_custom_token_item("example 1", "https://www.dndbeyond.com/avatars/thumbnails/6/359/420/618/636272697874197438.png", 1, -1);
+	example1.draggable('disable');
+	tokenExamplesWrapper.append(example1);
+	// perectly square image
+	let example2 = build_custom_token_item("example 2", "https://www.dndbeyond.com/avatars/8/441/636306375308314493.jpeg", 1, -1);
+	example2.draggable("disable");
+	tokenExamplesWrapper.append(example2);
+	// idk, something else I guess
+	let example3 = build_custom_token_item("example 3", "https://i.imgur.com/2Lglcip.png", 1, -1);
+	example3.draggable("disable");
+	tokenExamplesWrapper.append(example3);
+	body.append(tokenExamplesWrapper);
+
+	let resetToDefaults = $(`<button class="token-image-modal-remove-all-button" title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px 30px 0px;">Reset Token Settings to Defaults</button>`);
+	resetToDefaults.click(function () {
+		for (let i = 0; i < token_settings.length; i++) {
+			let setting = token_settings[i];
+			let toggle = body.find(`button[name=${setting.name}]`);
+			if (toggle.hasClass("rc-switch-checked")) {
+				toggle.click();
+			}
+			window.TOKEN_SETTINGS[setting.name] = false;
+		}
+		persist_token_settings(window.TOKEN_SETTINGS);
+		redraw_settings_panel_token_examples();
+	});
+	body.append(resetToDefaults);
+
+
+	const experimental_features = [
+		// {
+		// 	name: 'test',
+		// 	label: 'Test One',
+		// 	enabledDescription: 'You are testing this feature',
+		// 	disabledDescription: 'Testing this feature means, you will see x, y, and z instead of a, b, and c.'
+		// }
+	];
+	if (experimental_features.length > 0) {
+		body.append(`
+			<br />
+			<h5 class="token-image-modal-footer-title">Experimental Features</h5>
+			<div class="sidebar-panel-header-explanation">These are experimental features. You must explicitly opt-in to them. Use at your own risk.</div>
+		`);
+		const experimental_features = [
+			// {
+			// 	name: 'test',
+			// 	label: 'Test One',
+			// 	enabledDescription: 'You are testing this feature',
+			// 	disabledDescription: 'Testing this feature means, you will see x, y, and z instead of a, b, and c.'
+			// }
+		];
+		for(let i = 0; i < experimental_features.length; i++) {
+			let setting = experimental_features[i];
+			let currentValue = window.TOKEN_SETTINGS[setting.name];
+			let inputWrapper = settingsPanel.build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
+				console.log(`${name} setting is now ${newValue}`);
+				// TODO: store this setting somewhere?
+			});
+			body.append(inputWrapper);
+		}
+		let optOutOfAll = $(`<button class="token-image-modal-remove-all-button" title="Opt out of all expirimental features." style="width:100%;padding:8px;margin:10px 0px 30px 0px;">Opt out of all</button>`);
+		optOutOfAll.click(function () {
+			for (let i = 0; i < experimental_features.length; i++) {
+				let setting = experimental_features[i];
+				let toggle = body.find(`button[name=${setting.name}]`);
+				if (toggle.hasClass("rc-switch-checked")) {
+					toggle.click();
+				}
+			}
+		});
+		body.append(optOutOfAll);
+	}
+
+	redraw_settings_panel_token_examples();
+}
+
+function redraw_settings_panel_token_examples() {
+	
+	let items = settingsPanel.body.find(".example-tokens-wrapper .custom-token-image-item");
+	items.css("margin", "auto");
+	items.css("width", "30%");
+
+	if (window.TOKEN_SETTINGS['hidden']) {
+		items.css("opacity", 0.5); // DM SEE HIDDEN TOKENS AS OPACITY 0.5
+	} else {
+		items.css("opacity", 1);
+	}
+
+	if (window.TOKEN_SETTINGS['square']) {
+		items.find("img").removeClass("token-round");
+	} else {
+		items.find("img").addClass("token-round");
+	}
+
+	if (window.TOKEN_SETTINGS['locked']) {
+		// nothing to show here?
+	} else {
+		// nothing to show here?
+	}
+
+	if (window.TOKEN_SETTINGS['disablestat']) {
+		items.find(".hpbar").remove();
+		items.find(".ac").remove();
+	} else if (window.CURRENT_SCENE_DATA !== undefined && window.CURRENT_SCENE_DATA.hpps !== undefined) {
+		items.find(".hpbar").remove();
+		items.find(".ac").remove();
+
+		// only do this if we've loaded scene data. Otherwise this breaks because it tries to do math on undefined
+		let tok = new Token(default_options());
+		tok.options.size = items.width();
+		tok.options.max_hp = 10;
+		tok.options.hp = 10;
+		tok.options.ac = 10;
+		let hp = tok.build_hp();
+		items.append(hp);
+		let ac = tok.build_ac();
+		items.append(ac);
+	}
+
+	if (window.TOKEN_SETTINGS['hidestat']) {
+		// anything to show here? This only affects players
+	} else {
+		// anything to show here? This only affects players
+	}
+
+	if (window.TOKEN_SETTINGS['disableborder']) {
+		items.find("img").css("border", "0px solid #000")
+	} else {
+		items.find("img").css("border", "4px solid #000")
+	}
+
+	if (window.TOKEN_SETTINGS['disableaura']) {
+		items.find("img").css("box-shadow", "");
+		items.find("img").css("transform", `scale(1)`);
+	} else {
+		items.find("img").css("box-shadow", "rgb(5 255 0 / 80%) 0px 0px 7px 7px");
+		items.find("img").css("transform", `scale(0.88)`); // close enough
+	}
+
+	if (window.TOKEN_SETTINGS['revealname']) {
+		// this messes with the size of the example tokens, and we can't use the `VTTToken` class because otherwise the scene will think it's a real token
+		// so for now, do nothing, and revisit this in the future
+		// items.addClass('hasTooltip');
+	} else {
+		// items.removeClass('hasTooltip');
+	}
+
+	if (window.TOKEN_SETTINGS['legacyaspectratio']) {
+		items.find("img").removeClass("preserve-aspect-ratio");
+	} else {
+		items.find("img").addClass("preserve-aspect-ratio");
+	}
 }
 
 function persist_token_settings(settings){

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -157,7 +157,7 @@ class SidebarPanel {
       };
     }
     
-    let inputLabel = $(`<div class="token-image-modal-footer-title">${titleText}</div>`)
+    let inputLabel = $(`<div class="token-image-modal-footer-title">${titleText}</div>`);
     let urlInput = $(`<input title="${titleText}" placeholder="https://..." name="addCustomImage" type="text" />`);
     urlInput.on('keyup', function(event) {
       let imageUrl = event.target.value;
@@ -192,6 +192,49 @@ class SidebarPanel {
     addButtonAndLabelUrlWrapper.append(addButton);          // add button on the right
     
     return addButtonAndLabelUrlWrapper;
+  }
+
+  build_select_input(labelText, input) {
+    let wrapper = $(`
+      <div class="token-image-modal-footer-select-wrapper">
+        <div class="token-image-modal-footer-title">${labelText}</div>
+      </div>
+    `);
+    wrapper.append(input);
+    return wrapper;
+  }
+
+  build_toggle_input(name, labelText, enabled, enabledHoverText, disabledHoverText, changeHandler) {
+    if (typeof changeHandler !== 'function') {
+      changeHandler = function(){};
+    }
+    let wrapper = $(`
+      <div class="token-image-modal-footer-select-wrapper sidebar-hovertext">
+        <div class="token-image-modal-footer-title">${labelText}</div>
+      </div>
+    `);
+    let input = $(`<button name="${name}" type="button" role="switch" class="rc-switch"><span class="rc-switch-inner"></span></button>`);
+    if (enabled) {
+      input.addClass("rc-switch-checked");
+      wrapper.attr("data-hover", enabledHoverText);
+    } else {
+      wrapper.attr("data-hover", disabledHoverText);
+    }
+    wrapper.append(input);
+    input.click(function(clickEvent) {
+      if ($(clickEvent.currentTarget).hasClass("rc-switch-checked")) {
+        // it was checked. now it is no longer checked
+        $(clickEvent.currentTarget).removeClass("rc-switch-checked");
+        wrapper.attr("data-hover", disabledHoverText);
+        changeHandler(name, false);
+      } else {
+        // it was not checked. now it is checked
+        $(clickEvent.currentTarget).addClass("rc-switch-checked");
+        wrapper.attr("data-hover", enabledHoverText);
+        changeHandler(name, true);
+      }
+    });
+    return wrapper;
   }
 
   //#endregion UI Construction

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1010,22 +1010,21 @@ function build_custom_token_form_footer(sidebarPanel, path, name, token) {
 		close_sidebar_modal();
 	});
 
-	const selectWrapper = function(labelText, input) {
-		let wrapper = $(`<div class="token-image-modal-footer-select-wrapper"><div class="token-image-modal-footer-title">${labelText}</div></div>`);
-		wrapper.append(input);
-		input.change(function(event) {
-			submit_custom_token_form(sidebarPanel, path);
-		});
-		return wrapper;
-	};
+	const onChange = function() {
+		submit_custom_token_form(sidebarPanel, path);
+	}
+	tokenSizeInput.change(onChange);
+	tokenTypeInput.change(onChange);
+	hideBorderInput.change(onChange);
+	aspectRatioInput.change(onChange);
 
 	inputWrapper.append($(`<div class="token-image-modal-footer-title" style="width:100%;padding-left:0px">Token Name</div>`));
 	inputWrapper.append(nameInput);
-	inputWrapper.append(selectWrapper("Token Size", tokenSizeInput));
+	inputWrapper.append(sidebarPanel.build_select_input("Token Size", tokenSizeInput));
 	inputWrapper.append(`<div class="sidebar-panel-header-explanation" style="padding-bottom:6px;">The following will override global settings for this token. Global settings can be changed in the settings tab.</div>`)
-	inputWrapper.append(selectWrapper("Token Shape", tokenTypeInput)); // class token-round
-	inputWrapper.append(selectWrapper("Border Visibility", hideBorderInput)); // border-width: 4
-	inputWrapper.append(selectWrapper("Aspect Ratio", aspectRatioInput)); // class preserve-aspect-ratio
+	inputWrapper.append(sidebarPanel.build_select_input("Token Shape", tokenTypeInput));        // adds class token-round
+	inputWrapper.append(sidebarPanel.build_select_input("Border Visibility", hideBorderInput)); // sets border-width: 4
+	inputWrapper.append(sidebarPanel.build_select_input("Aspect Ratio", aspectRatioInput));     // adds class preserve-aspect-ratio
 	inputWrapper.append(saveButton);
 
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1380,9 +1380,24 @@ body {
     letter-spacing: 1px;
     flex-grow: 1;
     color: #738694;
-    font-size: 13px;
     line-height: 1.4;
     margin-top: 6px;
+}
+div.token-image-modal-footer-title {
+    font-size: 13px;
+}
+h1.token-image-modal-footer-title:after,
+h2.token-image-modal-footer-title:after,
+h3.token-image-modal-footer-title:after,
+h4.token-image-modal-footer-title:after,
+h5.token-image-modal-footer-title:after {
+    /* This was lifted from source book titles, and tweaked slightly */
+    content: '';
+    width: 100%;
+    margin: 5px auto 20px;
+    height: 1px;
+    background-color: #979AA4;
+    display: block;
 }
 .sidebar-panel-footer input,
 .token-image-modal-footer input {
@@ -1626,3 +1641,98 @@ body {
     align-items: center;
 }
 
+.example-tokens-wrapper {
+    width: 100%;
+    height: 100px;
+    display: flex;
+    margin: 10px 0px;
+}
+
+/* all the rc-switch styles were lifted from the content sharing screen /campaigns/<campaign_id>/content-management and then tweaked slightly */
+.rc-switch {
+    position: relative;
+    display: inline-block;
+    box-sizing: border-box;
+    width: 44px;
+    height: 22px;
+    line-height: 20px;
+    padding: 0;
+    vertical-align: middle;
+    border-radius: 20px 20px;
+    border: 1px solid #ccc;
+    background-color: #ccc;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.35, 0, 0.25, 1);
+}
+.rc-switch-checked {
+    border: 1px solid #1b9af0;
+    background-color: #1b9af0;
+}
+.rc-switch-checked:after {
+    left: 22px;
+}
+.rc-switch:after {
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    left: 2px;
+    top: 1px;
+    border-radius: 50% 50%;
+    background-color: #fff;
+    content: " ";
+    cursor: pointer;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.26);
+    transform: scale(1);
+    transition: left 0.3s cubic-bezier(0.35, 0, 0.25, 1);
+    -webkit-animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
+    animation-timing-function: cubic-bezier(0.35, 0, 0.25, 1);
+    -webkit-animation-duration: 0.3s;
+    animation-duration: 0.3s;
+    -webkit-animation-name: rcSwitchOff;
+    animation-name: rcSwitchOff;
+}
+.rc-switch-inner {
+    color: #fff;
+    font-size: 12px;
+    position: absolute;
+    left: 24px;
+    top: 0;
+}
+.rc-switch-checked .rc-switch-inner {
+    left: 6px;
+}
+.rc-switch-checked:after {
+    left: 22px;
+}
+.rc-switch:hover:after {
+    transform: scale(1.1);
+    -webkit-animation-name: rcSwitchOn;
+    animation-name: rcSwitchOn;
+}
+
+.sidebar-hovertext:before {
+    content: attr(data-hover);
+    font-family: 'Roboto', sans-serif;
+    font-weight: 300;
+    font-size: 14px;
+    text-transform: none;
+    visibility: hidden;
+    opacity: 0;
+    width: max-content;
+    background-color: rgba(28,29,30,0.8);
+    color: #fff;
+    text-align: center;
+    border-radius: 5px;
+    padding: 5px 5px;
+    transition: opacity 1s ease-in-out;
+    position: absolute;
+    z-index: 1;
+    left: 5%;
+    margin-top: 30px;
+    width: 90%;
+}
+
+.sidebar-hovertext:hover:before {
+    opacity: 1;
+    visibility: visible;
+}


### PR DESCRIPTION
This is a UI update to the settings tab. 
1. It updates the style of the import / export section
2. It converts the checkboxes to a toggle that mimics the DDB content sharing settings. 
3. It adds descriptive hover text to all the settings and import / export buttons
4. It adds example tokens that get updated as settings are changed to better show what all the settings do.

![avtt-settings-panel-ui-again](https://user-images.githubusercontent.com/584771/147675026-f6b13276-f28e-4d0e-8f7e-fbfa1b5e14cc.gif)



