### PR TITLE
Image link async unfurling

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -26,27 +26,6 @@ function checkImage(url, callback){
 	image.src = parse_img(url);
 }
 
-function sendLinkOrImage(text, dmonly, whisper, isImg) {
-	let originalText = text;
-	if (isImg) {
-		text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
-	} else {
-		text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;
-	}
-	data = {
-		player: window.PLAYER_NAME,
-		img: window.PLAYER_IMG,
-		text: text,
-		dmonly: dmonly,
-		originalText: originalText
-	};
-
-	if(whisper)
-		data.whisper=whisper;
-
-	window.MB.inject_chat(data);
-}
-
 function whenAvailable(name, callback) {
     var interval = 10; // ms
     window.setTimeout(function() {
@@ -1457,22 +1436,20 @@ function init_ui() {
 				text="<b> &#8594;"+whisper+"</b>&nbsp;" +matches[2];
 			}
 
+			data = {
+				player: window.PLAYER_NAME,
+				img: window.PLAYER_IMG,
+				text: text,
+				dmonly: dmonly,
+			};
 			if(validateUrl(text)){
-				// checkImage(text, (isImg) => sendLinkOrImage(text, dmonly, whisper, isImg));
-				sendLinkOrImage(text, dmonly, whisper, false);
-			} else {
-				data = {
-					player: window.PLAYER_NAME,
-					img: window.PLAYER_IMG,
-					text: text,
-					dmonly: dmonly,
-				};
-	
-				if(whisper)
-					data.whisper=whisper;
-	
-				window.MB.inject_chat(data);
+				data.originalText = text;
+				data.text = `<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`
 			}
+			if(whisper)
+				data.whisper=whisper;
+
+			window.MB.inject_chat(data);
 		}
 
 	});

--- a/Main.js
+++ b/Main.js
@@ -11,21 +11,6 @@ function parse_img(url){
 	return retval;
 }
 
-function checkImage(url, callback){
-	var image = new Image();
-	image.onload = function() {
-		if (this.width > 0) {
-			callback(true);
-		} else {
-			callback(false)
-		}
-	}
-	image.onerror = function() {
-		callback(false);
-	}
-	image.src = parse_img(url);
-}
-
 function whenAvailable(name, callback) {
     var interval = 10; // ms
     window.setTimeout(function() {
@@ -36,7 +21,6 @@ function whenAvailable(name, callback) {
         }
     }, interval);
 }
