### PR TITLE
sanitize HTML being sent over the websocket

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -957,7 +957,7 @@ function init_player_sheet(pc_sheet, loadWait = 0)
 							$(this).css(newcss);
 						});
 
-						html = newobj.html();
+						html = window.MB.encode_message_text(newobj.html());
 						newobj.remove();
 						console.log(html);
 						data = {
@@ -1180,6 +1180,11 @@ function check_versions_match() {
 	}
 
 	return latestVersionSeen;
+}
+
+/** returns true if all connected users are on a version that is greater than or equal to `versionString` */
+function is_supported_version(versionString) {
+	return abovevtt_version >= versionString;
 }
 
 function init_ui() {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -212,7 +212,11 @@ class MessageBroker {
 						}
 					});
 					if(!found){
-						self.chat_pending_messages.push(current);
+						console.warn(`couldn't find a message matching ${JSON.stringify(current)}`);
+						// It's possible that we could lose messages due to this not being here, but
+						// if we push the message here, we can end up in an infinite loop.
+						// We may need to revisit this and do better with error handling if we end up missing too many messages.
+						// self.chat_pending_messages.push(current);
 					}
 				}
 				if(self.chat_pending_messages.length==0){
@@ -704,9 +708,35 @@ class MessageBroker {
 				window.MB.sendMessage('custom/myVTT/token', cur.options);
 			}
 		}
-    	}
+	}
+
+	encode_message_text(text) {
+		if (is_supported_version('0.66')) {
+			// This is used when the "Send to Gamelog" button sends HTML over the websocket.
+			// If there are special characters, then the _dndbeyond_message_broker_client fails to parse the JSON
+			// To work around this, we base64 encode the html here, and then decode it in MessageBroker.convertChat
+			return "base64" + window.btoa(unescape(encodeURIComponent(text)));
+		} else {
+			console.warn("There's at least one connection below version 0.66; not encoding message text to prevent that user from seeing base64 encoded text in the gamelog");
+			return text;
+		}
+	}
+	
+	decode_message_text(text) {
+		// no need to check version because the `startsWith("base64")` will return `false` if there are any connections below 0.65. See `encode_message_text` for more details.
+		if (text !== undefined && text.startsWith("base64")) {
+			// This is used when the "Send to Gamelog" button sends HTML over the websocket.
+			// If there are special characters, then the _dndbeyond_message_broker_client fails to parse the JSON
+			// To work around this, we base64 encode the html in encode_message_text, and then decode it here after the message has been received
+			text = decodeURIComponent(escape(window.atob(text.replace("base64", ""))));
+		}
+		return text;
+	}
 	
 	convertChat(data,local=false) {
+
+		data.text = this.decode_message_text(data.text);
+
 		//Security logic to prevent content being sent which can execute JavaScript.
 		data.player = DOMPurify.sanitize( data.player,{ALLOWED_TAGS: []});
 		data.img = DOMPurify.sanitize( data.img,{ALLOWED_TAGS: []});


### PR DESCRIPTION
I found one way to reproduce the "Send to Gamelog" bug

## How to Reproduce
Make a `Rock Gnome` character, and then press the "Send to Gamelog" button on the Racial Feature `Artificer's Lore`.  


## Results
The console log gives this error twice:
```
_dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:16 Uncaught SyntaxError: Unexpected token  in JSON at position 1780
    at JSON.parse (<anonymous>)
    at t.<anonymous> (_dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:16)
    at t.triggerHandler (_dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:1)
    at _dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:1
    at t.postSync (_dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:1)
    at t.postOrPostAndWait (_dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:1)
    at t.post (_dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:1)
    at WebSocket.m (_dndbeyond_message_broker_client.00a081b659ffc6309334.bundle.js:16)
```

When I look up the unicode character it's breaking on it's this:
```
U+0020 : SPACE [SP]
U+0019 : <control> END OF MEDIUM [EOM]
U+0020 : SPACE [SP]
```

When it breaks in this way, there seems to be an infinite loop of 
```
deciphering
MessageBroker.js:179 8887b4e8-f7ed-468c-838c-d67f05ae74eb1
MessageBroker.js:180 {player: 'Feat Tester', img: 'https://www.dndbeyond.com/avatars/thumbnails/17/921/60/60/636378851716447403.jpeg', text: '<div class="ct-racial-trait-pane" style="display: …normally apply.</p></div></div></div></div></div>'}
```
Note that the `...normally apply` is the chrome console truncating the message. You can expand it and see the entire JSON object.

## The Fix

Before we send the message, I base64 encode the `data.text`. Then when we interpret the message, I decode the message.  If anyone is on a previous version, they will see the base64 encoded message in the gamelog so I added a check to make sure that the version is at 0.66 before we encode the message. This allows us to get a full version with the decoding logic in place before we start encoding.


## Making It Better
I don't know what DDB is doing to convert that character because all of the JSON parsing tricks I tried worked just fine. Ideally, we'd figure out how to reproduce this in our code, run it through some sort of check before we even send it, and then log out an error to the console that would help us track down the character that breaks.

