### PR TITLE
clean up DM player card a bit

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -923,6 +923,10 @@ function init_player_sheet(pc_sheet, loadWait = 0)
 		// characters page manipulates the html on the page instead of loading an iframe
 		return;
 	}
+	if (pc_sheet === undefined || pc_sheet.length == 0) {
+		// This happens for the DM representation.
+		return;
+	}
 
 	let container = $("#sheet");
 	iframe = $("<iframe id='PlayerSheet"+getPlayerIDFromSheet(pc_sheet)+"' src=''></iframe>")


### PR DESCRIPTION
There were some odd interactions with the DM card on the players panel. 
1. The DM card is no longer shown to the DM since it's useless for the DM to see it.
2. players can no longer drag and drop other player tokens (it never added the tokens, but they also don't need to be able to drag and drop them at all)
3. The DM would also get an iframe in the `#sheet` container which would never load since it's not a real character. This no longer happens