### PR TITLE
update custom tokens row UI to use gear icon

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -691,7 +691,11 @@ function build_custom_token_row(name, imgSrc, subtitleText, enableDrag = true) {
 			<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.2 10.8V18h3.6v-7.2H18V7.2h-7.2V0H7.2v7.2H0v3.6h7.2z"></path></svg>
 		</button>
 	`);
-	let handle = $(`<div class="custom-token-image-row-handle"><svg class="monster-row__cell--drag-handle__icon" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11 2a1 1 0 110 2H1a1 1 0 110-2h10zm0 6a1 1 0 110 2H1a1 1 0 110-2h10z"></path></svg></div>`);
+	let handle = $(`
+		<div class="custom-token-image-row-handle">
+			<img src="${window.EXTENSION_PATH}assets/icons/cog.svg" style="width:100%;height:100%;" />
+		</div>	
+	`);
 
 	rowItem.append(imgHolder);
 	rowItem.append(details);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1735,7 +1735,7 @@ h5.token-image-modal-footer-title:after {
     width: 38px;
     max-width: 38px;
     object-fit: cover;
-    padding: 13px;
+    padding: 7px;
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
     background-color: #f2f6f8;
@@ -1744,7 +1744,7 @@ h5.token-image-modal-footer-title:after {
     margin: -4px -4px -4px 8px;
     cursor: pointer;
 }
-.custom-token-image-row-handle svg {
+.custom-token-image-row-handle img {
     width: 100%;
     height: 100%;
     fill: #738694;


### PR DESCRIPTION
Now that the Monster rows have been rebuilt, the custom tokens rows need to be updated to match.

### Before
<img width="340" alt="Screen Shot 2022-03-05 at 1 12 14 PM" src="https://user-images.githubusercontent.com/584771/156896980-cbb14336-11d4-4540-b851-038c3b0a6843.png">

### After
<img width="333" alt="Screen Shot 2022-03-05 at 1 26 10 PM" src="https://user-images.githubusercontent.com/584771/156897341-e74bb4ff-a9a6-4294-b81d-58f77d75ec93.png">


Closes #216
