### PR TITLE
Journal.js edit_note - add options to tinyMCE initialize to fix url rewrite bug

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -312,6 +312,9 @@ class JournalManager{
 				'image': "/content/1-0-1688-0/js/tinymce/tiny_mce/plugins/image/plugin.min.js",
 				'videoembed': "/content/1-0-1688-0/js/tinymce/custom_plugins/videoembed/plugin.js",
 			},
+			relative_urls : false,
+			remove_script_host : false,
+			convert_urls : true,
 			save_onsavecallback: function(e) {
 				// @todo !IMPORTANT grab the id somewhere from the form, so that you can use this safely
 				let note_id = $(this.getElement()).attr('data-note-id');


### PR DESCRIPTION
When embedding an image into journal entries, tinyMCE was trying to re-write certain urls (any image loading from dndbeyond domain) from absolute to relative.  This was causing players to not be able to see the image since the relative path is different from the player page vs. the dm page.  Adding a few lines to the tinyMCE init fixes this.

