### PR TITLE
fix: add party button doesn't respect global configs

### DIFF
--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -24,9 +24,29 @@ function update_pclist() {
 
 	const addPartyButtonContainer = $("<div class='add-party-container'></div>");
 	const addPartyButton = $("<button id='add-party'>ADD PARTY</button>");
-	addPartyButton.on('click', () => {
+	addPartyButton.on('click', (event) => {
+		// place all the players at the center of the window, and then fan them out from there
 		window.pcs.forEach(function (player, i) {
-			token_button({ target: $(`[data-set-token-id='${player.sheet}']`) }, i, window.pcs.length);
+			if (player.sheet !== undefined && player.sheet.length > 0) {
+				let playerId = player.sheet;
+				if (window.TOKEN_OBJECTS[playerId] === undefined) {
+					// no need to do aything for already placed tokens
+					place_player_token(playerId, event.shiftKey);
+					let token = window.TOKEN_OBJECTS[playerId];
+					let size = token.options.size;
+					let numberOfPlayers = window.pcs.length - 1; // don't count the DM
+					let left = (parseFloat(token.options.left) + (((size || 68.33) * 5) / 2) * Math.cos(2 * Math.PI * i / numberOfPlayers));
+					let top = (parseFloat(token.options.top) + (((size || 68.33) * 5) / 2) * Math.sin(2 * Math.PI * i / numberOfPlayers));
+					token.options.top = `${top}px`;
+					token.options.left = `${left}px`;
+					let shallwesnap = (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);
+					if (shallwesnap) {
+						token.snap_to_closest_square();
+					} else {
+						token.place_sync_persist();
+					}
+				}
+			}
 		});
 	});
 	
@@ -457,7 +477,7 @@ function place_player_token(playerId, hidden, specificImage, eventPageX, eventPa
 	}
 
 
-	if (eventPageX == undefined || eventPageY == undefined) {
+	if (eventPageX === undefined || eventPageY === undefined) {
 		place_token_in_center_of_map(options);
 	} else {
 		place_token_under_cursor(options, eventPageX, eventPageY);

--- a/Token.js
+++ b/Token.js
@@ -164,6 +164,32 @@ class Token {
 			this.persist();
 		}
 	}
+	snap_to_closest_square() {
+		if ((!window.DM && this.options.restrictPlayerMove) || this.options.locked) return; // don't allow moving if the token is locked
+		if (window.DM && this.options.locked) return; // don't allow moving if the token is locked
+		// shamelessly copied from the draggable code later in this file
+		// this should be a XOR... (A AND !B) OR (!A AND B)
+		let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);		
+		if (shallwesnap) {
+			// calculate offset in real coordinates
+			const startX = window.CURRENT_SCENE_DATA.offsetx;
+			const startY = window.CURRENT_SCENE_DATA.offsety;
+
+			const selectedOldTop = parseInt(this.options.top);
+			const selectedOldleft = parseInt(this.options.left);
+			
+			const selectedNewtop =  Math.round(Math.round( (selectedOldTop - startY) / window.CURRENT_SCENE_DATA.vpps)) * window.CURRENT_SCENE_DATA.vpps + startY;
+			const selectedNewleft = Math.round(Math.round( (selectedOldleft - startX) / window.CURRENT_SCENE_DATA.hpps)) * window.CURRENT_SCENE_DATA.hpps + startX;
+
+			console.log("Snapping from "+selectedOldleft+ " "+selectedOldTop + " -> "+selectedNewleft + " "+selectedNewtop);
+			console.log("params startX " + startX + " startY "+ startY + " vpps "+window.CURRENT_SCENE_DATA.vpps + " hpps "+window.CURRENT_SCENE_DATA.hpps);
+
+			this.update_from_page();
+			this.options.top = `${selectedNewtop}px`;
+			this.options.left = `${selectedNewleft}px`;
+			this.place_sync_persist();
+		}		
+	}
 	place_sync_persist() {
 		this.place();
 		this.sync();


### PR DESCRIPTION
Closes #220 

Rather than using the old `token_button` function, the "add party" button now calls the `place_player_token` button which already takes into account global configs, custom images, etc. I also added support for adding the player tokens as hidden if you hold the shift key when you press it.