### PR TITLE
Stop scroll when switching scenes and improve performance of scene panel

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1086,7 +1086,6 @@ class MessageBroker {
 		}
 
 		if(window.CLOUD && window.DM){
-			refresh_scenes();
 			$("#combat_area").empty();
 			ct_load();
 		}

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -852,56 +852,55 @@ function refresh_scenes() {
 		controls.append(delete_button);
 		newobj.append(controls);
 
-		$("#addscene").parent().before(newobj);
-
-		$("#scene_selector").sortable({
-			handle: ".scene_title",
-			forcePlaceholderSize: true,
-			placeholder: "sortable_placeholder", 
-			update: function(event, ui) {
-				let fromSceneIndex = ui.item.attr("data-scene-index");
-				let toSceneIndex;
-				let j = 0;
-				let tempScenes = [];
-				$("#scene_selector").children('.scene').each(function(j) {
-					let oldSceneID = $(this).attr("data-scene-index");
-					if (fromSceneIndex == oldSceneID) {
-						toSceneIndex = j;
-					}
-					tempScenes.push(window.ScenesHandler.scenes[oldSceneID]);
-					$(this).attr("data-scene-index", j);
-					if ($(this).hasClass('active_scene')) {
-						window.ScenesHandler.current_scene_id = j;
-					}
-					j++;
-				});
-				console.log("Scene "+fromSceneIndex+" moved to "+toSceneIndex);
-				if(window.CLOUD){
-					let neworder;
-					console.log(window.ScenesHandler.scenes);
-					if(toSceneIndex < fromSceneIndex){ // moving back
-						if(toSceneIndex==0)
-							neworder=window.ScenesHandler.scenes[0].order-100;
-						else
-							neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex-1].order)/2);
-					}
-					else{
-						if(toSceneIndex==(window.ScenesHandler.scenes.length-1)){
-							neworder=window.ScenesHandler.scenes[toSceneIndex].order+100;
-						}
-						else
-							neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex+1].order)/2);
-					}
-					window.ScenesHandler.scenes[fromSceneIndex].order=neworder;
-					window.ScenesHandler.persist_scene(fromSceneIndex);
-				}
-				window.ScenesHandler.scenes = tempScenes;
-				window.ScenesHandler.persist();
-				refresh_scenes();
-			}
-		});
-		$("#scene_selector").css("overflow","auto");
+		$("#addscene").parent().before(newobj);	
 	}
+	$("#scene_selector").sortable({
+		handle: ".scene_title",
+		forcePlaceholderSize: true,
+		placeholder: "sortable_placeholder", 
+		update: function(event, ui) {
+			let fromSceneIndex = ui.item.attr("data-scene-index");
+			let toSceneIndex;
+			let j = 0;
+			let tempScenes = [];
+			$("#scene_selector").children('.scene').each(function(j) {
+				let oldSceneID = $(this).attr("data-scene-index");
+				if (fromSceneIndex == oldSceneID) {
+					toSceneIndex = j;
+				}
+				tempScenes.push(window.ScenesHandler.scenes[oldSceneID]);
+				$(this).attr("data-scene-index", j);
+				if ($(this).hasClass('active_scene')) {
+					window.ScenesHandler.current_scene_id = j;
+				}
+				j++;
+			});
+			console.log("Scene "+fromSceneIndex+" moved to "+toSceneIndex);
+			if(window.CLOUD){
+				let neworder;
+				console.log(window.ScenesHandler.scenes);
+				if(toSceneIndex < fromSceneIndex){ // moving back
+					if(toSceneIndex==0)
+						neworder=window.ScenesHandler.scenes[0].order-100;
+					else
+						neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex-1].order)/2);
+				}
+				else{
+					if(toSceneIndex==(window.ScenesHandler.scenes.length-1)){
+						neworder=window.ScenesHandler.scenes[toSceneIndex].order+100;
+					}
+					else
+						neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex+1].order)/2);
+				}
+				window.ScenesHandler.scenes[fromSceneIndex].order=neworder;
+				window.ScenesHandler.persist_scene(fromSceneIndex);
+			}
+			window.ScenesHandler.scenes = tempScenes;
+			window.ScenesHandler.persist();
+			refresh_scenes();
+		}
+	});
+	$("#scene_selector").css("overflow","auto");
 }
 
 function init_scene_selector() {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -898,6 +898,7 @@ function refresh_scenes() {
 				}
 				window.ScenesHandler.scenes = tempScenes;
 				window.ScenesHandler.persist();
+				refresh_scenes();
 			}
 		});
 		$("#scene_selector").css("overflow","auto");

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -854,52 +854,54 @@ function refresh_scenes() {
 
 		$("#addscene").parent().before(newobj);	
 	}
