### PR TITLE
allow players to delete AoE tokens

### DIFF
--- a/AOETemplates.js
+++ b/AOETemplates.js
@@ -156,27 +156,30 @@ function drop_aoe_token(color, shape, feet) {
     console.log(`dropping aoe token: color ${color}, shape ${shape}, feet ${feet}`);
 
     let atts = {
-        'data-disablestat': true,
-        'data-hidestat': true,
-        'data-disableborder': true,
-        'data-square': 1,
-        'data-img': AOE_TEMPLATES[`${color}-${shape}`],
-        'data-size': Math.round(size),
+        disablestat: true,
+        hidestat: true,
+        disableborder: true,
+        square: true,
+        imgsrc: AOE_TEMPLATES[`${color}-${shape}`],
+        size: Math.round(size),
+        restrictPlayerMove: false,
+        hidden: false,
+        locked: false,
+        disableaura: true,
+        legacyaspectratio: false,
+        deleteableByPlayers: true
     };
 
     if(window.DM){
-        let fake=$("<div/>");
-        fake.attr(atts);
-        token_button({target:fake.get(0)});
-        fake.remove();
+        place_token_in_center_of_map(atts);
     }
     else{
         let centerX = $(window).scrollLeft() + Math.round(+$(window).width() / 2) - 200;
         let centerY = $(window).scrollTop() + Math.round($(window).height() / 2) - 200;
         centerX = Math.round(centerX * (1.0 / window.ZOOM));
         centerY = Math.round(centerY * (1.0 / window.ZOOM));
-        atts['data-left']=centerX;
-        atts['data-top']=centerY;
+        atts.left = centerX;
+        atts.top = centerY;
         window.MB.sendMessage("custom/myVTT/createtoken",atts);
     }
 }

--- a/Main.js
+++ b/Main.js
@@ -950,10 +950,10 @@ function observe_character_sheet_aoe(documentToObserve) {
 					// grab feet (this should always exist)
 					feet = $(this).prev().children().first().children().first().text();
 
-					// drop the token
-					container.animate({opacity:"0.1"},1000);
-					setTimeout( ()=>drop_aoe_token(color, shape, feet),1000);
-					setTimeout( ()=>container.animate({opacity:"1.0"},2000),3000);
+					// hide the sheet, and drop the token. Don't reopen the sheet because they probably  want to position the token right away
+					hide_player_sheet();
+					close_player_sheet();
+					drop_aoe_token(color, shape, feet);
 				});
 				return button;
 			});

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -409,10 +409,13 @@ class MessageBroker {
 			}
 			if(msg.eventType == "custom/myVTT/createtoken"){
 				if(window.DM){
-					let fake=$("<div/>");
-					fake.attr(msg.data);
-					token_button({target:fake.get(0)});
-					fake.remove();
+					let left = parseInt(msg.data.left);
+					let top = parseInt(msg.data.top);
+					if (!isNaN(top) && !isNaN(left)) {
+						place_token_at_point(msg.data, left, top);
+					} else {
+						place_token_in_center_of_map(msg.data);
+					}
 				}
 			}
 

--- a/Token.js
+++ b/Token.js
@@ -99,6 +99,10 @@ class Token {
 			this.persist();
 	}
 	delete(persist=true,sync=true) {
+		if (!window.DM && this.options.deleteableByPlayers != true) {
+			// only allow the DM to delete tokens unless the token specifies deleteableByPlayers == true which is used by AoE tokens and maybe others
+			return;
+		}
 		ct_remove_token(this, false);
 		let id = this.options.id;
 		let selector = "div[data-id='" + id + "']";
@@ -1246,162 +1250,6 @@ function default_options() {
 	};
 }
 
