### PR TITLE
Add 'Restrict player movement' as a default token setting

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -157,13 +157,12 @@ function init_settings(){
 				toggle.click();
 			}
 			if (setting.name == 'hidden') toggle.click();
-			//window.TOKEN_SETTINGS[setting.name] = (settings.name == 'hidden'); // Should be able to remove this line since the click does the exact same thing
 		}
 		persist_token_settings(window.TOKEN_SETTINGS);
 		redraw_settings_panel_token_examples();
 	});
 	body.append(resetToDefaults);
-	resetToDefaults.click(); // Sets the default settings instead of all false.
+	resetToDefaults.click(); // Sets the default token settings
 
 
 	const experimental_features = [

--- a/Settings.js
+++ b/Settings.js
@@ -128,7 +128,6 @@ function init_settings(){
 	for(let i = 0; i < token_settings.length; i++) {
 		let setting = token_settings[i];
 		let currentValue = window.TOKEN_SETTINGS[setting.name];
-		console.log('CURRENT VALUE: ', currentValue);
 		let inputWrapper = settingsPanel.build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
 			console.log(`${name} setting is now ${newValue}`);
 			window.TOKEN_SETTINGS[name] = newValue;
@@ -163,7 +162,6 @@ function init_settings(){
 			if (toggle.hasClass("rc-switch-checked")) {
 				toggle.click();
 			}
-			if (setting.name == 'restrictPlayerMove') toggle.click();
 		}
 		persist_token_settings(window.TOKEN_SETTINGS);
 		redraw_settings_panel_token_examples();

--- a/Settings.js
+++ b/Settings.js
@@ -82,6 +82,12 @@ function init_settings(){
 			disabledDescription: 'New tokens will be movable'
 		},
 		{
+			name: 'restrictPlayerMove',
+			label: 'Restrict Player Movement',
+			enabledDescription: 'Player will not be able to move new tokens',
+			disabledDescription: 'Player will be able to move new tokens'
+		},
+		{
 			name: 'disablestat',
 			label: 'Disable HP/AC',
 			enabledDescription: 'New tokens will not have HP/AC shown to either the DM or the players. This is most useful for tokens that represent terrain, vehicles, etc.',
@@ -122,6 +128,7 @@ function init_settings(){
 	for(let i = 0; i < token_settings.length; i++) {
 		let setting = token_settings[i];
 		let currentValue = window.TOKEN_SETTINGS[setting.name];
+		console.log('CURRENT VALUE: ', currentValue);
 		let inputWrapper = settingsPanel.build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
 			console.log(`${name} setting is now ${newValue}`);
 			window.TOKEN_SETTINGS[name] = newValue;
@@ -156,7 +163,7 @@ function init_settings(){
 			if (toggle.hasClass("rc-switch-checked")) {
 				toggle.click();
 			}
-			if (setting.name == 'hidden') toggle.click();
+			if (setting.name == 'restrictPlayerMove') toggle.click();
 		}
 		persist_token_settings(window.TOKEN_SETTINGS);
 		redraw_settings_panel_token_examples();
@@ -256,6 +263,12 @@ function redraw_settings_panel_token_examples() {
 	}
 
 	if (window.TOKEN_SETTINGS['hidestat']) {
+		// anything to show here? This only affects players
+	} else {
+		// anything to show here? This only affects players
+	}
+
+	if (window.TOKEN_SETTINGS['restrictPlayerMove']) {
 		// anything to show here? This only affects players
 	} else {
 		// anything to show here? This only affects players

--- a/Settings.js
+++ b/Settings.js
@@ -156,12 +156,14 @@ function init_settings(){
 			if (toggle.hasClass("rc-switch-checked")) {
 				toggle.click();
 			}
-			window.TOKEN_SETTINGS[setting.name] = false;
+			if (setting.name == 'hidden') toggle.click();
+			//window.TOKEN_SETTINGS[setting.name] = (settings.name == 'hidden'); // Should be able to remove this line since the click does the exact same thing
 		}
 		persist_token_settings(window.TOKEN_SETTINGS);
 		redraw_settings_panel_token_examples();
 	});
 	body.append(resetToDefaults);
+	resetToDefaults.click(); // Sets the default settings instead of all false.
 
 
 	const experimental_features = [

--- a/Settings.js
+++ b/Settings.js
@@ -169,8 +169,6 @@ function init_settings(){
 		redraw_settings_panel_token_examples();
 	});
 	body.append(resetToDefaults);
-	resetToDefaults.click(); // Sets the default token settings
-
 
 	const experimental_features = [
 		// {


### PR DESCRIPTION
This PR is intended as a first step into the project. (See https://discord.com/channels/815028457851191326/832199739398946817/931271695560507423)

It adds the restrictPlayerMove option to the token settings options in the Settings tab.

The "Reset Token Settings to Defaults" button calls the click() of each toggle that is turned on, and the click of each toggle sets the corresponding setting to the new value (See Settings.js line 125, which uses the function defined in SidebarPanel.js line 224).

Before, it simply set everything to false.
Now, Reset Token Settings essentially does the same thing except for the "restrictPlayerMove" setting where it sets it right back to true. I removed the window.TOKEN_SETTINGS[name] = false for each toggle in the loop. It needlessly set them a second time whenever clicking the button (since toggle.click already does that).