### PR TITLE
fix for combat stat button not working

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -267,7 +267,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				$(iframe_id).hide();
 			else{
 				$(".monster_frame").hide();
-				load_monster_stat(token.options.monster,this.options.id);
+				load_monster_stat(token.options.monster, token.options.id);
 				}
 		});
 		if(window.DM)


### PR DESCRIPTION
I'm guessing this was either a copy/paste error or a merge gone wrong. Either way, it's a simple fix