-	$("#scene_selector").sortable({
-		handle: ".scene_title",
-		forcePlaceholderSize: true,
-		placeholder: "sortable_placeholder", 
-		update: function(event, ui) {
-			let fromSceneIndex = ui.item.attr("data-scene-index");
-			let toSceneIndex;
-			let j = 0;
-			let tempScenes = [];
-			$("#scene_selector").children('.scene').each(function(j) {
-				let oldSceneID = $(this).attr("data-scene-index");
-				if (fromSceneIndex == oldSceneID) {
-					toSceneIndex = j;
-				}
-				tempScenes.push(window.ScenesHandler.scenes[oldSceneID]);
-				$(this).attr("data-scene-index", j);
-				if ($(this).hasClass('active_scene')) {
-					window.ScenesHandler.current_scene_id = j;
-				}
-				j++;
-			});
-			console.log("Scene "+fromSceneIndex+" moved to "+toSceneIndex);
-			if(window.CLOUD){
-				let neworder;
-				console.log(window.ScenesHandler.scenes);
-				if(toSceneIndex < fromSceneIndex){ // moving back
-					if(toSceneIndex==0)
-						neworder=window.ScenesHandler.scenes[0].order-100;
-					else
-						neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex-1].order)/2);
-				}
-				else{
-					if(toSceneIndex==(window.ScenesHandler.scenes.length-1)){
-						neworder=window.ScenesHandler.scenes[toSceneIndex].order+100;
+	if(!$("#scene_selector").hasClass("ui-sortable")) {
+		$("#scene_selector").sortable({
+			handle: ".scene_title",
+			forcePlaceholderSize: true,
+			placeholder: "sortable_placeholder", 
+			update: function(event, ui) {
+				let fromSceneIndex = ui.item.attr("data-scene-index");
+				let toSceneIndex;
+				let j = 0;
+				let tempScenes = [];
+				$("#scene_selector").children('.scene').each(function(j) {
+					let oldSceneID = $(this).attr("data-scene-index");
+					if (fromSceneIndex == oldSceneID) {
+						toSceneIndex = j;
 					}
-					else
-						neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex+1].order)/2);
+					tempScenes.push(window.ScenesHandler.scenes[oldSceneID]);
+					$(this).attr("data-scene-index", j);
+					if ($(this).hasClass('active_scene')) {
+						window.ScenesHandler.current_scene_id = j;
+					}
+					j++;
+				});
+				console.log("Scene "+fromSceneIndex+" moved to "+toSceneIndex);
+				if(window.CLOUD){
+					let neworder;
+					console.log(window.ScenesHandler.scenes);
+					if(toSceneIndex < fromSceneIndex){ // moving back
+						if(toSceneIndex==0)
+							neworder=window.ScenesHandler.scenes[0].order-100;
+						else
+							neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex-1].order)/2);
+					}
+					else{
+						if(toSceneIndex==(window.ScenesHandler.scenes.length-1)){
+							neworder=window.ScenesHandler.scenes[toSceneIndex].order+100;
+						}
+						else
+							neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex+1].order)/2);
+					}
+					window.ScenesHandler.scenes[fromSceneIndex].order=neworder;
+					window.ScenesHandler.persist_scene(fromSceneIndex);
 				}
-				window.ScenesHandler.scenes[fromSceneIndex].order=neworder;
-				window.ScenesHandler.persist_scene(fromSceneIndex);
+				window.ScenesHandler.scenes = tempScenes;
+				window.ScenesHandler.persist();
+				refresh_scenes();
 			}
