### PR TITLE
stop creating encounters on the encounter page

### DIFF
--- a/EncounterHandler.js
+++ b/EncounterHandler.js
@@ -45,7 +45,7 @@ class EncounterHandler {
 		this.fetch_feature_flags(function() {
 			window.EncounterHandler.fetch_all_encounters(function () {
 				window.EncounterHandler.delete_all_avtt_encounters(function () {
-					window.EncounterHandler.create_avtt_encounter(function() {
+					window.EncounterHandler.fetch_or_create_avtt_encounter(function() {
 						callback();
 					});
 				});


### PR DESCRIPTION
When you refresh the page on the encounters page, we would create a new encounter unnecessarily. It would eventually get cleaned up when you launch again, but we don't need to be doing that.

closes #340