### PR TITLE
Bugfix: Minor css changes for menus and ct

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -4,6 +4,8 @@ function init_combat_tracker(){
 	
 	ct=$("<div id='combat_tracker'/>");
 	ct.css("height","20px"); // IMPORTANT
+	ct.css("z-index", 1)
+	
 	toggle=$("<div id='combat_button' class='hideable ddbc-tab-options__header-heading' style='display:inline-block'><u>C</u>OMBAT</div>");
 	toggle.click(function(){
 		if($("#combat_tracker_inside").is(":visible")){

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -161,6 +161,8 @@ button.gamelog-to-everyone-button {
 .top_menu.visible {
     max-height: 100%;
     overflow-y: auto;
+    border: solid black 1px;
+    z-index: 2;
 }
 
 div.ct-sidebar__controls {


### PR DESCRIPTION
A few minor css changes in response to a couple bug reports. Makes it so that the dropdown: fog, draw, aoe menus can be used with the combat tracker active.


<img width="302" alt="Screen Shot 2022-03-16 at 8 52 57 AM" src="https://user-images.githubusercontent.com/95775779/158594140-3a9cd694-a5c0-4622-9577-248172d03e62.png">
.