### PR TITLE
Bugfix - for players owning tokens

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -571,24 +571,6 @@ class Token {
 		console.groupEnd()
 	}
 
-	/**
-	 * Changes token options to give power over to the player
-	 * @param token jquery selected div with the class "token"
-	 */
-	toggle_player_owned(token){
-		console.group("toggle_player_owned")
-		// give player "full" control of token
-		if (this.options.player_owned){
-			this.options.restrictPlayerMove = false
-			this.options.hidestat = false
-			this.options.disablestat = false
-		}
-		else if (!this.options.player_owned && !window.DM){		
-			this.options.restrictPlayerMove = true
-			this.options.hidestat = true
-		}
-		console.groupEnd()
-	}
 
 	build_conditions(parent) {
 		let self=this;
@@ -1241,7 +1223,6 @@ class Token {
 		selector = "div[data-id='" + this.options.id + "']";
 		let token = $("#tokens").find(selector);
 		this.build_stats(token)
-		this.toggle_player_owned(token)
 		this.toggle_stats(token)
 		this.update_health_aura(token)
 		this.update_dead_cross(token)

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1804,17 +1804,17 @@ function token_context_menu_expanded(tokenIds) {
 	// options
 	body.append("<h3 class='token-image-modal-footer-title' style='margin-top: 30px;'>Options</h3>");
 	const token_settings = [
-		{ name: 'hidden', label: 'Hide' },
-		{ name: 'square', label: 'Square Token' },
-		{ name: 'locked', label: 'Lock Token in Position' },
-		{ name: 'restrictPlayerMove', label: 'Restrict Player Movement' },
-		{ name: 'disablestat', label: 'Disable HP/AC' },
-		{ name: 'hidestat', label: 'Hide HP/AC from players' },
-		{ name: 'disableborder', label: 'Disable Border' },
-		{ name: 'disableaura', label: 'Disable Health Meter' },
-		{ name: 'revealname', label: 'Show name to players' },
-		{ name: 'legacyaspectratio', label: 'Ignore Image Aspect Ratio' },
-		{ name: 'player_owned', label: 'Players can access this token (HP/Stats)'}
+		{ name: 'hidden', label: 'Hide', enabledDescription:'Token is hidden to players', disabledDescription: 'Token is visible to players' },
+		{ name: 'square', label: 'Square Token', enabledDescription:'Token is square', disabledDescription: 'Token is round' },
+		{ name: 'locked', label: 'Lock Token in Position', enabledDescription:'Token is not moveable. Combine with "Restrict Player Movement" to make token appear as part of background to players', disabledDescription: 'Token is moveable' },
+		{ name: 'restrictPlayerMove', label: 'Restrict Player Movement', enabledDescription:'Token is not moveable by players. Combine with "Lock Token in Position" to make token appear as part of background to players', disabledDescription: 'Players can move token' },
+		{ name: 'disablestat', label: 'Disable HP/AC', enabledDescription:'Token stats are not visible to players', disabledDescription: 'Token stats are visible to players' },
+		{ name: 'hidestat', label: 'Hide Player HP/AC from players', enabledDescription:'If player token, other players wont see token stats. Does not affect monster tokens', disabledDescription: 'Players can view token stats of other players' },
+		{ name: 'disableborder', label: 'Disable Border', enabledDescription:'No border', disabledDescription: 'Token has a random coloured border'  },
+		{ name: 'disableaura', label: 'Disable Health Meter', enabledDescription:'No health glow', disabledDescription: 'Token has health glow corresponding with their current health' },
+		{ name: 'revealname', label: 'Show name to players', enabledDescription:'Players will see token name on hover', disabledDescription: 'Token name is hidden' },
+		{ name: 'legacyaspectratio', label: 'Ignore Image Aspect Ratio', enabledDescription:'Ignores image aspect ratio', disabledDescription: 'Does not ignore aspect ratio' },
+		{ name: 'player_owned', label: 'Players can access this tokens sheet', enabledDescription:'Allows players to view this tokens sheet', disabledDescription: 'Players cant view this tokens sheet'}
 	];
 	for(let i = 0; i < token_settings.length; i++) {
 		let setting = token_settings[i];
@@ -1834,7 +1834,7 @@ function token_context_menu_expanded(tokenIds) {
 		body.append(inputWrapper);
 	}
 
-	let resetToDefaults = $(`<button class="token-image-modal-remove-all-button" title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px 30px 0px;">Reset Token Settings to Defaults</button>`);
+	let resetToDefaults = $(`<button class='token-image-modal-remove-all-button" title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px 30px 0px;">Reset Token Settings to Defaults</button>`);
 	resetToDefaults.on("click", function (clickEvent) {
 		for (let i = 0; i < token_settings.length; i++) {
 			let setting = token_settings[i];

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1804,17 +1804,17 @@ function token_context_menu_expanded(tokenIds) {
 	// options
 	body.append("<h3 class='token-image-modal-footer-title' style='margin-top: 30px;'>Options</h3>");
 	const token_settings = [
-		{ name: 'hidden', label: 'Hide', enabledDescription:'Token is hidden to players', disabledDescription: 'Token is visible to players' },
-		{ name: 'square', label: 'Square Token', enabledDescription:'Token is square', disabledDescription: 'Token is round' },
-		{ name: 'locked', label: 'Lock Token in Position', enabledDescription:'Token is not moveable. Combine with "Restrict Player Movement" to make token appear as part of background to players', disabledDescription: 'Token is moveable' },
-		{ name: 'restrictPlayerMove', label: 'Restrict Player Movement', enabledDescription:'Token is not moveable by players. Combine with "Lock Token in Position" to make token appear as part of background to players', disabledDescription: 'Players can move token' },
-		{ name: 'disablestat', label: 'Disable HP/AC', enabledDescription:'Token stats are not visible to players', disabledDescription: 'Token stats are visible to players' },
-		{ name: 'hidestat', label: 'Hide Player HP/AC from players', enabledDescription:'If player token, other players wont see token stats. Does not affect monster tokens', disabledDescription: 'Players can view token stats of other players' },
-		{ name: 'disableborder', label: 'Disable Border', enabledDescription:'No border', disabledDescription: 'Token has a random coloured border'  },
-		{ name: 'disableaura', label: 'Disable Health Meter', enabledDescription:'No health glow', disabledDescription: 'Token has health glow corresponding with their current health' },
-		{ name: 'revealname', label: 'Show name to players', enabledDescription:'Players will see token name on hover', disabledDescription: 'Token name is hidden' },
-		{ name: 'legacyaspectratio', label: 'Ignore Image Aspect Ratio', enabledDescription:'Ignores image aspect ratio', disabledDescription: 'Does not ignore aspect ratio' },
-		{ name: 'player_owned', label: 'Players can access this tokens sheet', enabledDescription:'Allows players to view this tokens sheet', disabledDescription: 'Players cant view this tokens sheet'}
+		{ name: "hidden", label: "Hide", enabledDescription:"Token is hidden to players", disabledDescription: "Token is visible to players" },
+		{ name: "square", label: "Square Token", enabledDescription:"Token is square", disabledDescription: "Token is round" },
+		{ name: "locked", label: "Lock Token in Position", enabledDescription:"Token is not moveable, Players can not select this token", disabledDescription: "Token is moveable by at least the DM, players can select it however" },
+		{ name: "restrictPlayerMove", label: "Restrict Player Movement", enabledDescription:"Token is not moveable by players", disabledDescription: "Token is moveable by any player" },
+		{ name: "disablestat", label: "Disable HP/AC", enabledDescription:"Token stats are not visible", disabledDescription: "Token stats are visible to at least the DM" },
+		{ name: "hidestat", label: "Hide Player HP/AC from players", enabledDescription:"Token stats are hidden from players", disabledDescription: "Token stats are visible to players" },
+		{ name: "disableborder", label: "Disable Border", enabledDescription:"Token has no border", disabledDescription: "Token has a random coloured border"  },
+		{ name: "disableaura", label: "Disable Health Meter", enabledDescription:"Token has no health glow", disabledDescription: "Token has health glow corresponding with their current health" },
+		{ name: "revealname", label: "Show name to players", enabledDescription:"Token on hover name is visible to players", disabledDescription: "Token name is hidden to players" },
+		{ name: "legacyaspectratio", label: "Ignore Image Aspect Ratio", enabledDescription:"Token will stretch non-square images to fill the token space", disabledDescription: "Token will respect the aspect ratio of the image provided" },
+		{ name: "player_owned", label: "Player access to sheet/stats", enabledDescription:"Tokens' sheet is accessible to players via RMB click on token. If token stats is visible to players, players can modify the hp of the token", disabledDescription: "Tokens' sheet is not accessible to players. Players can't modify token stats"}
 	];
 	for(let i = 0; i < token_settings.length; i++) {
 		let setting = token_settings[i];


### PR DESCRIPTION
fixes #396 
Removed shortcutting "token owned by player" modifying other options. The DM now has more control over what the token does, so they could allow players to view a tokens sheet, but not show their hp/ac, or not allow them to move the token (this could be very cool if you have siege weapons or something like that)

Added enabled/disabled descriptions from token configuration menu as they were missing (the function had them as inputs though 😄 )
