### PR TITLE
mon image shows even when homebrew

### DIFF
--- a/EncounterHandler.js
+++ b/EncounterHandler.js
@@ -808,6 +808,14 @@ function inject_monster_image(stat) {
 		console.groupEnd();
 		return;
 	}
+	// weirdly if either of the url numbers in these 2 positions aren't 1000 it throws a 403 error...
+	let splitUrl = stat.data.largeAvatarUrl.split("/")
+	if ([splitUrl.length -2] !== 1000 || [splitUrl.length -3] !== 1000){
+		splitUrl[splitUrl.length -2] = 1000
+		splitUrl[splitUrl.length -3] = 1000
+		stat.data.largeAvatarUrl = (splitUrl).join("/")
+	}
+	
 	if (window.EncounterHandler.combat_body.find(".encounter-details-content-section__content .injected-image").length == 0) {
 		let content = window.EncounterHandler.combat_body.find(".encounter-details-content-section__content");
 		const image = `<img style="width:100%" class="injected-image" src="${stat.data.largeAvatarUrl}"


### PR DESCRIPTION
found a weird bug with urls in which the large avatar url is saved onto the monster but it might be wrong. the last 2 sections of the url have to be 1000 otherwise it fails

shown it working
https://discord.com/channels/815028457851191326/815028804103307354/959469570110939156