### PR TITLE
Fix possible constant dice rolls

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -316,6 +316,7 @@ class MessageBroker {
 			this.diceMessageSelector = "e5tW4dyfiZqZEWgkVugvEQ==";
 		}
 
+		this.origRequestAnimFrame = null;
 		this.lastAlertTS = 0;
 		this.latestVersionSeen = abovevtt_version;
 
@@ -615,6 +616,14 @@ class MessageBroker {
 				self.handlePlayerData(msg.data);
 			}
 			if (msg.eventType == "dice/roll/pending"){
+				// Hook requestAnimationFrame so DDB's animated dice rolls keep rolling when focus is lost
+				// We hook only if the roll originated from self
+				if (this.origRequestAnimFrame == null &&
+				    ((window.DM && msg.data.context.entityType === "user") || window.PLAYER_ID == msg.data.context.entityId)) {
+					console.log("Hooking requestAnimationFrame for dice roll");
+					this.origRequestAnimFrame = window.requestAnimationFrame;
+					window.requestAnimationFrame = function(cb) { setTimeout(cb, 33); }
+				}
 				// check for injected_data!
 				if(msg.data.injected_data){
 					notify_gamelog();
@@ -733,11 +742,16 @@ class MessageBroker {
 			}
 			
 			if (msg.eventType == "dice/roll/fulfilled") {
+				if (this.origRequestAnimFrame != null) {
+					console.log("Stop hooking requestAnimationFrame for dice roll");
+					window.requestAnimationFrame = this.origRequestAnimFrame;
+					this.origRequestAnimFrame = null;
+				}
+
 				notify_gamelog();
-								if (!window.DM)
+				if (!window.DM)
 					return;
 				
-					
 				// CHECK FOR INIT ROLLS (auto add to combat tracker)
 				if (msg.data.action == "Initiative") {
 					console.log(msg.data);


### PR DESCRIPTION
Users have reported an issue when using DDBs dice rolls where there's a chance
the roll will constantly be the same.

We believe the issue is when the tab loses focus, causing the dice roll
animation to stop. If enough time passes, DDB returns the previous value.

This attempts to fix this issue by hooking requestAnimationFrame
ONLY during dice rolls and replace it with setTimeout - these are used by DDBs
rendering engine to draw the dice rolls.

Browsers tend to stop respecting animation frames requests on focus lose,
whereas setTimeout will continue working.

NOTE: setTimeout may introduce stuttering in rolls animation as for rendering,
as requestAnimationFrame is the preferred way.

1. When we receive a pending dice roll message, we hook it ONLY for the user who initiated
the roll.
2. When we receive a fullfilled dice roll message, we stop the hook.