### PR TITLE
#276 : resolved homebrew monster not cascading onerror down to MB

### DIFF
--- a/EncounterHandler.js
+++ b/EncounterHandler.js
@@ -690,8 +690,12 @@ function inject_monster_image(stat) {
 	}
 	if (window.EncounterHandler.combat_body.find(".encounter-details-content-section__content .injected-image").length == 0) {
 		let content = window.EncounterHandler.combat_body.find(".encounter-details-content-section__content");
-		let image = `<img style="width:100%" class="injected-image" src="${stat.data.largeAvatarUrl}"
+		const image = stat.data.isHomebrew ?
+			`<img style="width:100%" class="injected-image" src="${stat.data.avatarUrl}"
+			alt="${stat.data.name}" class="monster-image" ;onerror=''></img>`
+		 	: `<img style="width:100%" class="injected-image" src="${stat.data.largeAvatarUrl}"
 			alt="${stat.data.name}" class="monster-image" onerror="this.src='${stat.data.avatarUrl}'";onerror=''></img>`;
+
 		content.find(".mon-stat-block").after(image);
 		let button = $("<button class='ddbeb-button monster-details-link'>SEND IMAGE TO GAMELOG</button>");
 		button.css({ "float": "right" });


### PR DESCRIPTION
fix #276 
This is a homebrew monster.
It appears that the `onerror` does not propogate down into the MB. Tried a few different ways to get it to go down but this seemed like the most sensible solution
![image](https://user-images.githubusercontent.com/9283242/158666698-59618b56-524a-4e02-98c3-7b609aeb9e8a.png)
