### PR TITLE
Convert rpgDiceRoll results to use DDB format

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1384,25 +1384,31 @@ function init_ui() {
 		$(".dice-roller > div img[data-count]").each(function() {
 			rollExpression.push($(this).attr("data-count") + $(this).attr("alt"));
 		});
-		const roll = new rpgDiceRoller.DiceRoll(rollExpression.join("+"));
-		const text = roll.output;
-		const uuid = new Date().getTime();
-		const data = {
-			player: window.PLAYER_NAME,
-			img: window.PLAYER_IMG,
-			text: text,
-			dmonly: window.DM || false,
-			id: window.DM ? `li_${uuid}` : undefined
-		};
-		window.MB.inject_chat(data);
 
-		if (window.DM) { // THIS STOPPED WORKING SINCE INJECT_CHAT
-			$("#" + uuid).on("click", () => {
-				const newData = {...data, dmonly: false, id: undefined, text: text};
-				window.MB.inject_chat(newData);
-				$(this).remove();
-			});
+		let sendToDM = window.DM || false;
+		let sentAsDDB = send_rpg_dice_to_ddb(rollExpression.join("+"), sendToDM);
+		if (!sentAsDDB) {
+			const roll = new rpgDiceRoller.DiceRoll(rollExpression.join("+"));
+			const text = roll.output;
+			const uuid = new Date().getTime();
+			const data = {
+				player: window.PLAYER_NAME,
+				img: window.PLAYER_IMG,
+				text: text,
+				dmonly: sendToDM,
+				id: window.DM ? `li_${uuid}` : undefined
+			};
+			window.MB.inject_chat(data);
+
+			if (window.DM) { // THIS STOPPED WORKING SINCE INJECT_CHAT
+				$("#" + uuid).on("click", () => {
+					const newData = {...data, dmonly: false, id: undefined, text: text};
+					window.MB.inject_chat(newData);
+					$(this).remove();
+				});
+			}
 		}
+
 		$(".roll-button").removeClass("show");
 		$(".dice-roller > div img[data-count]").removeAttr("data-count");
 		$(".dice-roller > div span").remove();
@@ -1417,13 +1423,30 @@ function init_ui() {
 			$("#chat-text").val("");
 
 			if(text.startsWith("/roll")) {
+				dmonly = window.DM;
 				expression = text.substring(6);
+				let sentAsDDB = send_rpg_dice_to_ddb(expression, dmonly);
+				if (sentAsDDB) {
+					return;
+				}
+				roll = new rpgDiceRoller.DiceRoll(expression);
+				text = roll.output;
+			}
+
+			if(text.startsWith("/r ")) {
+				dmonly = window.DM;
+				expression = text.substring(3);
+				let sentAsDDB = send_rpg_dice_to_ddb(expression, dmonly);
+				if (sentAsDDB) {
+					return;
+				}
 				roll = new rpgDiceRoller.DiceRoll(expression);
 				text = roll.output;
 			}
 
 			if(text.startsWith("/dmroll")) {
 				expression = text.substring(8);
+				// TODO: send_rpg_dice_to_ddb doesn't currently handle rolls to self or to dm
 				roll = new rpgDiceRoller.DiceRoll(expression);
 				text = roll.output;
 				dmonly=true;
@@ -1461,7 +1484,7 @@ function init_ui() {
 				data = {
 					player: window.PLAYER_NAME,
 					img: window.PLAYER_IMG,
-					text: text,
+					text: `<div class="custom-gamelog-message">${text}</div>`,
 					dmonly: dmonly,
 				};
 	
@@ -1790,6 +1813,8 @@ function init_ui() {
 			return origProcessFlashMessages(i, r);
 		}
 	};
+
+	monitor_messages();
 }
 
 const DRAW_COLORS = ["#D32F2F", "#FB8C00", "#FFEB3B", "#9CCC65", "#039BE5", 
@@ -2291,4 +2316,152 @@ function init_help_menu() {
 	$("#help_button").click(function(e) {
 		$('#help-container').fadeIn(200);
 	});
+}
+
+/**
+ * Attempts to convert the output of an rpgDiceRoller DiceRoll to the DDB format.
+ * If the conversion is successful, it will be sent over the websocket, and this will return true.
+ * If the conversion fails for any reason, nothing will be sent, and this will return false,
+ * @param {String} expression the dice rolling expression; ex: 1d20+4
+ * @param {Boolean} toSelf    whether this is sent to self or everyone
+ * @returns {Boolean}         true if we were able to convert and send; else false
+ */
+function send_rpg_dice_to_ddb(expression, toSelf = true) {
+	try {
+		expression = expression.replace(/\s+/g, ''); // remove all whitespace
+
+		const supportedDieTypes = ["d4", "d6", "d8", "d10", "d12", "d20", "d100"];
+
+		let roll = new rpgDiceRoller.DiceRoll(expression);
+
+		// rpgDiceRoller doesn't give us the notation of each roll so we're going to do our best to find and match them as we go
+		var choppedExpression = expression;
+		let notationList = [];
+		for (let i = 0; i < roll.rolls.length; i++) {
+			let currentRoll = roll.rolls[i];
+			if (typeof currentRoll === "string") {
+				let idx = choppedExpression.indexOf(currentRoll);
+				let previousNotation = choppedExpression.slice(0, idx);
+				notationList.push(previousNotation);
+				notationList.push(currentRoll);
+				choppedExpression = choppedExpression.slice(idx + currentRoll.length);
+			}
+		}
+		notationList.push(choppedExpression); // our last notation will still be here so add it to the list
+
+		if (roll.rolls.length != notationList.length) {
+			console.warn(`Failed to convert expression to DDB roll; expression ${expression}`);
+			return false;
+		}
+
+		let convertedDice = [];       // a list of objects in the format that DDB expects
+		let allValues = [];           // all the rolled values
+		let convertedExpression = []; // a list of strings that we'll concat for a string representation of the final math being done
+		let constantsTotal = 0;       // all the constants added together
+		for (let i = 0; i < roll.rolls.length; i++) {
+			let currentRoll = roll.rolls[i];
+			if (typeof currentRoll === "object") {
+				let currentNotation = notationList[i];
+				let currentDieType = supportedDieTypes.find(dt => currentNotation.includes(dt)); // we do it this way instead of splitting the string so we can easily clean up things like d20kh1, etc. It's less clever, but it avoids any parsing errors
+				if (!supportedDieTypes.includes(currentDieType)) {
+					console.warn(`found an unsupported dieType ${currentNotation}`);
+					return false;
+				}
+				if (currentNotation.includes("kh") || currentNotation.includes("kl")) {
+					let cleanerString = currentRoll.toString()
+						.replace("[", "(")    // swap square brackets with parenthesis
+						.replace("]", ")")    // swap square brackets with parenthesis
+						.replace("d", "")     // remove all drop notations
+						.replace(/\s+/g, ''); // remove all whitespace
+					convertedExpression.push(cleanerString);
+				} else {
+					convertedExpression.push(currentRoll.value);
+				}
+				let dice = currentRoll.rolls.map(d => {
+					allValues.push(d.value);
+					return { dieType: currentDieType, dieValue: d.value };
+				});
+
+				convertedDice.push({
+					"dice": dice,
+					"count": dice.length,
+					"dieType": currentDieType,
+					"operation": 0
+				})
+			} else if (typeof currentRoll === "string") {
+				convertedExpression.push(currentRoll);
+			} else if (typeof currentRoll === "number") {
+				convertedExpression.push(currentRoll);
+				if (i > 0) {
+					if (convertedExpression[i-1] == "-") {
+						constantsTotal -= currentRoll;
+					} else if (convertedExpression[i-1] == "+") {
+						constantsTotal += currentRoll;
+					} else {
+						console.warn(`found an unexpected symbol ${convertedExpression[i-1]}`);
+						return false;
+					}
+				} else {
+					constantsTotal += currentRoll;
+				}
+			}
+		}
+
+		let ddbJson = {
+			id: uuid(),
+			dateTime: `${Date.now()}`,
+			gameId: window.MB.gameid,
+			userId: window.MB.userid,
+			source: "web",
+			persist: true,
+			messageScope: toSelf ? "userId" : "gameId",
+			messageTarget: toSelf ? window.MB.userid : window.MB.gameid,
+			entityId: window.MB.userid,
+			entityType: "user",
+			eventType: "dice/roll/fulfilled",
+			data: {
+				action: "custom",
+				context: {
+					entityId: window.MB.userid,
+					entityType: "user",
+					messageScope: "userId",
+					messageTarget: window.MB.userid
+				},
+				rollId: uuid(),
+				rolls: [
+					{
+						diceNotation: {
+							set: convertedDice,
+							constant: constantsTotal
+						},
+						diceNotationStr: expression,
+						rollType: "roll",
+						rollKind: expression.includes("kh") ? "advantage" : expression.includes("kl") ? "disadvantage" : "",
+						result: {
+							constant: constantsTotal,
+							values: allValues,
+							total: roll.total,
+							text: convertedExpression.join("")
+						}
+					}
+				]
+			}
+		};
+
+		if (window.MB.ws.readyState == window.MB.ws.OPEN) {
+			window.MB.ws.send(JSON.stringify(ddbJson));
+			return true;
+		} else { // TRY TO RECOVER
+			get_cobalt_token(function(token) {
+				window.MB.loadWS(token, function() {
+					// TODO, CONSIDER ADDING A SYNCMEUP / SCENE PAIR HERE
+					window.MB.ws.send(JSON.stringify(ddbJson));
+				});
+			});
+			return true; // we can't guarantee that this actually worked, unfortunately
+		}
+	} catch (error) {
+		console.warn(`failed to send expression as DDB roll; expression = ${expression}`, error);
+		return false;
+	}
 }

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -187,8 +187,22 @@ class MessageBroker {
 							let li =$(this).closest("li");
 							let oldheight=li.height();
 							var newlihtml=self.convertChat(injection_data, current.data.player_name==window.PLAYER_NAME ).html();
-							if(newlihtml=="")
+							if(newlihtml=="") {
 								li.css("display","none"); // THIS IS TO HIDE DMONLY STUFF
+							} else if (injection_data.dmonly && window.DM) { 
+								// ADD THE "Send To Player Buttons"
+								let currentMessage = $(`<div></div>`).append(newlihtml);
+								let timeWrapper = $(`<div style="width:100%;"></div>`); // move time into a wrapper object so we can flex it horizontally with our new button
+								currentMessage.find(".GameLogEntry_MessageContainer__RhcYB").append(timeWrapper);
+								let sendToEveryone = $(`<button class="gamelog-to-everyone-button">Send To Everyone</button>`);
+								timeWrapper.append(sendToEveryone)
+								var time = currentMessage.find(".GameLogEntry_MessageContainer__RhcYB > time");
+								if (time.length > 0) {
+									timeWrapper.append(time);
+									time.css("float", "right")
+								}
+								newlihtml = currentMessage.html();
+							}
 								
 							li.animate({ opacity: 0 }, 250, function() {
 								li.html(newlihtml);
@@ -196,18 +210,7 @@ class MessageBroker {
 								li.height(oldheight);
 								li.animate({ opacity: 1, height: neweight }, 250, () => { li.height("") });
 								li.find(".magnify").magnificPopup({type: 'image', closeOnContentClick: true });
-
-								if (injection_data.dmonly && window.DM) { // ADD THE "Send To Player Buttons"
-									let btn = $("<button>Show to Players</button>")
-									li.append(btn);
-									btn.click(() => {
-										li.css("display", "none");
-										delete injection_data.dmonly;
-										self.inject_chat(injection_data); // RESEND THE MESSAGE REMOVING THE "injection only"
-									});
-								}
 							});
-							
 							
 						}
 					});
@@ -1061,3 +1064,44 @@ class MessageBroker {
 
 }
 
+function monitor_messages() {
+	$(".GameLog_GameLogEntries__3oNPD").on("DOMNodeInserted", function(addedEvent) {
+		// currentTarget is the <ol> that contains every message
+		// target is the <li> that represents the current message
+		let currentMessage = $(addedEvent.target);
+		if (currentMessage.find(".DiceMessage_Target__18rOt").text().includes("Self")) {
+			let timeWrapper = $(`<div style="width:100%;"></div>`); // move time into a wrapper object so we can flex it horizontally with our new button
+			currentMessage.find(".GameLogEntry_MessageContainer__RhcYB").append(timeWrapper);
+			let sendToEveryone = $(`<button class="gamelog-to-everyone-button">Send To Everyone</button>`);
+			timeWrapper.append(sendToEveryone)
+			var time = currentMessage.find(".GameLogEntry_MessageContainer__RhcYB > time");
+			if (time.length > 0) {
+				timeWrapper.append(time);
+				time.css("float", "right")
+			}
+			let toEveryoneHtml = currentMessage.find(".DiceMessage_Container__1rmut")[0].outerHTML;
+			sendToEveryone.click(function(clickEvent) {
+				// we want to send the expanded version so we have the click handler here and stopPropogation so that the on("click") below doesn't also fire. 
+				// The other handler will send the current html which could be the collapsed version. Since the collapse mechanism won't work in this situation, let's always send the expanded version
+				clickEvent.stopPropagation();
+				data = {
+					player: window.PLAYER_NAME,
+					img: window.PLAYER_IMG,
+					text: toEveryoneHtml,
+					dmonly: false,
+				};
+				window.MB.inject_chat(data);	
+			});
+		}
+	});
+	$(".GameLog_GameLogEntries__3oNPD").on("click", ".gamelog-to-everyone-button", function(clickEvent) {
+		let toEveryoneHtml = $(clickEvent.currentTarget).closest(".GameLogEntry_MessageContainer__RhcYB").find(".GameLogEntry_Message__1J8lC").html();
+		data = {
+			player: window.PLAYER_NAME,
+			img: window.PLAYER_IMG,
+			text: toEveryoneHtml,
+			dmonly: false,
+		};
+		window.MB.inject_chat(data);
+	});
+}

--- a/MonsterDice.js
+++ b/MonsterDice.js
@@ -64,6 +64,10 @@ function scan_monster(target, stats) {
 
 		expression = dice + mod;
 		console.log(expression);
+		let sentAsDDB = send_rpg_dice_to_ddb(expression);
+		if (sentAsDDB) {
+			return;
+		}
 		roll = new rpgDiceRoller.DiceRoll(expression);
 
 		let output_beauty = roll.output.replace(/=(.*)/, "= <b>$1</b>")

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -70,6 +70,31 @@ body > button:hover,
     background: #e6e6e6;
 }
 
+.custom-gamelog-message {
+    width: 100%;
+    font-size: 14px;
+    font-family: Roboto,Helvetica,sans-serif;
+    font-weight: 400;
+}
+button.gamelog-to-everyone-button {
+    background-color: rgb(255, 255, 255);
+    border-top: none;
+    border-right: 1px solid rgb(206, 217, 224);
+    border-bottom: 1px solid rgb(206, 217, 224);
+    border-left: 1px solid rgb(206, 217, 224);
+    border-image: initial;
+    border-radius: 0px 0px 4px 4px;
+    padding: 4px 10px;
+    text-transform: uppercase;
+    font-family: "Roboto Condensed", "Arial Narrow", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 0.7rem;
+    line-height: 16px;
+    letter-spacing: 0.4px;
+    color: #5c7080;
+}
+
 .material-icons.md-10 { font-size: 10px; }
 .material-icons.md-12 { font-size: 12px; }
 .material-icons.md-16 { font-size: 16px; }


### PR DESCRIPTION
This attempts to parse rpgDiceRolls to DDB format before sending them over the websocket. If the parsing fails for any reason or if the expression is too complex, it falls back to the old way.
![avtt-rpgDiceRoll-to-ddb-format](https://user-images.githubusercontent.com/584771/147834617-e02e7204-1ce2-4309-822f-2db384b441c0.gif)



I've also started injecting a "Send to Everyone" button into gamelog messages that were sent "TO: Self". This works for our rolls as well as for DDB dice rolls. The following gif shows an  rpgDiceRoll followed by two DDB rolls from the mobile app. The first is "to self" and the second is "to everyone" to show that it doesn't inject the button for those rolls.
![avtt-gamelog-send-to-everyone](https://user-images.githubusercontent.com/584771/147880836-da7c34fa-9537-4694-a995-5c888e01a64a.gif)