-
 
 function getRandomColorOLD() {
 	var letters = '0123456789ABCDEF';
@@ -1444,7 +1428,10 @@ function init_ui() {
 			};
 			if(validateUrl(text)){
 				data.originalText = text;
-				data.text = `<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`
+				data.text = `
+					<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>
+					<img width=200 class='magnify' href='${parse_img(text)}' src='${parse_img(text)}' alt='Chat Image' style='display: none'/>
+				`
 			}
 			if(whisper)
 				data.whisper=whisper;

--- a/Main.js
+++ b/Main.js
@@ -1427,7 +1427,6 @@ function init_ui() {
 				dmonly: dmonly,
 			};
 			if(validateUrl(text)){
-				data.originalText = text;
 				data.text = `
 					<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>
 					<img width=200 class='magnify' href='${parse_img(text)}' src='${parse_img(text)}' alt='Chat Image' style='display: none'/>

--- a/Main.js
+++ b/Main.js
@@ -26,6 +26,27 @@ function checkImage(url, callback){
 	image.src = parse_img(url);
 }
 
+function sendLinkOrImage(text, dmonly, whisper, isImg) {
+	let originalText = text;
+	if (isImg) {
+		text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
+	} else {
+		text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;
+	}
+	data = {
+		player: window.PLAYER_NAME,
+		img: window.PLAYER_IMG,
+		text: text,
+		dmonly: dmonly,
+		originalText: originalText
+	};
+
+	if(whisper)
+		data.whisper=whisper;
+
+	window.MB.inject_chat(data);
+}
+
 function whenAvailable(name, callback) {
     var interval = 10; // ms
     window.setTimeout(function() {
@@ -1436,27 +1457,9 @@ function init_ui() {
 				text="<b> &#8594;"+whisper+"</b>&nbsp;" +matches[2];
 			}
 
-			sendLinkOrImage = (text, dmonly, whisper, isImg) => {
-				if (isImg) {
-					text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
-				} else {
-					text=`<a class='chat-link' href=${text} target='_blank' rel='noopener noreferrer'>${text}</a>`;
-				}
-				data = {
-					player: window.PLAYER_NAME,
-					img: window.PLAYER_IMG,
-					text: text,
-					dmonly: dmonly,
-				};
-	
-				if(whisper)
-					data.whisper=whisper;
-	
-				window.MB.inject_chat(data);
-			}
-
 			if(validateUrl(text)){
-				checkImage(text, (isImg) => sendLinkOrImage(text, dmonly, whisper, isImg));
+				// checkImage(text, (isImg) => sendLinkOrImage(text, dmonly, whisper, isImg));
+				sendLinkOrImage(text, dmonly, whisper, false);
 			} else {
 				data = {
 					player: window.PLAYER_NAME,

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -196,7 +196,10 @@ class MessageBroker {
 								text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
 								self.postChatMessage(element, {...injection_data, text}, current);
 							};
-							checkImage(injection_data.originalText ?? injection_data.text, (isImg) => postImage(isImg, li, injection_data, current));
+							// originalText will only be set if the text was converted into a link.
+							if (injection_data.originalText != null) {
+								checkImage(injection_data.originalText, (isImg) => postImage(isImg, li, injection_data, current));
+							}
 						}
 					});
 					if(!found){

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -188,17 +188,16 @@ class MessageBroker {
 							// post the chat message as is
 							self.postChatMessage(li, injection_data, current);
 							// if the chat message is a link, check if it's a valid image link
-							// use a callback that calls postChatMessage to the same element with the updated injection data
-							let postImage = (isImg, element, injection_data, current) => {
-								if (!isImg) return;
-
-								let text = injection_data.originalText ?? injection_data.text;
-								text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
-								self.postChatMessage(element, {...injection_data, text}, current);
-							};
 							// originalText will only be set if the text was converted into a link.
 							if (injection_data.originalText != null) {
-								checkImage(injection_data.originalText, (isImg) => postImage(isImg, li, injection_data, current));
+								// use a callback that calls postChatMessage to the same element with the updated injection data
+								checkImage(injection_data.originalText, (isImg) => {
+									if (!isImg) return;
+	
+									let text = injection_data.originalText ?? injection_data.text;
+									text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
+									self.postChatMessage(li, {...injection_data, text}, current);
+								});
 							}
 						}
 					});

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -185,8 +185,39 @@ class MessageBroker {
 							found=true;
 							console.log("TROVATOOOOOOOOOOOOOOOOO");
 							let li = $(this).closest("li");
-							// post the chat message as is
-							self.postChatMessage(li, injection_data, current);
+							let oldheight=li.height();
+							var newlihtml=self.convertChat(injection_data, current.data.player_name==window.PLAYER_NAME ).html();
+							if(newlihtml=="")
+								li.css("display","none"); // THIS IS TO HIDE DMONLY STUFF
+								
+							li.animate({ opacity: 0 }, 250, function() {
+								li.html(newlihtml);
+								let neweight = li.height();
+								li.height(oldheight);
+								li.animate({ opacity: 1, height: neweight }, 250, () => { li.height("") });
+
+								let img = li.find(".magnify");
+								img.magnificPopup({type: 'image', closeOnContentClick: true });
+
+								if (img[0]) {
+									img[0].onload = () => {
+										if (img[0].naturalWidth > 0) {
+											li.find('.chat-link')[0].style.display = 'none';
+											img[0].style.display = 'block';
+										}
+									}
+								}
+
+								if (injection_data.dmonly && window.DM) { // ADD THE "Send To Player Buttons"
+									let btn = $("<button>Show to Players</button>")
+									li.append(btn);
+									btn.click(() => {
+										li.css("display", "none");
+										delete injection_data.dmonly;
+										self.inject_chat(injection_data); // RESEND THE MESSAGE REMOVING THE "injection only"
+									});
+								}
+							});
 						}
 					});
 					if(!found){
@@ -208,37 +239,7 @@ class MessageBroker {
 
 	postChatMessage(li, injection_data, current) {
 		let self = this;
-		let oldheight=li.height();
-		var newlihtml=self.convertChat(injection_data, current.data.player_name==window.PLAYER_NAME ).html();
-		if(newlihtml=="")
-			li.css("display","none"); // THIS IS TO HIDE DMONLY STUFF
-			
-		li.animate({ opacity: 0 }, 250, function() {
-			li.html(newlihtml);
-			let neweight = li.height();
-			li.height(oldheight);
-			li.animate({ opacity: 1, height: neweight }, 250, () => { li.height("") });
-			let img = li.find(".magnify");
-			if (img) {
-				img[0].onload = () => {
-					if (img[0].naturalWidth > 0) {
-						img.magnificPopup({type: 'image', closeOnContentClick: true });
-						li.find('.chat-link')[0].style.display = 'none';
-						img[0].style.display = 'block';
-					}
-				}
-			}
-
-			if (injection_data.dmonly && window.DM) { // ADD THE "Send To Player Buttons"
-				let btn = $("<button>Show to Players</button>")
-				li.append(btn);
-				btn.click(() => {
-					li.css("display", "none");
-					delete injection_data.dmonly;
-					self.inject_chat(injection_data); // RESEND THE MESSAGE REMOVING THE "injection only"
-				});
-			}
-		});
+		
 	}
 
 	constructor() {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -216,8 +216,6 @@ class MessageBroker {
 		}
 	}
 
-	
-
 	postChatMessage(li, injection_data, current) {
 		let self = this;
 		let oldheight=li.height();

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -237,11 +237,6 @@ class MessageBroker {
 		}
 	}
 
-	postChatMessage(li, injection_data, current) {
-		let self = this;
-		
-	}
-
 	constructor() {
 		var self = this;
 		

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -187,18 +187,6 @@ class MessageBroker {
 							let li = $(this).closest("li");
 							// post the chat message as is
 							self.postChatMessage(li, injection_data, current);
-							// if the chat message is a link, check if it's a valid image link
-							// originalText will only be set if the text was converted into a link.
-							if (injection_data.originalText != null) {
-								// use a callback that calls postChatMessage to the same element with the updated injection data
-								checkImage(injection_data.originalText, (isImg) => {
-									if (!isImg) return;
-	
-									let text = injection_data.originalText ?? injection_data.text;
-									text="<img width=200 class='magnify' href=" + parse_img(text) + " src='" + parse_img(text) + "' alt='Chat Image'>";
-									self.postChatMessage(li, {...injection_data, text}, current);
-								});
-							}
 						}
 					});
 					if(!found){
@@ -230,7 +218,16 @@ class MessageBroker {
 			let neweight = li.height();
 			li.height(oldheight);
 			li.animate({ opacity: 1, height: neweight }, 250, () => { li.height("") });
-			li.find(".magnify").magnificPopup({type: 'image', closeOnContentClick: true });
+			let img = li.find(".magnify");
+			if (img) {
+				img[0].onload = () => {
+					if (img[0].naturalWidth > 0) {
+						img.magnificPopup({type: 'image', closeOnContentClick: true });
+						li.find('.chat-link')[0].style.display = 'none';
+						img[0].style.display = 'block';
+					}
+				}
+			}
 
 			if (injection_data.dmonly && window.DM) { // ADD THE "Send To Player Buttons"
 				let btn = $("<button>Show to Players</button>")

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -174,7 +174,7 @@ class MessageBroker {
 				for(var i=0;i<pend_length;i++){
 					var current=self.chat_pending_messages.shift();
 					
-					var injection_id=data.messageId ?? current.data.rolls[0].rollType;
+					var injection_id=current.data.rolls[0].rollType;
 					var injection_data=current.data.injected_data;
 					console.log(injection_id);
 					console.log(injection_data);
@@ -183,8 +183,8 @@ class MessageBroker {
 					$(".DiceMessage_RollType__wlBsW").each(function(){
 						if($(this).text()==injection_id){
 							found=true;
-							console.log("TROVATOOOOOOOOOOOOOOOOO");
 							let li = $(this).closest("li");
+							console.log("TROVATOOOOOOOOOOOOOOOOO");
 							let oldheight=li.height();
 							var newlihtml=self.convertChat(injection_data, current.data.player_name==window.PLAYER_NAME ).html();
 							if(newlihtml=="")


### PR DESCRIPTION
This PR further improves image handling in chat by initially posting the image link to the chat, then replacing it with the image if the image can be loaded. If the image can't be loaded, or the link doesn't point to an image, the link stays in place.

This ensures that the chat messages will maintain their order even if messages are being posted very quickly or the load time for an image is very long. This should also be more efficient since we're loading the image once and not loading a separate image in memory before creating the image tag (which would cause us to have to load the image twice).