### PR TITLE
persist player token customizations in the cloud

### DIFF
--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -310,9 +310,14 @@ function read_player_token_customizations() {
 	}
 }
 
-function write_player_token_customizations(customMappingData) {
+function write_player_token_customizations(customMappingData, sendToCloud = true) {
 	if (customMappingData !== undefined && customMappingData != null) {
 		localStorage.setItem("PlayerTokenCustomization", JSON.stringify(customMappingData));
+	}
+	if (sendToCloud && window.CLOUD) {
+		persist_campaign_data_in_cloud(function() {
+			console.log("sent player token customizations to the cloud!");
+		});
 	}
 }
 


### PR DESCRIPTION
player token customizations are specific to a campaign so I just added them to the campaignData that is already persisted in the cloud. I tested with two accounts across firefox and chrome and seems to be working just fine

Closes #295