### PR TITLE
Fix for slow dice

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -610,7 +610,7 @@ class MessageBroker {
 				    ((window.DM && msg.data.context.entityType === "user") || window.PLAYER_ID == msg.data.context.entityId)) {
 					console.log("Hooking requestAnimationFrame for dice roll");
 					this.origRequestAnimFrame = window.requestAnimationFrame;
-					window.requestAnimationFrame = function(cb) { setTimeout(cb, 33); }
+					window.requestAnimationFrame = function(cb) { setTimeout(cb, 1); }
 				}
 				// check for injected_data!
 				if(msg.data.injected_data){


### PR DESCRIPTION
Fixes #385 

Reduced the timeout to 1 and it fixes the slow dice.

https://user-images.githubusercontent.com/65363489/161475576-7c35b97a-68f1-468f-89f5-107b85c92635.mp4

Note: since the changes they made to encounters and the character sheet my dice roll dummy fast like this on all of dndbeyond.
