### PR TITLE
temporarily disable monster row drag and drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 .history
+.idea

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -214,7 +214,8 @@ function update_monster_row(monsterRow) {
 	let avatar = monsterRow.find(".monster-row__cell--avatar");
 	avatar.attr('data-monster', monsterId);
 	avatar.attr('data-name', monsterName);
-	make_element_draggable_token(avatar, true);
+	// this is currently broken as of the update to jquery 3.6.0. https://github.com/cyruzzo/AboveVTT/issues/287
+	// make_element_draggable_token(avatar, true);
 	avatar.click(function(event) {
 		event.stopPropagation();
 		event.preventDefault();


### PR DESCRIPTION
I think we should temporarily disable drag and drop form a monsterPanel row. It is currently broken and leaves an img in the top left corner of the map until you refresh. Until a real fix can be implemented, we should prevent the bad experience.

This is not a solution to https://github.com/cyruzzo/AboveVTT/issues/287, so this issue should not get closed if this PR is merged.