-			window.ScenesHandler.scenes = tempScenes;
-			window.ScenesHandler.persist();
-			refresh_scenes();
-		}
-	});
+		});
+	}
 	$("#scene_selector").css("overflow","auto");
 }
 

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -898,7 +898,6 @@ function refresh_scenes() {
 				}
 				window.ScenesHandler.scenes = tempScenes;
 				window.ScenesHandler.persist();
-				refresh_scenes();
 			}
 		});
 		$("#scene_selector").css("overflow","auto");

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -771,11 +771,11 @@ function refresh_scenes() {
 		newobj.append(title);
 		controls = $("<div/>");
 		if(window.CLOUD){
-			let switch_players=$("<button>PLAYERS</button>");
+			let switch_players=$("<button class='player_scenes_button'>PLAYERS</button>");
 
 			if(window.PLAYER_SCENE_ID==window.ScenesHandler.scenes[scene_id].id){
 				console.log("players are here!");
-				switch_players.css("background","#FF7F7F");
+				switch_players.addClass("selected");
 			}
 
 			switch_players.click(function(){
@@ -783,20 +783,24 @@ function refresh_scenes() {
 					sceneId:window.ScenesHandler.scenes[scene_id].id,
 				};
 				window.PLAYER_SCENE_ID=window.ScenesHandler.scenes[scene_id].id;
-				refresh_scenes();
+				$(".player_scenes_button.selected").removeClass("selected");
+				$(this).addClass("selected");
 				window.MB.sendMessage("custom/myVTT/switch_scene",msg);
 				add_zoom_to_storage()
 			});
 			
-			let switch_dm=$("<button>DM</button>");
+			let switch_dm=$("<button class='dm_scenes_button'>DM</button>");
 			if(window.CURRENT_SCENE_DATA && (window.CURRENT_SCENE_DATA.id==window.ScenesHandler.scenes[scene_id].id)){
-				switch_dm.css("background","#FF7F7F");
+				switch_dm.addClass("selected");
 			}
 			switch_dm.click(function(){
+				$(".dm_scenes_button.selected").removeClass("selected");
+				console.log("remove selected!!!!!!!!!!!!!!!!!!!!!!!!!");
 				let msg={
 					sceneId:window.ScenesHandler.scenes[scene_id].id,
 					switch_dm: true
 				};
+				$(this).addClass("selected");
 				window.MB.sendMessage("custom/myVTT/switch_scene",msg);
 				add_zoom_to_storage()
 			});

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -795,7 +795,6 @@ function refresh_scenes() {
 			}
 			switch_dm.click(function(){
 				$(".dm_scenes_button.selected").removeClass("selected");
-				console.log("remove selected!!!!!!!!!!!!!!!!!!!!!!!!!");
 				let msg={
 					sceneId:window.ScenesHandler.scenes[scene_id].id,
 					switch_dm: true

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2049,6 +2049,15 @@ button.avtt-roll-button {
     z-index: 58000;
 }
 
+.dm_scenes_button.selected,
+.player_scenes_button.selected{
+    background: #ff7f7f;
+}
+.scene .dm_scenes_button,
+.scene .player_scenes_button{
+    transition: none;
+}
+
 .button-loading::after {
     content: "";
     position: absolute;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2050,11 +2050,13 @@ button.avtt-roll-button {
 }
 
 .dm_scenes_button.selected,
-.player_scenes_button.selected{
+.player_scenes_button.selected,
+.dm_scenes_button.selected:hover,
+.player_scenes_button.selected:hover{
     background: #ff7f7f;
 }
 .scene .dm_scenes_button,
-.scene .player_scenes_button{
+.scene .player_scenes_button {
     transition: none;
 }
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -472,7 +472,7 @@ div#scene_properties form > div {
     max-height: 60vh;
     min-width: 200px;
     width: calc(100vw - 720px);
-    max-width: 748px;
+    max-width: 750px;
     z-index: 9999;
     border: solid black 2px;
     overflow: auto;


### PR DESCRIPTION
Closes #358 

I believe this also Fixes #384 

I believe the actual request once figured out on discord was to not have the scenes panel scroll up when selecting a new scene. So you can easily switch both players and DM.

https://user-images.githubusercontent.com/65363489/161395246-7b13a1ef-f946-434b-a021-0f047a4568a1.mp4


