### PR TITLE
fix drawing clear and undo not functioning properly

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2516,12 +2516,17 @@ function init_buttons() {
 			if (r === true) {
 				window.DRAWINGS = [];
 				redraw_drawings();
-				window.ScenesHandler.persist();
-				window.ScenesHandler.sync();
+				if(window.CLOUD){
+					sync_drawings();
+				} else {
+					window.ScenesHandler.persist();
+					window.ScenesHandler.sync();
+				}
 			}
 		});
 
 		draw_menu.find("#draw_undo").click(function() {
+			console.log("undo once")
 			window.DRAWINGS.pop();
 			redraw_drawings();
 			if(window.CLOUD){
@@ -2533,18 +2538,6 @@ function init_buttons() {
 			}
 		}
 	);
-
-	draw_menu.find("#draw_undo").click(function() {
-		window.DRAWINGS.pop();
-		redraw_drawings();
-		if(window.CLOUD){
-			sync_drawings();
-		}
-		else{
-			window.ScenesHandler.persist();
-			window.ScenesHandler.sync();
-		}
-	});
 
 		colors = $("<div class='ccpicker' style='background: #D32F2F;' />");
 			


### PR DESCRIPTION
Closes #388 

There was also a bug where the Undo button would pop twice instead of once. I think the click handler got duplicated during some merge conflict so I removed the extra click handler and now it works correctly