### PR TITLE
Fix for sending conditions to gamelog

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -424,7 +424,7 @@ class Token {
 					const data = {
 						player: window.PLAYER_NAME,
 						img: window.PLAYER_IMG,
-						text: `<div>${[conditionName, ...conditionDescription].map(line => `<p>${line}</p>`).join(``)}</div>`
+						text: window.MB.encode_message_text(`<div>${[conditionName, ...conditionDescription].map(line => `<p>${line}</p>`).join(``)}</div>`)
 					};
 					window.MB.inject_chat(data);
 				});


### PR DESCRIPTION
Simple fix for readding double click conditions to send them to gamelog. 

Just adds it as text, I don't think we need any more than that(?)

