### PR TITLE
Make the monster tokens hidden to the players by default.

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -157,13 +157,12 @@ function init_settings(){
 				toggle.click();
 			}
 			if (setting.name == 'hidden') toggle.click();
-			//window.TOKEN_SETTINGS[setting.name] = (settings.name == 'hidden'); // Should be able to remove this line since the click does the exact same thing
 		}
 		persist_token_settings(window.TOKEN_SETTINGS);
 		redraw_settings_panel_token_examples();
 	});
 	body.append(resetToDefaults);
-	resetToDefaults.click(); // Sets the default settings instead of all false.
+	resetToDefaults.click(); // Sets the default token settings
 
 
 	const experimental_features = [

--- a/Settings.js
+++ b/Settings.js
@@ -156,12 +156,14 @@ function init_settings(){
 			if (toggle.hasClass("rc-switch-checked")) {
 				toggle.click();
 			}
-			window.TOKEN_SETTINGS[setting.name] = false;
+			if (setting.name == 'hidden') toggle.click();
+			//window.TOKEN_SETTINGS[setting.name] = (settings.name == 'hidden'); // Should be able to remove this line since the click does the exact same thing
 		}
 		persist_token_settings(window.TOKEN_SETTINGS);
 		redraw_settings_panel_token_examples();
 	});
 	body.append(resetToDefaults);
+	resetToDefaults.click(); // Sets the default settings instead of all false.
 
 
 	const experimental_features = [


### PR DESCRIPTION
This PR is intended as a first step into the project. It changes and sets the default token settings inside the init_settings() function.