### PR TITLE
Monitor and attempt re-connection to DDBs web-socket

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -721,23 +721,21 @@ class MessageBroker {
 			}
 		};
 
-
-
-
-
-
-
 		get_cobalt_token(function(token) {
 			self.loadWS(token);
 		});
 
 		self.loadAboveWS();
 
-
 		setInterval(function() {
 			self.sendPing();
 			self.sendAbovePing();
 		}, 180000);
+
+		// Ensure we have an initial delay (15 seconds) before attempting re-connects to let everything load (every 4 seconds)
+		setTimeout(setInterval(function() {
+			   	forceDdbWsReconnect();
+		}, 4000), 15000);
 	}
 
     	handleCT(data){


### PR DESCRIPTION
DDBs web-socket may get disconnected due to various reasons,
and their current logic doesn't always manage to reconnect the
web-socket.

Added code that checks DDBs web-socket status and forces a reconnection
attempt when possible. This fixes issues with dice rolls not appearing and
other various issues which forced users to refresh the page in order
to get things working again.

The logic it runs is as follows:
	1. Every 4 seconds (following an initial 15 seconds delay) check
	   if the browser is online, and if it is, check if DDBs web-socket
	   is in connected state. If it's note, force reconnect.
	2. Every call to get_cobalt_token now does that same check, to ensure
	   we don't attempt to sent messages that won't arrive to the other side.

The force re-connect is protected by a best-effort lock (non-atomic).