### PR TITLE
Add a menu for group roll

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -105,6 +105,7 @@ function init_combat_tracker(){
 			}
 			next.attr('data-current','1');
 		}
+		
 		ct_persist();
 		//var target=$("#combat_area tr[data-current=1]").attr('data-target');
 	});
@@ -174,123 +175,130 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	entry=$("<tr/>");
 	entry.css("height","30px");
 	entry.attr("data-target",token.options.id);	
+	entry.attr("ishidden", token.options.hidden);
 	entry.addClass("CTToken");
-	
-	if ((token.options.name) && (window.DM || !token.options.monster || token.options.revealname)) {
-		entry.attr("data-name", token.options.name);
-		entry.addClass("hasTooltip");
-	}
-
-	if(token.options.monster > 0)
-		entry.attr('data-monster',token.options.monster);
-	
-	img=$("<img width=35 height=35 class='Avatar_AvatarPortrait__2dP8u'>");
-	img.attr('src',token.options.imgsrc);
-	img.css('border','3px solid '+token.options.color);
-	
-	entry.append($("<td/>").append(img));
-	let init=$("<input class='init' maxlength=2 style='font-size:12px;'>");
-	init.css('width','20px');
-	init.css('-webkit-appearance','none');
-	if(window.DM){
-		init.val(0);
-		init.change(ct_reorder);
-	}
-	else{
-		init.attr("disabled","disabled");
-	}
-	entry.append($("<td/>").append(init));
-	
-	// auto roll initiative for monsters
-	
-	if(window.DM && (token.options.monster > 0) && (!disablerolling)){
-		window.StatHandler.rollInit(token.options.monster,function(value){
-				init.val(value);
-				setTimeout(ct_reorder,1000);
-			});
-	}
-	
-	
-	
-	hp=$("<div class='hp'/>");
-	hp.text(token.options.hp);
-	
-	hp.css('font-size','11px');
-	//hp.css('width','20px');
-	if(window.DM || !(token.options.monster > 0) )
-		entry.append($("<td/>").append(hp));
-	else
-		entry.append($("<td/>"))
-	max_hp=$("<div/>");
-	max_hp.text("/"+token.options.max_hp);
-	max_hp.css('font-size','11px');
-	//max_hp.css('width','20px');
-	if(window.DM || !(token.options.monster > 0) )
-		entry.append($("<td/>").append(max_hp));
-	else
-		entry.append($("<td/>"));
-	
-	
-	var buttons=$("<td/>");
-	
-	
-	find=$("<button style='font-size:10px;'>FIND</button>");
-	find.click(function(){
-		var target=$(this).parent().parent().attr('data-target');
-		if(target in window.TOKEN_OBJECTS){
-			window.TOKEN_OBJECTS[target].highlight();
+	if (token.options.hidden != true || window.DM){
+		if ((token.options.name) && (window.DM || !token.options.monster || token.options.revealname)) {
+			entry.attr("data-name", token.options.name);
+			entry.addClass("hasTooltip");
 		}
-	});
-	
-	
-	buttons.append(find);
-	
-	del=$("<button style='font-size:10px;'>DEL</button>");
-	del.click(
-		function(){
-			if($(this).parent().parent().attr("data-current")=="1"){
-				$("#combat_next_button").click();
+
+		if(token.options.monster > 0)
+			entry.attr('data-monster',token.options.monster);
+		
+		img=$("<img width=35 height=35 class='Avatar_AvatarPortrait__2dP8u'>");
+		img.attr('src',token.options.imgsrc);
+		img.css('border','3px solid '+token.options.color);
+		if (token.options.hidden == true){
+			img.css('opacity','0.5');
+		}
+		
+		entry.append(img);
+
+		entry.append($("<td/>").append(img));
+		let init=$("<input class='init' maxlength=2 style='font-size:12px;'>");
+		init.css('width','20px');
+		init.css('-webkit-appearance','none');
+		if(window.DM){
+			init.val(0);
+			init.change(ct_reorder);
+		}
+		else{
+			init.attr("disabled","disabled");
+		}
+		entry.append($("<td/>").append(init));
+		
+		// auto roll initiative for monsters
+		
+		if(window.DM && (token.options.monster > 0) && (!disablerolling)){
+			window.StatHandler.rollInit(token.options.monster,function(value){
+					init.val(value);
+					setTimeout(ct_reorder,1000);
+				});
+		}
+		
+		
+		
+		hp=$("<div class='hp'/>");
+		hp.text(token.options.hp);
+		
+		hp.css('font-size','11px');
+		//hp.css('width','20px');
+		if(window.DM || !(token.options.monster > 0) )
+			entry.append($("<td/>").append(hp));
+		else
+			entry.append($("<td/>"))
+		max_hp=$("<div/>");
+		max_hp.text("/"+token.options.max_hp);
+		max_hp.css('font-size','11px');
+		//max_hp.css('width','20px');
+		if(window.DM || !(token.options.monster > 0) )
+			entry.append($("<td/>").append(max_hp));
+		else
+			entry.append($("<td/>"));
+		
+		
+		var buttons=$("<td/>");
+		
+		
+		find=$("<button style='font-size:10px;'>FIND</button>");
+		find.click(function(){
+			var target=$(this).parent().parent().attr('data-target');
+			if(target in window.TOKEN_OBJECTS){
+				window.TOKEN_OBJECTS[target].highlight();
 			}
-			$(this).parent().parent().remove();
+		});
+		
+		
+		buttons.append(find);
+		
+		del=$("<button style='font-size:10px;'>DEL</button>");
+		del.click(
+			function(){
+				if($(this).parent().parent().attr("data-current")=="1"){
+					$("#combat_next_button").click();
+				}
+				$(this).parent().parent().remove();
+				ct_persist();
+			}
+		);
+		if(window.DM)
+			buttons.append(del);
+		
+		if(token.options.monster > 0){
+			stat=$("<button style='font-size:10px;'>STAT</button>");
+			
+			stat.click(function(){
+				iframe_id="#iframe-monster-"+token.options.monster;
+				if($(iframe_id).is(":visible"))
+					$(iframe_id).hide();
+				else{
+					$(".monster_frame").hide();
+					load_monster_stat(token.options.monster);
+					}
+			});
+			if(window.DM)
+				buttons.append(stat);
+			
+		}	
+		else{
+			stat=$("<button style='font-size:10px;'>STAT</button>");
+			stat.click(function(){
+				open_player_sheet(token.options.id);
+			});
+			if(window.DM)
+				buttons.append(stat);
+		}
+		
+			entry.append(buttons);
+		
+		
+		$("#combat_area").append(entry);
+		$("#combat_area td").css("vertical-align","middle");
+		
+		if(persist){
 			ct_persist();
 		}
-	);
-	if(window.DM)
-		buttons.append(del);
-	
-	if(token.options.monster > 0){
-		stat=$("<button style='font-size:10px;'>STAT</button>");
-		
-		stat.click(function(){
-			iframe_id="#iframe-monster-"+token.options.monster;
-			if($(iframe_id).is(":visible"))
-				$(iframe_id).hide();
-			else{
-				$(".monster_frame").hide();
-				load_monster_stat(token.options.monster);
-				}
-		});
-		if(window.DM)
-			buttons.append(stat);
-		
-	}	
-	else{
-		stat=$("<button style='font-size:10px;'>STAT</button>");
-		stat.click(function(){
-			open_player_sheet(token.options.id);
-		});
-		if(window.DM)
-			buttons.append(stat);
-	}
-	
-		entry.append(buttons);
-	
-	
-	$("#combat_area").append(entry);
-	$("#combat_area td").css("vertical-align","middle");
-	
-	if(persist){
-		ct_persist();
 	}
 }
 

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -319,7 +319,6 @@ function display_monster_customization_modal(placedToken, monsterId, monsterName
 	}
 }
 
-
 function build_monster_customization_item(monsterId, monsterName, imageUrl, customImgIndex, placedToken) {
 	let tokenDiv = build_custom_token_item(monsterName, imageUrl, undefined, customImgIndex, placedToken);
 	tokenDiv.attr("data-monster", monsterId);

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -96,6 +96,58 @@ function init_monster_panel() {
 				button.attr('data-hp', stat.data.averageHitPoints);
 				button.attr('data-maxhp', stat.data.averageHitPoints);
 				button.attr('data-ac', stat.data.armorClass);
+							
+				console.log(stat.data);
+
+				// determine the Proficiency bonus, based on CR -> actually CR ID which has 0, 1/8, 1/4, 1/2, 1, 2, ...etc
+				//console.log(stat.data.challengeRatingId)
+				CR = stat.data.challengeRatingId;
+				switch (true) {
+					case CR >= 34://CR 29
+						prof = 9;
+						break;
+					case CR >= 30://CR 25 
+						prof = 8;
+						break;
+					case CR >= 25://CR 21
+						prof = 7;
+						break;
+					case CR >= 21://CR 17
+						prof = 6;
+						break;
+					case CR >= 17://CR 13
+						prof = 5;
+						break;
+					case CR >= 13://CR 9 
+						prof = 4;
+						break;
+					case CR >= 9://CR 5
+						prof = 3;
+						break;
+					case CR <= 8://CR <4 
+						prof = 2;
+						break;
+				}
+				button.attr('data-prof-bonus', prof);
+
+				//Data for Rolls 
+				console.log(stat.data.stats[0])
+
+				button.attr('data-ability-scores', stat.data.stats)
+				button.attr('data-saving-throws', stat.data.savingThrows)
+
+				for (let x of stat.data.stats){
+					button.attr(`data-ability-${[x.statId]}`, x.value);
+				}
+				for (let y of stat.data.savingThrows){
+					button.attr(`data-save-${[y.statId]}`, y.value);
+				}
+
+				console.log(button.attr('data-ability-1'))
+				// Damage mods could be added, but will require determining each of DDB's index values for different damage types. Tedious.
+				//options.damage_vul = stat.data.damage_vul
+				//options.damge_resist = stat.data.damge_resist
+				//
 				token_button(e);
 			});
 
@@ -447,6 +499,58 @@ function place_monster_at_point(htmlElement, monsterId, name, imgSrc, tokenSize,
 			options.hp = stat.data.averageHitPoints;
 			options.max_hp = stat.data.averageHitPoints;
 			options.ac = stat.data.armorClass;
+						//Data for Rolls  
+
+			// determine the Proficiency bonus, based on CR -> actually CR ID which has 0, 1/8, 1/4, 1/2, 1, 2, ...etc
+			console.log(stat.data.challengeRatingId)
+			CR = stat.data.challengeRatingId;
+			switch (true) {
+				case CR >= 34://CR 29
+					prof = 9;
+					break;
+				case CR >= 30://CR 25 
+					prof = 8;
+					break;
+				case CR >= 25://CR 21
+					prof = 7;
+					break;
+				case CR >= 21://CR 17
+					prof = 6;
+					break;
+				case CR >= 17://CR 13
+					prof = 5;
+					break;
+				case CR >= 13://CR 9 
+					prof = 4;
+					break;
+				case CR >= 9://CR 5
+					prof = 3;
+					break;
+				case CR <= 8://CR <4 
+					prof = 2;
+					break;
+			}
+			options.prof_bonus = prof;
+
+			options.ability_scores = [];
+			for (let x of stat.data.stats){
+				console.log(x.statId)
+				console.log(x.value)
+				options.ability_scores[x.statId] = x.value;
+			}
+			options.saving_throws = [];
+			for (let y of stat.data.savingThrows){
+				console.log(y.statId)
+				console.log(y.value)
+				options.saving_throws[y.statId] = prof
+			}
+
+			// Damage mods could be added, but will require determining each of DDB's index values for different damage types. Tedious.
+			//options.damage_vul = stat.data.damage_vul
+			//options.damge_resist = stat.data.damge_resist
+			//
+
+
 			if (eventPageX == undefined || eventPageY == undefined) {
 				place_token_in_center_of_map(options);
 			} else {

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -257,9 +257,6 @@ function get_higher_res_url(thumbnailUrl) {
 	return thumbnailUrl.replace(/\/thumbnails(\/\d+\/\d+\/)\d+\/\d+\//, '$1');
 }
 
-
-
-
 function read_player_token_customizations() {
 	let customMappingData = localStorage.getItem('PlayerTokenCustomization');
 	if (customMappingData !== undefined && customMappingData != null) {

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -431,8 +431,18 @@ function place_player_token(playerId, hidden, specificImage, eventPageX, eventPa
 		disableborder: window.TOKEN_SETTINGS['disableborder'],
 		legacyaspectratio: window.TOKEN_SETTINGS['legacyaspectratio'],
 		disablestat: window.TOKEN_SETTINGS['disablestat'],
-		color: "#" + get_player_token_border_color(pc.sheet)
+		color: "#" + get_player_token_border_color(pc.sheet),
+		//Doing this the long way because no looping
+		
+		strength_save: playerData.abilities[0]['save'],
+		dexterity_save: playerData.abilities[1]['save'],
+		constitution_save: playerData.abilities[2]['save'],
+		intelligence_save: playerData.abilities[3]['save'],
+		wisdom_save: playerData.abilities[4]['save'],
+		charisma_save: playerData.abilities[5]['save'],
+		
 	};
+	
 
 	if (specificImage !== undefined) {
 		options.imgsrc = parse_img(specificImage);

--- a/Token.js
+++ b/Token.js
@@ -2777,17 +2777,32 @@ function open_roll_menu(e) {
 				if (save_dc != "undefined"){
 					if (parseInt(rolled_value) >= parseInt(save_dc)){
 						x.options.hp -= half_damage_save_success
+						damage = half_damage_save_success
 					}
 					else {
 						x.options.hp -= damage_failed_save
+						damage = damage_failed_save
 					}
 				}
 				//if not defined apply full damage.
 				else {
 					x.options.hp -= damage_failed_save
+					damage = damage_failed_save
 				}
-				x.place()
-				update_hp.text(x.options.hp);
+				if(x.options.monster > 0){
+					x.place()
+					update_hp.text(x.options.hp);
+				}
+				else {
+					// doing it this way, because Players might also have resistances or abilites and they should manage their own HP. 
+					var msgdata = {
+						player: window.PLAYER_NAME,
+						img: window.PLAYER_IMG,
+						text: x.options.name + " takes " + damage +" damage",	
+					};
+					window.MB.inject_chat(msgdata);
+					x.place()
+				}
 			}
 		});
 	});
@@ -2823,6 +2838,7 @@ function add_to_roll_menu(token) {
 	img.css('margin', '2px 2px');
 	roll_menu_entry.append($("<td/>").append(img));
 
+	console.log(token.options)
 	if(token.options.monster > 0){
 		score_bonus = Math.floor((token.options.dexterity - 10) /2 )
 		if (token.options.dexterity_save){

--- a/Token.js
+++ b/Token.js
@@ -2624,7 +2624,7 @@ function open_roll_menu() {
 	roll_dialog.css('top', '200px');
 	roll_dialog.css('left', '300px');
 	roll_dialog.css('height', '250px');
-	roll_dialog.css('z-index', 9);
+	roll_dialog.css('z-index', 1);
 	roll_dialog.css('border', 'solid 2px black');
 	roll_dialog.css('display', 'flex');
 	roll_dialog.css('margin', '1px 1px')
@@ -2637,9 +2637,11 @@ function open_roll_menu() {
 	roll_dialog.empty();
 
 	roll_menu_header = $("<div id='roll_menu_header' class=roll_menu_header ></div>");
-	roll_menu_header.append($('<input type="roll_menu" id="save_dc" placeholder="Save DC" name="save_dc"></input>'))
+	roll_menu_dc_input = $('<input type="roll_menu" id="save_dc" placeholder="Save DC" name="save_dc"></input>')
 
-	save_type_dropdown = $('<select id="save_dropdown" class="dropbtn"" onchange="save_type_change(this)">Save Type</select>')
+	roll_menu_header.append(roll_menu_dc_input)
+
+	save_type_dropdown = $('<select id="save_dropdown" class="dropbtn" onchange="save_type_change(this)">Save Type</select>')
 	save_type_dropdown.append($('<option value="dexterity">Dexterity</option>'))
 	save_type_dropdown.append($('<option value="wisdom">Wisdom</option>'))
 	save_type_dropdown.append($('<option value="constitution">Constitution</option>'))
@@ -2647,9 +2649,9 @@ function open_roll_menu() {
 	save_type_dropdown.append($('<option value="intelligence">Intelligence</option>'))
 	save_type_dropdown.append($('<option value="charisma">Charisma</option>'))
 	
-	damage_input  = $('<input type="roll_menu" id="damage_failed_save" placeholder="Damage/Roll"></input>')
-	half_damage_input = $('<input type="roll_menu" id="half_damage_save" placeholder="Success Damage"></input>')
-	
+	damage_input  = $('<input type="roll_menu" id="damage_failed_save" placeholder="Damage/Roll""></input>')
+	half_damage_input = $('<input type="roll_menu" id="half_damage_save" placeholder="Success Damage""></input>')
+
 	damage_input.change(function(){
 		//console.log(this.value)
 		_dmg = $('#damage_failed_save').val();
@@ -2674,7 +2676,7 @@ function open_roll_menu() {
 
 	let roll_form = $("<form />");
 	roll_menu_body = $("<div id='roll_menu_body' class='roll_menu_body'></div>");
-	//roll_form.append(roll_dialog_content)
+
 	roll_menu_body.append($('<span> Use +- for custom bonus, add a "A" or "D" for Adv/Disadv </span>'))
 	roll_menu_body.append(roll_form)
 
@@ -2804,7 +2806,7 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.css("height","30px");
 	roll_menu_entry.attr("data-target", token.options.id);	
 
-	img=$("<img width=45 height=45 class='Avatar_AvatarPortrait__2dP8u'>");
+	img=$("<img width=42 height=42 class='Avatar_AvatarPortrait__2dP8u'>");
 	img.attr('src',token.options.imgsrc);
 	img.css('border','3px solid '+token.options.color);
 	img.css('margin', '2px 2px');
@@ -2826,17 +2828,16 @@ function add_to_roll_menu(token) {
 		}
 	}
 
-	name_line = $("<div style='width:10%;'>"+token.options.name+"</div>")
+	name_line = $("<div style='width:100px;'>"+token.options.name+"</div>")
 
 	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' maxlength=3 style='font-size:12px; margin: 1px 1px;' > </input>`);
-	bonus_input.css('width','35px');
+	bonus_input.css('width','30px');
 	bonus_input.css('-webkit-appearance','none');
 
 	bonus_input.val(score_bonus);
 
 	hp=$("<div class='hp'></div>");
 	hp.text(token.options.hp);
-	
 	hp.css('font-size','12px');
 
 	roll_menu_entry.append(name_line);

--- a/Token.js
+++ b/Token.js
@@ -2872,7 +2872,7 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.append(find);
 	
 	remove_from_list=$("<button style='font-size:12px;margin: 1px 1px;' title='Remove this entry from this roll menu.'>Remove</button>");
-	find.tooltip()
+	remove_from_list.tooltip()
 	remove_from_list.click(
 		function() {
 			console.log('Removing from list')
@@ -2882,7 +2882,7 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.append(remove_from_list);
 	
 	if(token.options.monster > 0){
-		stat=$("<button style='font-size:12px;margin: 1px 1px;' title='Open this monster's stat block'>Stats</button>");
+		stat=$("<button style='font-size:12px;margin: 1px 1px;' title='Open this monster`s stat block'>Stats</button>");
 		stat.tooltip()
 		
 		stat.click(function(){
@@ -2897,7 +2897,7 @@ function add_to_roll_menu(token) {
 		roll_menu_entry.append(stat);
 	}	
 	else {
-		stat=$("<button style='font-size:12px; margin: 1px 1px;' title='Open this character's stat block'>Stats</button>");
+		stat=$("<button style='font-size:12px; margin: 1px 1px;' title='Open this character`s stat block'>Stats</button>");
 		stat.tooltip()
 		stat.click(function(){
 			open_player_sheet(token.options.id);

--- a/Token.js
+++ b/Token.js
@@ -1503,7 +1503,7 @@ function menu_callback(key, options, event) {
 	}
 	
 	if (key == 'quick_roll_menu') {
-		open_roll_menu()
+		open_roll_menu(event)
 		id = $(this).attr('data-id');
 		add_to_roll_menu(window.TOKEN_OBJECTS[id])						
 	}
@@ -1747,7 +1747,7 @@ function multiple_callback(key, options, event) {
 		});
 	}
 	if (key == 'group_roll') {
-		open_roll_menu()
+		open_roll_menu(event)
 		$("#tokens .tokenselected").each(function() {
 			id = $(this).attr('data-id');
 			add_to_roll_menu(window.TOKEN_OBJECTS[id])
@@ -2614,7 +2614,7 @@ function undo_delete_tokens() {
 	window.TOKEN_OBJECTS_RECENTLY_DELETED = {};
 }
 
-function open_roll_menu() {
+function open_roll_menu(e) {
 	//opens a roll menu for group rolls 
 	console.log("Opening Roll menu")
 	$("#group_roll_dialog").remove();
@@ -2623,8 +2623,8 @@ function open_roll_menu() {
 	roll_dialog.css('background', "url('/content/1-0-1487-0/skins/waterdeep/images/mon-summary/paper-texture.png')");
 	roll_dialog.css('overflow', 'auto');
 	roll_dialog.css('width', '380px');
-	roll_dialog.css('top', '200px');
-	roll_dialog.css('left', '300px');
+	roll_dialog.css('top', e.clientY+'px');
+	roll_dialog.css('left', e.clientX+'px');
 	roll_dialog.css('height', '250px');
 	roll_dialog.css('z-index', 1);
 	roll_dialog.css('border', 'solid 2px black');

--- a/Token.js
+++ b/Token.js
@@ -2714,11 +2714,11 @@ function open_roll_menu(e) {
 				var modifier = y.val().toLowerCase()
 				if (modifier.includes("a") == true) {
 					modifier = modifier.replace(/[^\d.-]/g, '');
-					dice = '2d20kh1';
+					dice = '2d20kh1 +';
 				}
 				else if (modifier.includes("d") == true) {
 					modifier = modifier.replace(/[^\d.-]/g, '');
-					dice = '2d20kl1';
+					dice = '2d20kl1 +';
 				}
 			}
 			else {
@@ -2838,7 +2838,7 @@ function add_to_roll_menu(token) {
 
 	name_line = $("<div style='width:100px;'>"+token.options.name+"</div>")
 
-	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' maxlength=3 style='font-size:12px; margin: 1px 1px;' > </input>`);
+	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' style='font-size:12px; margin: 1px 1px;' > </input>`);
 	bonus_input.css('width','30px');
 	bonus_input.css('-webkit-appearance','none');
 

--- a/Token.js
+++ b/Token.js
@@ -2179,6 +2179,8 @@ function token_menu() {
 					if (!id.endsWith(window.PLAYER_ID)) {
 						delete ret.items.sep3;
 						delete ret.items.imgsrcSelect;
+						delete ret.items.quick_roll_menu
+
 					}
 				}
 

--- a/Token.js
+++ b/Token.js
@@ -2694,9 +2694,15 @@ function open_roll_menu() {
 			
 			save_drop = $("#roll_menu_header").children('select')
 			score_bonus = Math.floor((x.options[save_drop.val()] - 10) /2 )
-			if (x.options[`${save_drop.value}_save`]){
-				score_bonus += x.options.prof_bonus
+			if (x.options[`${save_drop.val()}_save`]){
+				if(x.options.monster > 0){
+					score_bonus += x.options.prof_bonus
+				}
+				else {
+					score_bonus = x.options[`${save_drop.val()}_save`]
+				}
 			}
+
 			if (score_bonus >= 0){
 				score_bonus = "+"+score_bonus;
 			}
@@ -2708,7 +2714,7 @@ function open_roll_menu() {
 					modifier = modifier.replace(/[^\d.-]/g, '');
 					dice = '2d20kh1';
 				}
-				else if (modifier.includes("a") == true) {
+				else if (modifier.includes("d") == true) {
 					modifier = modifier.replace(/[^\d.-]/g, '');
 					dice = '2d20kl1';
 				}

--- a/Token.js
+++ b/Token.js
@@ -48,7 +48,6 @@ class Token {
 		}
 	}
 
-
 	stopAnimation(){
 		var selector = "div[data-id='" + this.options.id + "']";
 		var tok = $("#tokens").find(selector);
@@ -83,6 +82,7 @@ class Token {
 		if (this.persist != null)
 			this.persist();
 	}
+
 	show() {
 		this.update_from_page();
 		delete this.options.hidden;
@@ -91,6 +91,7 @@ class Token {
 		if (this.persist != null)
 			this.persist();
 	}
+
 	delete(persist=true) {
 		if (!window.DM) return; // only allow DMs to delete tokens
 		ct_remove_token(this, false);
@@ -106,6 +107,7 @@ class Token {
 			draw_selected_token_bounding_box(); // redraw the selection box
 		}
 	}
+
 	rotate(newRotation) {
 		if ((!window.DM && this.options.restrictPlayerMove) || this.options.locked) return; // don't allow rotating if the token is locked
 		if (window.DM && this.options.locked) return; // don't allow rotating if the token is locked
@@ -125,22 +127,27 @@ class Token {
 		tokenElement.find("img").css("transform", "scale(" + scale + ") rotate(" + newRotation + "deg)");
 		
 	}
+	
 	moveUp() {
 		let newTop = `${parseFloat(this.options.top) - parseFloat(window.CURRENT_SCENE_DATA.vpps)}px`;
 		this.move(newTop, this.options.left)
 	}
+
 	moveDown() {
 		let newTop = `${parseFloat(this.options.top) + parseFloat(window.CURRENT_SCENE_DATA.vpps)}px`;
 		this.move(newTop, this.options.left)
 	}
+
 	moveLeft() {
 		let newLeft = `${parseFloat(this.options.left) - parseFloat(window.CURRENT_SCENE_DATA.hpps)}px`;
 		this.move(this.options.top, newLeft)
 	}
+
 	moveRight() {
 		let newLeft = `${parseFloat(this.options.left) + parseFloat(window.CURRENT_SCENE_DATA.hpps)}px`;
 		this.move(this.options.top, newLeft)
 	}
+
 	move(top, left) {
 		if ((!window.DM && this.options.restrictPlayerMove) || this.options.locked) return; // don't allow moving if the token is locked
 		if (window.DM && this.options.locked) return; // don't allow moving if the token is locked
@@ -153,6 +160,7 @@ class Token {
 			this.persist();
 		}
 	}
+
 	place_sync_persist() {
 		this.place();
 		this.sync();
@@ -195,7 +203,6 @@ class Token {
 
 
 	}
-
 
 	notify(text) {
 		var n = $("<div/>");
@@ -277,7 +284,6 @@ class Token {
 		}
 
 	}
-
 
 	update_and_sync(e) {
 		self = this;
@@ -512,7 +518,6 @@ class Token {
 			return [cond, moreCond];
 		}
 	}
-
 
 	place(animationDuration) {
 		if(!window.CURRENT_SCENE_DATA){
@@ -1099,7 +1104,6 @@ class Token {
 			check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 		}
 	}
-
 }
 
 // Stop the right click mouse down from cancelling our drag
@@ -1193,6 +1197,49 @@ function token_button(e, tokenIndex = null, tokenTotal = null) {
 		}
 	}
 	
+	if ($(e.target).attr(`data-ability-1`)) {
+		options.strength = $(e.target).attr('data-ability-1');
+	}
+	if ($(e.target).attr(`data-ability-2`)) {
+		options.dexterity = $(e.target).attr('data-ability-2');
+	}
+	if ($(e.target).attr(`data-ability-3`)) {
+		options.constitution = $(e.target).attr('data-ability-3');
+	}
+	if ($(e.target).attr(`data-ability-4`)) {
+		options.wisdom = $(e.target).attr('data-ability-4');
+	}
+	if ($(e.target).attr(`data-ability-5`)) {
+		options.intelligence = $(e.target).attr('data-ability-5');
+	}
+	if ($(e.target).attr(`data-ability-6`)) {
+		options.charisma = $(e.target).attr('data-ability-6');
+	}
+
+
+	if ($(e.target).attr(`data-save-1`)) {
+		options.strength_save = $(e.target).attr('data-save-1');
+	}
+	if ($(e.target).attr(`data-save-2`)) {
+		options.dexterity_save = $(e.target).attr('data-save-2');
+	}
+	if ($(e.target).attr(`data-save-3`)) {
+		options.constitution_save = $(e.target).attr('data-save-3');
+	}
+	if ($(e.target).attr(`data-save-4`)) {
+		options.wisdom_save = $(e.target).attr('data-save-4');
+	}
+	if ($(e.target).attr(`data-save-5`)) {
+		options.intelligence_save = $(e.target).attr('data-save-5');
+	}
+	if ($(e.target).attr(`data-save-6`)) {
+		options.charisma_save = $(e.target).attr('data-save-6');
+	}
+
+
+	if ($(e.target).attr('data-prof-bonus')) {
+		options.prof_bonus = $(e.target).attr('data-prof-bonus');
+	}
 	
 	if ($(e.target).attr('data-size')) {
 		options.size = $(e.target).attr('data-size');
@@ -1455,6 +1502,11 @@ function menu_callback(key, options, event) {
 		
 	}
 	
+	if (key == 'quick_roll_menu') {
+		open_roll_menu()
+		id = $(this).attr('data-id');
+		add_to_roll_menu(window.TOKEN_OBJECTS[id])						
+	}
 
 	if (key == "token_combat") {
 		id = $(this).attr('data-id');
@@ -1694,6 +1746,13 @@ function multiple_callback(key, options, event) {
 			ct_persist();
 		});
 	}
+	if (key == 'group_roll') {
+		open_roll_menu()
+		$("#tokens .tokenselected").each(function() {
+			id = $(this).attr('data-id');
+			add_to_roll_menu(window.TOKEN_OBJECTS[id])
+		});							
+	}
 	if (key == "hide") {
 		$("#tokens .tokenselected").each(function() {
 			id = $(this).attr('data-id');
@@ -1752,6 +1811,7 @@ function token_menu() {
 					callback: multiple_callback,
 					items: {
 						token_combat: { name: 'Add to Combat Tracker' },
+						group_roll: { name: 'Quick Group Roll' },
 						hide: { name: 'Hide From Players' },
 						show: { name: 'Show To Players' },
 						delete: { name: 'Delete Token' },
@@ -2017,7 +2077,13 @@ function token_menu() {
 								note_delete: {name: 'Delete Note'},
 							}
 						},
+
+						quick_roll_menu: { 
+							name: 'Quick Roll Menu' 
+						},
+
 						sep1: "-------",
+
 						hp: {
 							type: 'text',
 							name: 'Current HP',
@@ -2544,4 +2610,291 @@ function undo_delete_tokens() {
 		}
 	}
 	window.TOKEN_OBJECTS_RECENTLY_DELETED = {};
+}
+
+function open_roll_menu() {
+	//opens a roll menu for group rolls 
+	console.log("Opening Roll menu")
+	$("#group_roll_dialog").remove();
+
+	roll_dialog = $("<div id='group_roll_dialog'></div>");
+	roll_dialog.css('background', "url('/content/1-0-1487-0/skins/waterdeep/images/mon-summary/paper-texture.png')");
+	roll_dialog.css('overflow', 'auto');
+	roll_dialog.css('width', '370px');
+	roll_dialog.css('top', '200px');
+	roll_dialog.css('left', '300px');
+	roll_dialog.css('height', '250px');
+	roll_dialog.css('z-index', 9);
+	roll_dialog.css('border', 'solid 1px black');
+	roll_dialog.css('display', 'flex');
+	roll_dialog.css('flex-direction', 'column');
+
+
+	$(roll_dialog).draggable();
+
+	$("#site").append(roll_dialog);
+
+	roll_dialog.empty();
+
+	roll_menu_header = $("<div id='roll_menu_header' class=roll_menu_header ></div>");
+	roll_menu_header.append($('<input type="roll_menu" id="save_dc" placeholder="Save DC" name="save_dc"></input>'))
+
+	save_type_dropdown = $('<select id="save_dropdown" class="dropbtn"" onchange="save_type_change(this)">Save Type</select>')
+	//save_type_dropdown.append($('<option value="0"> Save type </option>'))
+	save_type_dropdown.append($('<option value="dexterity">Dexterity</option>'))
+	save_type_dropdown.append($('<option value="wisdom">Wisdom</option>'))
+	save_type_dropdown.append($('<option value="constitution">Constitution</option>'))
+	save_type_dropdown.append($('<option value="strength">Strength</option>'))
+	save_type_dropdown.append($('<option value="intelligence">Intelligence</option>'))
+	save_type_dropdown.append($('<option value="charisma">Charisma</option>'))
+	
+	damage_input  = $('<input type="roll_menu" id="damage_failed_save" placeholder="Damage"></input>')
+	half_damage_input = $('<input type="roll_menu" id="half_damage_save" placeholder="Save Success Damage"></input>')
+	
+	damage_input.keyup(function(){
+		//console.log(this.value)
+		$("#half_damage_save").val(Math.floor($('#damage_failed_save').val()/2));
+	});
+
+	roll_menu_header.append(damage_input)
+	roll_menu_header.append(half_damage_input)
+	roll_menu_header.append(save_type_dropdown)
+
+	let roll_form = $("<form />");
+	roll_menu_body = $("<div id='roll_menu_body' class='roll_menu_body'></div>");
+	//roll_form.append(roll_dialog_content)
+	roll_menu_body.append($('<span>(+- for custom bonus, add a "A" or "D" for Adv/Disadv)</span>'))
+	roll_menu_body.append(roll_form)
+
+	roll_cancel = $("<button>Cancel</button>");
+	roll_cancel.click(function() {
+		$("#group_roll_dialog").remove();
+	});
+
+	roll_button = $("<button>Roll!</button>");
+	roll_button.click(function() {
+		$('#roll_menu_footer').children('#apply_damage').show()
+		$("#roll_menu_body").children('tr').each(function (){
+			let x = window.TOKEN_OBJECTS[$(this).attr('data-target')]
+			let y = $(this).children('input');
+			
+			save_drop = $("#roll_menu_header").children('select')
+			score_bonus = Math.floor((x.options[save_drop.val()] - 10) /2 )
+			if (x.options[`${save_drop.value}_save`]){
+				score_bonus += x.options.prof_bonus
+			}
+			if (score_bonus >= 0){
+				score_bonus = "+"+score_bonus;
+			}
+
+			dice = '1d20';
+			if (y.val().includes('+') == true || y.val().includes('-') == true){
+				var modifier = y.val().toLowerCase()
+				if (modifier.includes("a") == true) {
+					modifier = modifier.replace(/[^\d.-]/g, '');
+					dice = '2d20kh1';
+				}
+				else if (modifier.includes("a") == true) {
+					modifier = modifier.replace(/[^\d.-]/g, '');
+					dice = '2d20kl1';
+				}
+			}
+			else {
+				var modifier = score_bonus
+			}
+			
+			var expression = dice + modifier;
+			//console.log(expression)
+			var roll = new rpgDiceRoller.DiceRoll(expression);
+			console.log(expression + "->" + roll.total);
+			//reassign to the input 
+			y.val(roll.total);
+			//display a Save success or failure. ]
+			
+			save_dc = $("#roll_menu_header").children('#save_dc').val()
+
+			pass_fail_label = $(this).children('span')[0]
+			
+			if (save_dc != ""){
+				if (parseInt(roll.total) >= parseInt(save_dc)){
+					pass_fail_label.innerHTML = '  Success!'
+				}
+				else {
+					pass_fail_label.innerHTML = '  Fail!'
+				}
+			}
+			else {//if not defined apply full damage.
+				pass_fail_label.innerHTML = '  No DC (Auto-Fail)'
+			}
+			
+		});
+	});
+
+	update_hp = $("<button id=apply_damage> Apply Damage </button>");
+	update_hp.click(function() {
+		$("#roll_menu_body").children('tr').each(function (){
+			update_hp=$(this).children("#hp");
+			let rolled_value = $(this).children('input').val();
+			if (!rolled_value.includes('+') && !rolled_value.includes('-')) {
+				let x = window.TOKEN_OBJECTS[$(this).attr('data-target')]
+				damage_failed_save = $("#roll_menu_header").children('#damage_failed_save').val()
+				half_damage_save_success = $("#roll_menu_header").children('#half_damage_save').val()
+
+				save_dc = $("#roll_menu_header").children('#save_dc').val()
+
+				if (save_dc != "undefined"){
+					if (parseInt(rolled_value) >= parseInt(save_dc)){
+						x.options.hp -= half_damage_save_success
+					}
+					else {
+						x.options.hp -= damage_failed_save
+					}
+				}
+				//if not defined apply full damage.
+				else {
+					x.options.hp -= damage_failed_save
+				}
+				x.place()
+				update_hp.text(x.options.hp);
+			}
+		});
+	});
+	
+
+	roll_menu_footer = $("<div id='roll_menu_footer' class=roll_menu_footer/>");
+	roll_menu_footer.append(roll_button);
+	roll_menu_footer.append(update_hp);
+	roll_menu_footer.append(roll_cancel);
+	update_hp.hide()
+
+	roll_dialog.append(roll_menu_header);
+	roll_dialog.append(roll_menu_body);
+	roll_dialog.append(roll_menu_footer);
+	
+	roll_dialog.css('opacity', '0.0');
+	roll_dialog.animate({
+		opacity: '1.0'
+	}, 1000);
+}
+
+function add_to_roll_menu(token) {
+	//Adds a specific target to the roll menu
+
+	//console.log(token);
+	roll_menu_entry=$("<tr/>");
+	roll_menu_entry.css("height","30px");
+	roll_menu_entry.attr("data-target", token.options.id);	
+
+	img=$("<img width=40 height=40 class='Avatar_AvatarPortrait__2dP8u'>");
+	img.attr('src',token.options.imgsrc);
+	img.css('border','3px solid '+token.options.color);
+	roll_menu_entry.append($("<td/>").append(img));
+
+	if(token.options.monster > 0){
+		score_bonus = Math.floor((token.options.dexterity - 10) /2 )
+		if (token.options.dexterity_save){
+			score_bonus += token.options.prof_bonus
+		}
+		if (score_bonus >= 0){
+			score_bonus = "+"+score_bonus;
+		}
+	}
+	else {
+		score_bonus = token.options.dexterity_save
+		if (score_bonus >= 0){
+			score_bonus = "+"+score_bonus;
+		}
+	}
+
+	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' maxlength=3 style='font-size:12px;'> </input>`);
+	bonus_input.css('width','30px');
+	bonus_input.css('-webkit-appearance','none');
+
+	bonus_input.val(score_bonus);
+
+	hp=$("<div class='hp'></div>");
+	hp.text(token.options.hp);
+	
+	hp.css('font-size','11px');
+	
+	roll_menu_entry.append($("<td/>").append(hp));
+	max_hp=$("<div/>");
+	max_hp.text("/"+token.options.max_hp);
+	max_hp.css('font-size','11px');
+	
+	roll_menu_entry.append($("<td/>").append(max_hp));
+	
+	find=$("<button style='font-size:10px;'>Find</button>");
+	find.click(function(){
+		var target=$(this).parent().attr('data-target');
+		if(target in window.TOKEN_OBJECTS){
+			window.TOKEN_OBJECTS[target].highlight();
+		}
+	});
+	roll_menu_entry.append(bonus_input)
+	roll_menu_entry.append(find);
+	
+	remove_from_list=$("<button style='font-size:10px;'>Remove</button>");
+	remove_from_list.click(
+		function() {
+			console.log('Removing from list')
+			$(this).parent().remove();
+		}
+	);
+	roll_menu_entry.append(remove_from_list);
+	
+	if(token.options.monster > 0){
+		stat=$("<button style='font-size:10px;'>Stats</button>");
+		
+		stat.click(function(){
+			iframe_id="#iframe-monster-"+token.options.monster;
+			if($(iframe_id).is(":visible"))
+				$(iframe_id).hide();
+			else{
+				$(".monster_frame").hide();
+				load_monster_stat(token.options.monster);
+				}
+		});
+		roll_menu_entry.append(stat);
+	}	
+	else {
+		stat=$("<button style='font-size:10px;'>Stats</button>");
+		stat.click(function(){
+			open_player_sheet(token.options.id);
+		});
+		roll_menu_entry.append(stat);
+	}
+
+	roll_menu_entry.append("<span id=save_fail_label> </span>")
+	
+	//$("#group_roll_dialog").append(roll_menu_entry)
+	$("#roll_menu_body").append(roll_menu_entry)
+}
+
+function save_type_change(dropdown) {
+	console.log("Save type is: "+ dropdown.value );
+	$('#roll_menu_footer').children('#apply_damage').hide()
+	//$('#group_roll_dialog').children('tr').each(function () {
+	$('#roll_menu_body').children('tr').each(function () {
+		let x = window.TOKEN_OBJECTS[$(this).attr('data-target')]
+		if(x.options.monster > 0){
+			score_bonus = Math.floor((x.options[dropdown.value] - 10) /2 )
+			if (x.options[`${dropdown.value}_save`]){
+				score_bonus += x.options.prof_bonus
+			}
+			if (score_bonus >= 0){
+				score_bonus = "+"+score_bonus;
+			}
+		}
+		else {
+			score_bonus = x.options[`${dropdown.value}_save`]
+			if (score_bonus >= 0){
+				score_bonus = "+"+score_bonus;
+			}
+		}
+		//console.log($(this).children('input'))
+		$(this).children('input').val(score_bonus);
+		
+
+	});
 }

--- a/Token.js
+++ b/Token.js
@@ -288,11 +288,25 @@ class Token {
 			self.persist(e);
 		check_token_visibility();
 
+		this.update_combat_tracker()
+	}
 
+	update_combat_tracker(){
 		/* UPDATE COMBAT TRACKER */
 		if (window.DM) {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").text(this.options.hp);
+			
+			if (this.options.hidden == false || typeof this.options.hidden == 'undefined'){
+				console.log("Setting combat tracker opacity to 1.0")
+				$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").find('img').css('opacity','1.0');
+			}
+			else {
+				console.log("Setting combat tracker opacity to 0.5")
+				$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").find('img').css('opacity','0.5');
+			}
 		}
+
+
 	}
 
 	build_hp() {
@@ -514,9 +528,7 @@ class Token {
 		var self = this;
 
 		/* UPDATE COMBAT TRACKER */
-		if (window.DM) {
-			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").text(this.options.hp);
-		}
+		self.update_combat_tracker()
 
 
 		if (old.length > 0) {

--- a/Token.js
+++ b/Token.js
@@ -2620,15 +2620,15 @@ function open_roll_menu() {
 	roll_dialog = $("<div id='group_roll_dialog'></div>");
 	roll_dialog.css('background', "url('/content/1-0-1487-0/skins/waterdeep/images/mon-summary/paper-texture.png')");
 	roll_dialog.css('overflow', 'auto');
-	roll_dialog.css('width', '370px');
+	roll_dialog.css('width', '380px');
 	roll_dialog.css('top', '200px');
 	roll_dialog.css('left', '300px');
 	roll_dialog.css('height', '250px');
 	roll_dialog.css('z-index', 9);
-	roll_dialog.css('border', 'solid 1px black');
+	roll_dialog.css('border', 'solid 2px black');
 	roll_dialog.css('display', 'flex');
+	roll_dialog.css('margin', '1px 1px')
 	roll_dialog.css('flex-direction', 'column');
-
 
 	$(roll_dialog).draggable();
 
@@ -2640,7 +2640,6 @@ function open_roll_menu() {
 	roll_menu_header.append($('<input type="roll_menu" id="save_dc" placeholder="Save DC" name="save_dc"></input>'))
 
 	save_type_dropdown = $('<select id="save_dropdown" class="dropbtn"" onchange="save_type_change(this)">Save Type</select>')
-	//save_type_dropdown.append($('<option value="0"> Save type </option>'))
 	save_type_dropdown.append($('<option value="dexterity">Dexterity</option>'))
 	save_type_dropdown.append($('<option value="wisdom">Wisdom</option>'))
 	save_type_dropdown.append($('<option value="constitution">Constitution</option>'))
@@ -2648,12 +2647,25 @@ function open_roll_menu() {
 	save_type_dropdown.append($('<option value="intelligence">Intelligence</option>'))
 	save_type_dropdown.append($('<option value="charisma">Charisma</option>'))
 	
-	damage_input  = $('<input type="roll_menu" id="damage_failed_save" placeholder="Damage"></input>')
-	half_damage_input = $('<input type="roll_menu" id="half_damage_save" placeholder="Save Success Damage"></input>')
+	damage_input  = $('<input type="roll_menu" id="damage_failed_save" placeholder="Damage/Roll"></input>')
+	half_damage_input = $('<input type="roll_menu" id="half_damage_save" placeholder="Success Damage"></input>')
 	
-	damage_input.keyup(function(){
+	damage_input.change(function(){
 		//console.log(this.value)
-		$("#half_damage_save").val(Math.floor($('#damage_failed_save').val()/2));
+		_dmg = $('#damage_failed_save').val();
+		if (_dmg.includes('d')) {
+			var expression = _dmg
+			console.log(expression)
+			var roll = new rpgDiceRoller.DiceRoll(expression);
+			console.log(expression + "->" + roll.total);
+			//reassign to the input 
+			_dmg = roll.total
+			$('#damage_failed_save').val(_dmg);
+		}
+		else {
+			_dmg.replace(/[^\d.-]/g, '')
+		}
+		$("#half_damage_save").val(Math.floor(_dmg/2));
 	});
 
 	roll_menu_header.append(damage_input)
@@ -2663,15 +2675,15 @@ function open_roll_menu() {
 	let roll_form = $("<form />");
 	roll_menu_body = $("<div id='roll_menu_body' class='roll_menu_body'></div>");
 	//roll_form.append(roll_dialog_content)
-	roll_menu_body.append($('<span>(+- for custom bonus, add a "A" or "D" for Adv/Disadv)</span>'))
+	roll_menu_body.append($('<span> Use +- for custom bonus, add a "A" or "D" for Adv/Disadv </span>'))
 	roll_menu_body.append(roll_form)
 
-	roll_cancel = $("<button>Cancel</button>");
+	roll_cancel = $("<button style='margin: 1px 1px; float: right; font-size:14px;'>Cancel</button>");
 	roll_cancel.click(function() {
 		$("#group_roll_dialog").remove();
 	});
 
-	roll_button = $("<button>Roll!</button>");
+	roll_button = $("<button style='margin: 1px 1px; font-size:14px;'>Roll!</button>");
 	roll_button.click(function() {
 		$('#roll_menu_footer').children('#apply_damage').show()
 		$("#roll_menu_body").children('tr').each(function (){
@@ -2713,24 +2725,28 @@ function open_roll_menu() {
 			
 			save_dc = $("#roll_menu_header").children('#save_dc').val()
 
-			pass_fail_label = $(this).children('span')[0]
-			
+			pass_fail_label = $(this).children('#save_fail_label')[0]
+			$(pass_fail_label).show()
+
 			if (save_dc != ""){
 				if (parseInt(roll.total) >= parseInt(save_dc)){
 					pass_fail_label.innerHTML = '  Success!'
+					$(pass_fail_label).css('background', 'green')
 				}
 				else {
 					pass_fail_label.innerHTML = '  Fail!'
+					$(pass_fail_label).css('background', 'red')
 				}
 			}
 			else {//if not defined apply full damage.
 				pass_fail_label.innerHTML = '  No DC (Auto-Fail)'
+				//$(pass_fail_label).css('background', 'red')
 			}
 			
 		});
 	});
 
-	update_hp = $("<button id=apply_damage> Apply Damage </button>");
+	update_hp = $("<button id=apply_damage style='margin: 1px 1px; font-size:14px;'> Apply Damage </button>");
 	update_hp.click(function() {
 		$("#roll_menu_body").children('tr').each(function (){
 			update_hp=$(this).children("#hp");
@@ -2739,6 +2755,9 @@ function open_roll_menu() {
 				let x = window.TOKEN_OBJECTS[$(this).attr('data-target')]
 				damage_failed_save = $("#roll_menu_header").children('#damage_failed_save').val()
 				half_damage_save_success = $("#roll_menu_header").children('#half_damage_save').val()
+
+				damage_failed_save = damage_failed_save.replace(/[^\d.-]/g, '');
+				half_damage_save_success = half_damage_save_success.replace(/[^\d.-]/g, '');
 
 				save_dc = $("#roll_menu_header").children('#save_dc').val()
 
@@ -2785,9 +2804,10 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.css("height","30px");
 	roll_menu_entry.attr("data-target", token.options.id);	
 
-	img=$("<img width=40 height=40 class='Avatar_AvatarPortrait__2dP8u'>");
+	img=$("<img width=45 height=45 class='Avatar_AvatarPortrait__2dP8u'>");
 	img.attr('src',token.options.imgsrc);
 	img.css('border','3px solid '+token.options.color);
+	img.css('margin', '2px 2px');
 	roll_menu_entry.append($("<td/>").append(img));
 
 	if(token.options.monster > 0){
@@ -2806,8 +2826,10 @@ function add_to_roll_menu(token) {
 		}
 	}
 
-	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' maxlength=3 style='font-size:12px;'> </input>`);
-	bonus_input.css('width','30px');
+	name_line = $("<div style='width:10%;'>"+token.options.name+"</div>")
+
+	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' maxlength=3 style='font-size:12px; margin: 1px 1px;' > </input>`);
+	bonus_input.css('width','35px');
 	bonus_input.css('-webkit-appearance','none');
 
 	bonus_input.val(score_bonus);
@@ -2815,16 +2837,18 @@ function add_to_roll_menu(token) {
 	hp=$("<div class='hp'></div>");
 	hp.text(token.options.hp);
 	
-	hp.css('font-size','11px');
-	
+	hp.css('font-size','12px');
+
+	roll_menu_entry.append(name_line);
 	roll_menu_entry.append($("<td/>").append(hp));
+
 	max_hp=$("<div/>");
 	max_hp.text("/"+token.options.max_hp);
-	max_hp.css('font-size','11px');
+	max_hp.css('font-size','12px');
 	
 	roll_menu_entry.append($("<td/>").append(max_hp));
 	
-	find=$("<button style='font-size:10px;'>Find</button>");
+	find=$("<button style='font-size:12px; margin: 1px 1px;'>Find</button>");
 	find.click(function(){
 		var target=$(this).parent().attr('data-target');
 		if(target in window.TOKEN_OBJECTS){
@@ -2834,7 +2858,7 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.append(bonus_input)
 	roll_menu_entry.append(find);
 	
-	remove_from_list=$("<button style='font-size:10px;'>Remove</button>");
+	remove_from_list=$("<button style='font-size:12px;margin: 1px 1px;'>Remove</button>");
 	remove_from_list.click(
 		function() {
 			console.log('Removing from list')
@@ -2844,7 +2868,7 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.append(remove_from_list);
 	
 	if(token.options.monster > 0){
-		stat=$("<button style='font-size:10px;'>Stats</button>");
+		stat=$("<button style='font-size:12px;margin: 1px 1px;'>Stats</button>");
 		
 		stat.click(function(){
 			iframe_id="#iframe-monster-"+token.options.monster;
@@ -2858,14 +2882,14 @@ function add_to_roll_menu(token) {
 		roll_menu_entry.append(stat);
 	}	
 	else {
-		stat=$("<button style='font-size:10px;'>Stats</button>");
+		stat=$("<button style='font-size:12px; margin: 1px 1px;'>Stats</button>");
 		stat.click(function(){
 			open_player_sheet(token.options.id);
 		});
 		roll_menu_entry.append(stat);
 	}
 
-	roll_menu_entry.append("<span id=save_fail_label> </span>")
+	roll_menu_entry.append("<div id=save_fail_label> </div>")
 	
 	//$("#group_roll_dialog").append(roll_menu_entry)
 	$("#roll_menu_body").append(roll_menu_entry)
@@ -2892,6 +2916,9 @@ function save_type_change(dropdown) {
 				score_bonus = "+"+score_bonus;
 			}
 		}
+		let label = $(this).children('#save_fail_label')
+		$(label).hide()
+
 		//console.log($(this).children('input'))
 		$(this).children('input').val(score_bonus);
 		

--- a/Token.js
+++ b/Token.js
@@ -2639,20 +2639,23 @@ function open_roll_menu(e) {
 	roll_dialog.empty();
 
 	roll_menu_header = $("<div id='roll_menu_header' class=roll_menu_header ></div>");
-	roll_menu_dc_input = $('<input type="roll_menu" id="save_dc" placeholder="Save DC" name="save_dc"></input>')
+	roll_menu_dc_input = $('<input type="roll_menu" id="save_dc" placeholder="Save DC" name="save_dc" title="Enter the value for the DC of the saving throw."></input>')
+	roll_menu_dc_input.tooltip();
 
 	roll_menu_header.append(roll_menu_dc_input)
 
-	save_type_dropdown = $('<select id="save_dropdown" class="dropbtn" onchange="save_type_change(this)">Save Type</select>')
+	save_type_dropdown = $('<select id="save_dropdown" class="dropbtn" onchange="save_type_change(this)" title="Select the type of saving throw to be made. ">Save Type</select>')
 	save_type_dropdown.append($('<option value="dexterity">Dexterity</option>'))
 	save_type_dropdown.append($('<option value="wisdom">Wisdom</option>'))
 	save_type_dropdown.append($('<option value="constitution">Constitution</option>'))
 	save_type_dropdown.append($('<option value="strength">Strength</option>'))
 	save_type_dropdown.append($('<option value="intelligence">Intelligence</option>'))
 	save_type_dropdown.append($('<option value="charisma">Charisma</option>'))
-	
-	damage_input  = $('<input type="roll_menu" id="damage_failed_save" placeholder="Damage/Roll""></input>')
-	half_damage_input = $('<input type="roll_menu" id="half_damage_save" placeholder="Success Damage""></input>')
+	save_type_dropdown.tooltip()
+	damage_input  = $('<input type="roll_menu" id="damage_failed_save" placeholder="Damage/Roll" title="Enter the integer value for damage or the roll to be made i.e. 8d6"></input>')
+	damage_input.tooltip()
+	half_damage_input = $('<input type="roll_menu" id="half_damage_save" placeholder="Success Damage" title="Enter the integer value for half damage, or autopopulate from damage entry as half rounded down.""></input>')
+	half_damage_input.tooltip()
 
 	damage_input.change(function(){
 		//console.log(this.value)
@@ -2679,7 +2682,7 @@ function open_roll_menu(e) {
 	let roll_form = $("<form />");
 	roll_menu_body = $("<div id='roll_menu_body' class='roll_menu_body'></div>");
 
-	roll_menu_body.append($('<span> Use +- for custom bonus, add a "A" or "D" for Adv/Disadv </span>'))
+	//roll_menu_body.append($('<span> Use +- for custom bonus, add a "A" or "D" for Adv/Disadv </span>'))
 	roll_menu_body.append(roll_form)
 
 	roll_cancel = $("<button style='margin: 1px 1px; float: right; font-size:14px;'>Cancel</button>");
@@ -2838,10 +2841,10 @@ function add_to_roll_menu(token) {
 
 	name_line = $("<div style='width:100px;'>"+token.options.name+"</div>")
 
-	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' style='font-size:12px; margin: 1px 1px;' > </input>`);
+	bonus_input = $(`<input id=bonus_input type='roll_menu_roll' style='font-size:12px; margin: 1px 1px;' title='Use +- for custom bonus, add a "A" or "D" for Adv/Disadv'> </input>`);
 	bonus_input.css('width','30px');
 	bonus_input.css('-webkit-appearance','none');
-
+	bonus_input.tooltip()
 	bonus_input.val(score_bonus);
 
 	hp=$("<div class='hp'></div>");
@@ -2857,7 +2860,8 @@ function add_to_roll_menu(token) {
 	
 	roll_menu_entry.append($("<td/>").append(max_hp));
 	
-	find=$("<button style='font-size:12px; margin: 1px 1px;'>Find</button>");
+	find=$("<button style='font-size:12px; margin: 1px 1px;' title='Find the token on the map.'>Find</button>");
+	find.tooltip()
 	find.click(function(){
 		var target=$(this).parent().attr('data-target');
 		if(target in window.TOKEN_OBJECTS){
@@ -2867,7 +2871,8 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.append(bonus_input)
 	roll_menu_entry.append(find);
 	
-	remove_from_list=$("<button style='font-size:12px;margin: 1px 1px;'>Remove</button>");
+	remove_from_list=$("<button style='font-size:12px;margin: 1px 1px;' title='Remove this entry from this roll menu.'>Remove</button>");
+	find.tooltip()
 	remove_from_list.click(
 		function() {
 			console.log('Removing from list')
@@ -2877,7 +2882,8 @@ function add_to_roll_menu(token) {
 	roll_menu_entry.append(remove_from_list);
 	
 	if(token.options.monster > 0){
-		stat=$("<button style='font-size:12px;margin: 1px 1px;'>Stats</button>");
+		stat=$("<button style='font-size:12px;margin: 1px 1px;' title='Open this monster's stat block'>Stats</button>");
+		stat.tooltip()
 		
 		stat.click(function(){
 			iframe_id="#iframe-monster-"+token.options.monster;
@@ -2891,7 +2897,8 @@ function add_to_roll_menu(token) {
 		roll_menu_entry.append(stat);
 	}	
 	else {
-		stat=$("<button style='font-size:12px; margin: 1px 1px;'>Stats</button>");
+		stat=$("<button style='font-size:12px; margin: 1px 1px;' title='Open this character's stat block'>Stats</button>");
+		stat.tooltip()
 		stat.click(function(){
 			open_player_sheet(token.options.id);
 		});

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1741,3 +1741,64 @@ h5.token-image-modal-footer-title:after {
     opacity: 1;
     visibility: visible;
 }
+.dropbtn {
+    background-color: #3498DB;
+    color: white;
+    padding: 6px 6px;
+    margin: 1px 5px;
+    font-size: 12px;
+    border: none;
+    cursor: pointer;
+}
+.dropbtn:hover, .dropbtn:focus {
+    background-color: #2980B9;
+}
+.dropdown {
+    position: relative;
+    display: inline-block;
+} 
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f1f1f1;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}  
+.dropdown-content a {
+    color: black;
+    padding: 10px 10px;
+    text-decoration: none;
+    display: block;
+}
+.dropdown-content a:hover {background-color: #ddd}
+
+.show {display:block;}
+
+input[type=roll_menu] {
+    width: 21%;
+    padding: 4px 4px;
+    margin: 2px 2px;
+    box-sizing: border-box;
+    display: inline-block;
+}
+input[type=roll_menu_roll] {
+    width: 10%;
+    padding: 1px 1px;
+    box-sizing: border-box;
+    display: inline-block;
+}
+#roll_menu_header {
+    width: 100%;
+    padding: 1px 1px;
+    background-color: #033a5f;
+}
+#roll_menu_footer {
+    padding: 1px 1px;
+    width: 100%;
+    background-color: #033a5f;
+}
+#roll_menu_body {
+    flex: 1;
+    overflow: auto;
+}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1741,64 +1741,52 @@ h5.token-image-modal-footer-title:after {
     opacity: 1;
     visibility: visible;
 }
+
 .dropbtn {
-    background-color: #3498DB;
-    color: white;
-    padding: 6px 6px;
-    margin: 1px 5px;
-    font-size: 12px;
-    border: none;
-    cursor: pointer;
+    border-radius: 0;
+    height: 25px;
+    padding: 4px 4px;
+    margin: 2px 2px;
+    background-color: white;
+    box-shadow: inset 0 0 4px 0 rgba(138,177,198,0.48);
+    border: solid 1px #d8dde3;
 }
-.dropbtn:hover, .dropbtn:focus {
-    background-color: #2980B9;
-}
-.dropdown {
-    position: relative;
-    display: inline-block;
-} 
-.dropdown-content {
-    display: none;
-    position: absolute;
-    background-color: #f1f1f1;
-    min-width: 160px;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-    z-index: 1;
-}  
-.dropdown-content a {
-    color: black;
-    padding: 10px 10px;
-    text-decoration: none;
-    display: block;
-}
-.dropdown-content a:hover {background-color: #ddd}
-
-.show {display:block;}
-
 input[type=roll_menu] {
-    width: 21%;
+    width: 22%;
     padding: 4px 4px;
     margin: 2px 2px;
     box-sizing: border-box;
     display: inline-block;
+    padding: 5px;
+    font-family: sans-serif;
+    font-size: 100%;
+    color: #666;
+    outline: 0;
+    border: 0;
+    -webkit-box-shadow: none;
+    box-shadow: none;
 }
 input[type=roll_menu_roll] {
     width: 10%;
     padding: 1px 1px;
+    margin: 2px 2px;
     box-sizing: border-box;
     display: inline-block;
 }
 #roll_menu_header {
     width: 100%;
-    padding: 1px 1px;
-    background-color: #033a5f;
+    padding: 2px 2px;
+    /*background-color: #1b9af0;*/
+    background-color: #1b9af0;
+
 }
 #roll_menu_footer {
-    padding: 1px 1px;
+    padding: 2px 2px;
     width: 100%;
-    background-color: #033a5f;
+    background-color: #1b9af0;
 }
 #roll_menu_body {
     flex: 1;
     overflow: auto;
+    background-color: rgb(235, 241, 245);
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1766,13 +1766,14 @@ input[type=roll_menu] {
     -webkit-box-shadow: none;
     box-shadow: none;
 }
-input[type=roll_menu_roll] {
+input[type=roll_menu_roll]{
     width: 10%;
     padding: 1px 1px;
     margin: 2px 2px;
     box-sizing: border-box;
     display: inline-block;
 }
+
 #roll_menu_header {
     width: 100%;
     padding: 2px 2px;


### PR DESCRIPTION
Could definitely use some cosmetic improvements, but I would like to crowd source that.

Adds a menu for group rolling/rolls. Also works for single targets/players. 

https://imgur.com/nSehTNb

Pulls the data for monsters and players from sheet and auto-populates the save input. 

https://imgur.com/AQ41FaY

Can be adjusted with Advantage or Disadvantage (Currently doesn't display any difference outside of console log, but this could be changed.)

Input damage, dice format or integer. 