### PR TITLE
Fix chat log links being converted to images.

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1350,7 +1350,11 @@ function init_ui() {
 
 
 			if(validateUrl(text)){
-				text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
+        if (text.match(/\.(jpeg|jpg|gif|png)$/)) {
+          text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
+        } else {
+          text=`<a href=${text} target="_blank" rel="noopener noreferrer">${text}</a>`;
+        }
 			}
 
 			data = {

--- a/Main.js
+++ b/Main.js
@@ -1350,11 +1350,11 @@ function init_ui() {
 
 
 			if(validateUrl(text)){
-        if (text.match(/\.(jpeg|jpg|gif|png)$/)) {
-          text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
-        } else {
-          text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;
-        }
+				if (text.match(/\.(jpeg|jpg|gif|png)$/)) {
+					text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
+				} else {
+					text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;
+				}
 			}
 
 			data = {

--- a/Main.js
+++ b/Main.js
@@ -11,6 +11,24 @@ function parse_img(url){
 	return retval;
 }
 
+async function checkImage(url, callback){
+	var image = new Image();
+  image.onload = function() {
+    if (this.width > 0) {
+			console.log("Image!")
+      callback(true);
+    } else {
+			console.log("Width 0 not image!")
+			callback(false)
+		}
+  }
+  image.onerror = function() {
+		console.log("error not image!")
+    callback(false);
+  }
+  image.src = url;
+}
+
 function whenAvailable(name, callback) {
     var interval = 10; // ms
     window.setTimeout(function() {
@@ -1348,27 +1366,40 @@ function init_ui() {
 				text="<b> &#8594;"+whisper+"</b>&nbsp;" +matches[2];
 			}
 
-
-			if(validateUrl(text)){
-				if (text.match(/\.(jpeg|jpg|gif|png|webp|webm)$/)) {
+			sendLinkOrImage = (text, dmonly, whisper, isImg) => {
+				if (isImg) {
 					text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
 				} else {
 					text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;
 				}
+				data = {
+					player: window.PLAYER_NAME,
+					img: window.PLAYER_IMG,
+					text: text,
+					dmonly: dmonly,
+				};
+	
+				if(whisper)
+					data.whisper=whisper;
+	
+				window.MB.inject_chat(data);
 			}
 
-			data = {
-				player: window.PLAYER_NAME,
-				img: window.PLAYER_IMG,
-				text: text,
-				dmonly: dmonly,
-			};
-
-			if(whisper)
-				data.whisper=whisper;
-
-			window.MB.inject_chat(data);
-
+			if(validateUrl(text)){
+				checkImage(text, (isImg) => sendLinkOrImage(text, dmonly, whisper, isImg));
+			} else {
+				data = {
+					player: window.PLAYER_NAME,
+					img: window.PLAYER_IMG,
+					text: text,
+					dmonly: dmonly,
+				};
+	
+				if(whisper)
+					data.whisper=whisper;
+	
+				window.MB.inject_chat(data);
+			}
 		}
 
 	});

--- a/Main.js
+++ b/Main.js
@@ -1353,7 +1353,7 @@ function init_ui() {
         if (text.match(/\.(jpeg|jpg|gif|png)$/)) {
           text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
         } else {
-          text=`<a href=${text} target="_blank" rel="noopener noreferrer">${text}</a>`;
+          text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;
         }
 			}
 

--- a/Main.js
+++ b/Main.js
@@ -1350,7 +1350,7 @@ function init_ui() {
 
 
 			if(validateUrl(text)){
-				if (text.match(/\.(jpeg|jpg|gif|png)$/)) {
+				if (text.match(/\.(jpeg|jpg|gif|png|webp|webm)$/)) {
 					text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
 				} else {
 					text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;

--- a/Main.js
+++ b/Main.js
@@ -11,7 +11,7 @@ function parse_img(url){
 	return retval;
 }
 
-async function checkImage(url, callback){
+function checkImage(url, callback){
 	var image = new Image();
 	image.onload = function() {
 		if (this.width > 0) {

--- a/Main.js
+++ b/Main.js
@@ -13,17 +13,17 @@ function parse_img(url){
 
 async function checkImage(url, callback){
 	var image = new Image();
-  image.onload = function() {
-    if (this.width > 0) {
-      callback(true);
-    } else {
+	image.onload = function() {
+		if (this.width > 0) {
+			callback(true);
+		} else {
 			callback(false)
 		}
-  }
-  image.onerror = function() {
-    callback(false);
-  }
-  image.src = parse_img(url);
+	}
+	image.onerror = function() {
+		callback(false);
+	}
+	image.src = parse_img(url);
 }
 
 function whenAvailable(name, callback) {

--- a/Main.js
+++ b/Main.js
@@ -15,18 +15,15 @@ async function checkImage(url, callback){
 	var image = new Image();
   image.onload = function() {
     if (this.width > 0) {
-			console.log("Image!")
       callback(true);
     } else {
-			console.log("Width 0 not image!")
 			callback(false)
 		}
   }
   image.onerror = function() {
-		console.log("error not image!")
     callback(false);
   }
-  image.src = url;
+  image.src = parse_img(url);
 }
 
 function whenAvailable(name, callback) {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -928,7 +928,6 @@ class MessageBroker {
 		if (this.ws.readyState == this.ws.OPEN) {
 			this.ws.send(JSON.stringify(message));
 		}
-
 		this.handle_injected_data(message);
 
 	}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -928,6 +928,7 @@ class MessageBroker {
 		if (this.ws.readyState == this.ws.OPEN) {
 			this.ws.send(JSON.stringify(message));
 		}
+
 		this.handle_injected_data(message);
 
 	}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -710,7 +710,7 @@ class MessageBroker {
 		//Security logic to prevent content being sent which can execute JavaScript.
 		data.player = DOMPurify.sanitize( data.player,{ALLOWED_TAGS: []});
 		data.img = DOMPurify.sanitize( data.img,{ALLOWED_TAGS: []});
-		data.text = DOMPurify.sanitize( data.text,{ALLOWED_TAGS: ['img','div','p', 'b', 'button', 'span', 'style', 'path', 'svg']}); //This array needs to include all HTML elements the extension sends via chat.
+		data.text = DOMPurify.sanitize( data.text,{ALLOWED_TAGS: ['img','div','p', 'b', 'button', 'span', 'style', 'path', 'svg', 'a'], ADD_ATTR: ['target']}); //This array needs to include all HTML elements the extension sends via chat.
 
 		if(data.dmonly && !(window.DM) && !local) // /dmroll only for DM of or the user who initiated it
 			return $("<div/>");
@@ -928,7 +928,7 @@ class MessageBroker {
 		if (this.ws.readyState == this.ws.OPEN) {
 			this.ws.send(JSON.stringify(message));
 		}
-		
+
 		this.handle_injected_data(message);
 
 	}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1625,4 +1625,9 @@ body {
     width: 100%;
     align-items: center;
 }
+.chat-link {
+  word-wrap: break-word;
+  width: 100%;
+  text-decoration: underline;
+}
 


### PR DESCRIPTION
~The fix is generally pretty simple. After validating that a string is a URL before injecting it to chat, there was no handling for if  the string was a non-image url. I've added an additional bit of logic to determine whether the link is to an image or not, and generate an `<a>` tag instead of an `<img>` tag if it's not an image type.~

~I've included the most common image types in my additional logic, but if another needs to be accounted for, it's easy enough to add.~

I've gone with an alternative approach to the original. If a link is detected, we try to load an image tag with that link, if the image load succeeds, we create an image tag, otherwise we create an `<a>` tag.

Note: I'm using string interpolation to construct the `<a>` tag, I've not seen that much elsewhere in the code, so if there's some reason not to use that JS feature let me know and I'll remove it.