### PR TITLE
add support for images hosted in dropbox

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -5,9 +5,12 @@ function parse_img(url){
 		console.warn("parse_img was called without a url");
 		return "";
 	}
-	retval=url;
-	if(retval.startsWith("https://drive.google.com") && retval.indexOf("uc?id=") < 0)
-		retval='https://drive.google.com/uc?id=' + retval.split('/')[5];
+	retval = url;
+	if (retval.startsWith("https://drive.google.com") && retval.indexOf("uc?id=") < 0) {
+		retval = 'https://drive.google.com/uc?id=' + retval.split('/')[5];
+	} else if (retval.includes("dropbox.com") && retval.includes("?dl=")) {
+		retval = retval.split("?dl=")[0] + "?raw=1";
+	}
 	return retval;
 }
 

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -406,6 +406,7 @@ function display_monster_customization_modal(placedToken, monsterId, monsterName
 			modalBody.empty();
 			removeAllButton.show();
 		}
+		imageUrl = parse_img(imageUrl);
 		add_custom_monster_image_mapping(monsterId, imageUrl);
 		let updatedImages = get_custom_monster_images(monsterId);
 		let imgIndex = updatedImages.indexOf(imageUrl);
@@ -466,7 +467,7 @@ function display_monster_customization_modal(placedToken, monsterId, monsterName
 		addForAllButton.click(function(event) {
 			let imageUrl = $(`input[name='addCustomImage']`)[0].value;
 			if (imageUrl != undefined && imageUrl.length > 0) {
-				add_token_customization_image(imageUrl);
+				add_token_customization_image(parse_img(imageUrl));
 			}
 		});
 		inputWrapper.append(addForAllButton);

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -209,11 +209,8 @@ function edit_scene_dialog(scene_id) {
 				nValue = $(this).val();
 			}
 
-			if ( ((n === 'player_map') || (n==='dm_map'))   
-					&& nValue.startsWith("https://drive.google.com")
-					&& nValue.indexOf("uc?id=") < 0
-			) {
-				nValue = 'https://drive.google.com/uc?id=' + nValue.split('/')[5];
+			if ( ((n === 'player_map') || (n==='dm_map')) ) {
+				nValue = parse_img(nValue);
 			}
 
 			scene[n] = nValue;

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -199,8 +199,8 @@ class SidebarPanel {
     let inputLabel = $(`<div class="token-image-modal-footer-title">${titleText}</div>`);
     let urlInput = $(`<input title="${titleText}" placeholder="https://..." name="addCustomImage" type="text" />`);
     urlInput.on('keyup', function(event) {
-      let imageUrl = event.target.value;
-      if (event.key == "Enter" && imageUrl != undefined && imageUrl.length > 0) {
+      let imageUrl = parse_img(event.target.value);
+      if (event.key == "Enter" && imageUrl !== undefined && imageUrl.length > 0) {
         if(imageUrl.startsWith("data:")){
           alert("You cannot use urls starting with data:");
           return;


### PR DESCRIPTION
Closes #222 

This updates the `parse_img` function to process dropbox links in a similar way to how it processes good drive links. It also updates the `ScenesPanel` to use the `parse_img` function instead of duplicating the logic of that function. While testing this change, I found a bug in the token customization where `parse_img` wasn't being called so I fixed that, too.