### PR TITLE
Improve encounter handler startup flow

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2849,7 +2849,13 @@ $(function() {
 				window.PLAYER_IMG = 'https://media-waterdeep.cursecdn.com/attachments/thumbnails/0/14/240/160/avatar_2.png';
 				init_above();
 			}
+
+			let oldText = $(".joindm").text();
 			$(".joindm").removeClass("button-loading");
+			$(".joindm").text("Check for blocked pop ups!");
+			setTimeout(function () {
+				$(".joindm").text(oldText);
+			}, 2000);
 		});
 	});
 	

--- a/Main.js
+++ b/Main.js
@@ -1525,7 +1525,7 @@ function init_things() {
 	if (window.DM) {
 		window.CONNECTED_PLAYERS['0'] = abovevtt_version; // ID==0 is DM
 		window.ScenesHandler = new ScenesHandler(gameId);
-		window.EncounterHandler = new EncounterHandler(function() {
+		window.EncounterHandler = new EncounterHandler(function(wasSuccessful) {
 			init_ui();
 			if (is_encounters_page()) {
 

--- a/Main.js
+++ b/Main.js
@@ -1525,7 +1525,10 @@ function init_things() {
 	if (window.DM) {
 		window.CONNECTED_PLAYERS['0'] = abovevtt_version; // ID==0 is DM
 		window.ScenesHandler = new ScenesHandler(gameId);
-		window.EncounterHandler = new EncounterHandler(function(wasSuccessful) {
+		window.EncounterHandler = new EncounterHandler(function(didSucceed) {
+			if (didSucceed === false) {
+				alert("An unexpected error occurred! Please check the developer console for errors, and report this via the AboveVTT Discord.");
+			}
 			init_ui();
 			if (is_encounters_page()) {
 
@@ -2830,8 +2833,11 @@ $(function() {
 		e.preventDefault();
 		$(".joindm").addClass("button-loading");
 		gather_pcs();
-		window.EncounterHandler = new EncounterHandler(function() {
-			if (window.EXPERIMENTAL_SETTINGS[ddbDiceKey] == true && window.EncounterHandler.avttId !== undefined && window.EncounterHandler.avttId.length > 0) {
+		window.EncounterHandler = new EncounterHandler(function(didSucceed) {
+			if (didSucceed === false) {
+				alert("An unexpected error occurred! Please check the developer console for errors, and report this via the AboveVTT Discord.");
+			}
+			if (window.EXPERIMENTAL_SETTINGS[ddbDiceKey] === true && window.EncounterHandler.avttId !== undefined && window.EncounterHandler.avttId.length > 0) {
 				let cs=$(".ddb-campaigns-invite-primary").text().split("/").pop();
 				window.open(`https://www.dndbeyond.com/encounters/${window.EncounterHandler.avttId}?cs=${cs}&cid=${get_campaign_id()}&abovevtt=true`, '_blank');
 			} else {

--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -8,13 +8,6 @@ function init_monster_panel() {
 		return;
 	}
 	monster_panel_init_started = true;
-	// cover the panel while we fetch, and alter it
-	window.EncounterHandler.fetch_or_create_avtt_encounter(function(encounter) {
-		init_monster_panel_with_encounter();
-	});
-}
-
-function init_monster_panel_with_encounter() {
 
 	if ($("#iframe-monster-panel").length > 0) {
 		// we already did this


### PR DESCRIPTION
closes #341 

1. reduce the risk of unintentionally creating or deleting encounters on refresh DM refresh
2. alert users that experience fatal errors during encounter handler startup
3. temporarily prompt users that may have a pop-up blocker. Most users will never see this, but those that get blocked, will.
