### PR TITLE
Fix: The remove from combat button in the combat tracker should now update the token combat status properly.

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -339,10 +339,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	del=$('<button class="removeTokenCombatButton" style="font-size:10px;"><svg class="delSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg></button>');
 	del.click(
 		function(){
-			if($(this).parent().parent().attr("data-current")=="1"){
-				$("#combat_next_button").click();
-			}
-			$(this).parent().parent().remove();
+			ct_remove_token(token);
 			ct_persist();
 		}
 	);


### PR DESCRIPTION
The remove from combat button in the combat tracker should now update the token combat status properly. 

fixes #413 