### PR TITLE
fix : scroll bar no longer overlaps over dice in combat lag

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -934,6 +934,7 @@ div#scene_properties form > div {
     position: absolute;
     right: 0;
     top: 28px;
+    height: calc(100vh - 30px) !important;
 }
 
 .ddbc-tab-list__nav-item {


### PR DESCRIPTION
fixes #237
![image](https://user-images.githubusercontent.com/9283242/157831740-b6f23e86-54b7-4a79-99cf-295060a3123b.png)
![image](https://user-images.githubusercontent.com/9283242/157831781-8aa94fa1-9da6-46e3-a734-ed79bb4ddabe.png)
