### PR TITLE
added some user feedback so they know they have to specify a name

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1169,6 +1169,8 @@ function submit_custom_token_form(sidebarPanel, path) {
 	let nameInput = inputWrapper.find(`input[name='addCustomName']`)[0];
 	let name = nameInput.value;
 	if (name === undefined || name.length == 0) {
+		$(nameInput).css("border","1px solid red")
+		$(nameInput).attr("placeholder","token name is required")
 		console.warn("not saving a token with no name");
 		return;
 	}


### PR DESCRIPTION
Some person was a bit confused as to why he couldn't add in a token 
https://discord.com/channels/815028457851191326/852495991227809802/965231200119709726

we didn't provide any feedback to say name was required. This resolves that