### PR TITLE
stop calling init_splash twice

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1378,7 +1378,6 @@ function init_things() {
 	window.STARTING = true;
 	let searchParams = new URLSearchParams(window.location.search)
 	var gameid = $("#message-broker-client").attr("data-gameId");
-	init_splash();
 	window.TOKEN_OBJECTS = {};
 	window.REVEALED = [];
 	window.DRAWINGS = [];


### PR DESCRIPTION
`init_splash` was being called twice. It didn't cause any real issues, but there's no need to have 2 splash screens up