### PR TITLE
A few minor scenes handler changes which "shouldn't" interfere

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -191,6 +191,34 @@ function edit_scene_dialog(scene_id) {
 	if (typeof scene.fog_of_war == "undefined")
 		scene.fog_of_war = "1";
 
+	var dupe_button = $("<button>Duplicate Scene</button>");
+
+	dupe_button.click(function() {
+		f.find("input").each(function() {
+			var n = $(this).attr('name');
+			let nValue = $(this).val();
+
+			if ( ((n === 'player_map') || (n==='dm_map'))   
+					&& nValue.startsWith("https://drive.google.com")
+					&& nValue.indexOf("uc?id=") < 0
+			) {
+				nValue = 'https://drive.google.com/uc?id=' + nValue.split('/')[5];
+			}
+
+			scene[n] = nValue;
+			console.log('setto ' + n + ' a ' + $(this).val());
+		});
+		
+		window.ScenesHandler.scenes.push(JSON.parse(JSON.stringify(scene)))
+		window.ScenesHandler.persist();
+		$("#edit_dialog").remove();
+		$("#scene_selector").removeAttr("disabled");
+		$("#scene_selector_toggle").click();
+		$("#scene_selector_toggle").click();// Reopen?
+
+		//path = scene.folderpath; //Go to the 'folder' of this scene
+	});
+
 	var save_button = $("<button>Save</button>");
 
 	save_button.click(function() {
@@ -217,7 +245,7 @@ function edit_scene_dialog(scene_id) {
 		$("#scene_selector_toggle").click();
 		$("#scene_selector_toggle").click();// Reopen on just save?
 
-		path = scene.folderpath; //Go to the 'folder' of this scene
+		//path = scene.folderpath; //Go to the 'folder' of this scene
 	});
 
 	var sub = $("<button>Save And Switch</button>");
@@ -742,6 +770,7 @@ function edit_scene_dialog(scene_id) {
 
 	f.append(sub);
 	f.append(save_button);
+	f.append(dupe_button)
 	f.append(cancel);
 	f.append(hide_all_button);
 	//		f.append(export_grid);

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -191,6 +191,34 @@ function edit_scene_dialog(scene_id) {
 	if (typeof scene.fog_of_war == "undefined")
 		scene.fog_of_war = "1";
 
+	var save_button = $("<button>Save</button>");
+
+	save_button.click(function() {
+		f.find("input").each(function() {
+			var n = $(this).attr('name');
+			let nValue = $(this).val();
+
+			if ( ((n === 'player_map') || (n==='dm_map'))   
+					&& nValue.startsWith("https://drive.google.com")
+					&& nValue.indexOf("uc?id=") < 0
+			) {
+				nValue = 'https://drive.google.com/uc?id=' + nValue.split('/')[5];
+			}
+
+			scene[n] = nValue;
+			console.log('setto ' + n + ' a ' + $(this).val());
+		});
+		window.ScenesHandler.persist();
+		if (window.ScenesHandler.current_scene_id == scene_id){
+			window.ScenesHandler.switch_scene(scene_id);
+		}
+		$("#edit_dialog").remove();
+		$("#scene_selector").removeAttr("disabled");
+		$("#scene_selector_toggle").click();
+		$("#scene_selector_toggle").click();// Reopen on just save?
+
+		path = scene.folderpath; //Go to the 'folder' of this scene
+	});
 
 	var sub = $("<button>Save And Switch</button>");
 
@@ -713,6 +741,7 @@ function edit_scene_dialog(scene_id) {
 
 
 	f.append(sub);
+	f.append(save_button);
 	f.append(cancel);
 	f.append(hide_all_button);
 	//		f.append(export_grid);
@@ -737,8 +766,8 @@ function refresh_scenes() {
 		var scene = window.ScenesHandler.scenes[i];
 		var newobj = $("<div class='scene' data-scene-index='"+i+"'/>");
 
-
-		title = $("<div class='scene_title' style='text-align:center;'/>");
+		// Adds a background to the title of the scene... this looks okay, but could be tricky ensuring the text actually shows up on every map.
+		title = $("<div class='scene_title' style='text-align:center; background:url("+scene.player_map+"); background-size: cover;' />"); 
 		title.html(scene.title);
 
 		if (i == window.ScenesHandler.current_scene_id)

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -228,7 +228,14 @@ function edit_scene_dialog(scene_id) {
 	save_button.click(function() {
 		f.find("input").each(function() {
 			var n = $(this).attr('name');
-			let nValue = $(this).val();
+			var t = $(this).attr('type');
+			let nValue = null;
+			if (t == "checkbox") {
+				nValue = $(this).prop("checked") ? "1" : "0";
+			}
+			else {
+				nValue = $(this).val();
+			}
 
 			if ( ((n === 'player_map') || (n==='dm_map'))   
 					&& nValue.startsWith("https://drive.google.com")

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -208,8 +208,12 @@ function edit_scene_dialog(scene_id) {
 			scene[n] = nValue;
 			console.log('setto ' + n + ' a ' + $(this).val());
 		});
-		
-		window.ScenesHandler.scenes.push(JSON.parse(JSON.stringify(scene)))
+		//copy the scene token and all 
+		duped_scene = JSON.parse(JSON.stringify(scene))
+		//make a new unique id. 
+		duped_scene.id = uuid()
+		duped_scene.title += ' (Duplicated)'
+		window.ScenesHandler.scenes.push(duped_scene)
 		window.ScenesHandler.persist();
 		$("#edit_dialog").remove();
 		$("#scene_selector").removeAttr("disabled");

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -366,7 +366,8 @@ div#scene_properties form > div {
 
 #scene_selector .scene_title {
     cursor: move;
-    font-weight: bold;
+    text-shadow: 0px 0px 5px rgb(0, 0, 0);
+    -webkit-text-stroke: 1px rgb(255, 255, 255);
 }
 
 .active_scene {


### PR DESCRIPTION
This is a couple minor changes to the scenes handler which should not interfere with the other work. But serve as a nice QoL  change which should hold people over until the full scenes rework. 

Adds the background image to the scene's dropdown.

<img width="804" alt="Screen Shot 2022-01-03 at 1 21 13 PM" src="https://user-images.githubusercontent.com/95775779/147965500-24feb940-17ab-46d1-9e1c-eaa0093cf73d.png">

It also adds a normal save button (which acts as a normal save+switch if on current scene)

<img width="1017" alt="Screen Shot 2022-01-03 at 1 21 39 PM" src="https://user-images.githubusercontent.com/95775779/147965501-69d1897f-074e-4f73-b0c3-4601320d31ac.png">

