### PR TITLE
Fix: Align buttons properly in the combat tracker for custom tokens and other tokens with fewer buttons.

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2882,17 +2882,17 @@ button.avtt-roll-button {
     pointer-events: none;
 }
 
-.encounter-builder-app #combat_tracker td button:first-child:nth-last-child(1) {
+.encounter-builder-app #combat_area td button:first-child:nth-last-child(1) {
     margin-right:60px;
 }
 
 /* two buttons */
-.encounter-builder-app #combat_tracker td button:first-child:nth-last-child(2) ~ button:last-of-type {
+.encounter-builder-app #combat_area td button:first-child:nth-last-child(2) ~ button:last-of-type {
     margin-right:30px;
 }
 
 /* three buttons */
-.encounter-builder-app #combat_tracker td button:first-child:nth-last-child(3) ~ button:last-of-type {
+.encounter-builder-app #combat_area td button:first-child:nth-last-child(3) ~ button:last-of-type {
     margin-right:0px;
 }
 .tracker-list{


### PR DESCRIPTION
This will align the buttons like the one on the right here:
![image](https://user-images.githubusercontent.com/65363489/164367889-3877186b-f779-4169-958a-8773ffb79083.png)

Fixes #415 

