### PR TITLE
Update MessageBroker.js

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -392,6 +392,7 @@ class MessageBroker {
 			if(msg.eventType=="custom/myVTT/delete_token"){
 				let tokenid=msg.data.id;
 				if(tokenid in window.TOKEN_OBJECTS)
+					window.TOKEN_OBJECTS[tokenid].options.deleteableByPlayers = true;
 					window.TOKEN_OBJECTS[tokenid].delete(false,false);
 			}
 			if(msg.eventType == "custom/myVTT/createtoken"){


### PR DESCRIPTION
Fixes #333 This should allow the token delete to sync again. The problem seems to be the delete function was stopping if they weren't deleteable by players. This sets the deleteable by players flag to true for delete messages sent.