### PR TITLE
fix extras monsters not parsing when no image

### DIFF
--- a/MonsterDice.js
+++ b/MonsterDice.js
@@ -97,7 +97,11 @@ function scan_player_creature_pane(target) {
 
 	let creatureType = target.find(".ct-sidebar__header .ct-sidebar__header-parent").text(); // wildshape, familiar, summoned, etc
 	let creatureName = target.find(".ct-sidebar__header .ddbc-creature-name").text(); // Wolf, Owl, etc
-	let creatureAvatar = target.find(".ct-sidebar__header .ct-sidebar__header-preview-image").css("background-image").slice(4, -1).replace(/"/g, "");
+	let creatureAvatar = window.pc.image;
+ 	try {
+ 		// not all creatures have an avatar for some reason
+ 		creatureAvatar = target.find(".ct-sidebar__header .ct-sidebar__header-preview-image").css("background-image").slice(4, -1).replace(/"/g, "");
+ 	} catch { }
 	let pc = window.pcs.find(t => t.sheet == find_currently_open_character_sheet());
 	let displayName = `${pc.name} (${creatureName} ${creatureType})`;
 	


### PR DESCRIPTION
This would throw an error and stop parsing if the monster didn't have an avatar image