-function token_button(e, tokenIndex = null, tokenTotal = null) {
-	console.log(e.target.outerHTML);
-	let imgsrc = parse_img($(e.target).attr("data-img"));
-	if (imgsrc.startsWith("data:")){
-		alert("WARNING! Support for token urls that starts with data: will be removed soon (as they can cause problems). Please find an image with url that begins with http:// or https://");
-	}
-	let id;
-	let centerX = $(window).scrollLeft() + Math.round(+$(window).width() / 2) - 200;
-	let centerY = $(window).scrollTop() + Math.round($(window).height() / 2) - 200;
-
-	centerX = Math.round(centerX * (1.0 / window.ZOOM));
-	centerY = Math.round(centerY * (1.0 / window.ZOOM));
-
-	if( $(e.target).attr("data-top"))
-		centerY=$(e.target).attr("data-top");
-	if( $(e.target).attr("data-left"))
-		centerX=$(e.target).attr("data-left");
-	id = $(e.target).attr('data-set-token-id');
-	if (typeof (id) === "undefined") {
-		id = uuid();
-	}
-
-	// if this is a player token, check if the token is already on the map
-	if(id in window.TOKEN_OBJECTS){
-		if(window.TOKEN_OBJECTS[id].isPlayer())
-		{
-			window.TOKEN_OBJECTS[id].highlight();
-			return;
-		}
-	}
-	
-	let options = default_options();
-	options.id = id;
-	options.imgsrc = imgsrc;
-	options.left = `${centerX}px`;
-	options.top = `${centerY}px`;
-	
-	if(typeof $(e.target).attr('data-stat') !== "undefined"){ // APPLY SAVED TOKEN SETTINGS ONLY FOR MONSTERS
-		for(let o in window.TOKEN_SETTINGS){
-				if(window.TOKEN_SETTINGS[o]){
-					options[o]="1";
-				}
-		}
-	}
-	
-	
-	if ($(e.target).attr('data-size')) {
-		options.size = $(e.target).attr('data-size');
-	}
-
-	if ($(e.target).attr('data-disablestat')) {
-		options.disablestat = $(e.target).attr('data-disablestat');
-	}
-
-	if ($(e.target).attr('data-hidestat')) {
-		options.hidestat = $(e.target).attr('data-hidestat');
-	}
-	
-	if ($(e.target).attr('data-disableborder')) {
-		options.disableborder = $(e.target).attr('data-disableborder');
-	}
-	
-	if ($(e.target).attr('data-square')=="1") {
-		options.square = true;
-	}
-
-	if ($(e.target).attr('data-hp')) {
-		options.hp = $(e.target).attr('data-hp');
-	}
-
-	if ($(e.target).attr('data-maxhp')) {
-		options.max_hp = $(e.target).attr('data-maxhp');
-	}
-
-	if ($(e.target).attr('data-ac')) {
-		options.ac = $(e.target).attr('data-ac');
-	}
-
-	if ($(e.target).attr('data-elev')) {
-		options.elev = $(e.target).attr('data-elev');
-	}
-
-
-	if ($(e.target).attr('data-hidden')) {
-		options.hidden = true;
-	}
-
-	if ($(e.target).attr('data-revealname')) {
-		options.revealname = true;
-	}
-
-	if (typeof $(e.target).attr('data-stat') !== "undefined") {
-		options.monster = $(e.target).attr('data-stat');
-	}
-
-	if (options.monster || options.id.includes("/")) {
-		// monsters and players should use the global setting as the default
-		options.legacyaspectratio = window.TOKEN_SETTINGS['legacyaspectratio'];
-	} else if ($(e.target).attr('data-legacyaspectratio') == true || $(e.target).attr('data-legacyaspectratio') == 'true' || $(e.target).attr('data-legacyaspectratio') == undefined) {
-		// this is a custom token. It should use the setting that was defined when it was created
-		// if the option is undefined, this token was created before the option existed and should therefore use the legacy behavior
-		// if the option is true, the user actively enabled the option.
-		// if the option is false, then we want to preserve aspect ratio
-		options.legacyaspectratio = true;
-	}
-
-
-	if ($(e.target).attr('data-name')) {
-		options.name = $(e.target).attr('data-name');
-		if (options.monster > 0) { // ADD number to the end of named monsters
-			var count = 1;
-			for (var tokenid in window.TOKEN_OBJECTS) {
-				if (window.TOKEN_OBJECTS[tokenid].options.monster == options.monster)
-					count++;
-			}
-			if (count > 1) {
-				console.log("Count " + count);
-				options.name = $(e.target).attr('data-name') + " " + count;
-				options.color = "#" + TOKEN_COLORS[(count - 1) % 54];
-			}
-		}
-
-		let specifiedCustomImg = $(e.target).data('custom-img');
-		if (specifiedCustomImg != undefined && specifiedCustomImg.length > 0) {
-			// the user has specifically chosen a custom image so use it
-			options.imgsrc = specifiedCustomImg;
-		} else {
-			// if there are custom images defined, use those instead of the default DDB image
-			let customImgs = get_custom_monster_images($(e.target).attr('data-stat'));
-			if (customImgs != undefined && customImgs.length > 0) {
-				let randomIndex = getRandomInt(0, customImgs.length);
-				options.imgsrc = customImgs[randomIndex];
-			}
-		}
-	}
-
-	if (typeof $(e.target).attr('data-color') !== "undefined") {
-		options.color = $(e.target).attr('data-color');
-	}
-
-	if (tokenIndex !== null && tokenTotal !== null) {
-		options.left = (centerX + (((options.size || 68.33) * 5) / 2) * Math.cos(2 * Math.PI * tokenIndex / tokenTotal)) + 'px';
-		options.top = (centerY + (((options.size || 68.33) * 5) / 2) * Math.sin(2 * Math.PI * tokenIndex / tokenTotal)) + 'px';
-	}
-
-	//options = Object.assign({}, options, window.TOKEN_SETTINGS);
-	window.ScenesHandler.create_update_token(options);
-
-	if (id in window.PLAYER_STATS) {
-		window.MB.handlePlayerData(window.PLAYER_STATS[id]);
-	}
-
-	window.MB.sendMessage('custom/myVTT/token', options);
-
-}
-
 function place_token_in_center_of_map(tokenObject) {
 	let centerX = $(window).scrollLeft() + Math.round(+$(window).width() / 2) - 200;
 	let centerY = $(window).scrollTop() + Math.round($(window).height() / 2) - 200;
@@ -2213,6 +2061,7 @@ function token_menu() {
 
 				if (!is_monster && !is_player) {
 					delete ret.items.view;
+					delete ret.items.helptext;
 				}
 
 				if (is_monster) {
@@ -2243,7 +2092,6 @@ function token_menu() {
 					delete ret.items.sep1;
 					delete ret.items.hp;
 					delete ret.items.max_hp;
-					delete ret.items.delete;
 					delete ret.items.note_menu;
 					delete ret.items.name;
 					delete ret.items.sep2;
@@ -2253,6 +2101,11 @@ function token_menu() {
 						delete ret.items.sep3;
 						delete ret.items.imgsrcSelect;
 					}
+				}
+
+				if (!window.DM && window.TOKEN_OBJECTS[id].options.deleteableByPlayers != true) {
+					delete ret.items.delete;
+					delete ret.items.sep4;
 				}
 
 				return ret;
@@ -2657,17 +2510,21 @@ function paste_selected_tokens() {
 }
 
 function delete_selected_tokens() {
-	if (!window.DM) return;
-	window.TOKEN_OBJECTS_RECENTLY_DELETED = {};
+	
 	// move all the tokens into a separate list so the DM can "undo" the deletion
 	let tokensToDelete = [];
 	for (id in window.TOKEN_OBJECTS) {
 		let token = window.TOKEN_OBJECTS[id];
 		if (token.selected) {
-			window.TOKEN_OBJECTS_RECENTLY_DELETED[id] = Object.assign({}, token.options);
-			tokensToDelete.push(token);
+			if (window.DM || token.options.deleteableByPlayers == true) {				
+				window.TOKEN_OBJECTS_RECENTLY_DELETED[id] = Object.assign({}, token.options);
+				tokensToDelete.push(token);
+			}
 		}
 	}
+
+	if (tokensToDelete.length == 0) return;
+	window.TOKEN_OBJECTS_RECENTLY_DELETED = {};
 
 	if(window.CLOUD){
 		for (let i = 0; i < tokensToDelete.length; i++) {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -753,7 +753,6 @@ function register_token_row_context_menu() {
 	$(".custom-token-image-row").on("contextmenu", ".custom-token-image-row-add", function(event) {
 		event.preventDefault();
 		event.stopPropagation();
-		// token_button uses target which will often be the svg inside of the button, but we want to use the button which will always be currentTarget
 		let tokendatapath = $(event.currentTarget).attr("data-tokendatapath");
 		let tokendataname = $(event.currentTarget).attr("data-tokendataname");
 		if (tokendataname === undefined) {


### PR DESCRIPTION
This adds a new token option `deleteableByPlayers` which is checked when tokens are deleted. The only thing using it are AoE tokens since those are the only tokens that players can add to a scene.

AoE tokens were the only tokens still using the old `token_button` function so this also removes that function.

closes #263 