### PR TITLE
Fix: Reload maps on manual grid change so grid updates are displayed properly

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -217,13 +217,15 @@ function edit_scene_dialog(scene_id) {
 			console.log('setto ' + n + ' a ' + $(this).val());
 		});
 		if(window.CLOUD){
-			window.ScenesHandler.persist_scene(scene_id,true,true);
-			if($(".player_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
-				$(".player_scenes_button.selected").click();
-			}
-			if($(".dm_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
-				$(".dm_scenes_button.selected").click();
-			}			
+			window.ScenesHandler.persist_scene(scene_id,true,true);						
+			setTimeout(function() {
+				if($(".player_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
+					$(".player_scenes_button.selected").click();
+				}
+				if($(".dm_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
+					$(".dm_scenes_button.selected").click();
+				}
+			}, 200);			
 		}
 		else{
 			window.ScenesHandler.persist();

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -218,6 +218,12 @@ function edit_scene_dialog(scene_id) {
 		});
 		if(window.CLOUD){
 			window.ScenesHandler.persist_scene(scene_id,true,true);
+			if($(".player_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
+				$(".player_scenes_button.selected").click();
+			}
+			if($(".dm_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
+				$(".dm_scenes_button.selected").click();
+			}			
 		}
 		else{
 			window.ScenesHandler.persist();

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -216,16 +216,18 @@ function edit_scene_dialog(scene_id) {
 			scene[n] = nValue;
 			console.log('setto ' + n + ' a ' + $(this).val());
 		});
-		if(window.CLOUD){
-			window.ScenesHandler.persist_scene(scene_id,true,true);						
-			setTimeout(function() {
-				if($(".player_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
-					$(".player_scenes_button.selected").click();
+		if(window.CLOUD) {
+			$.ajax({
+				url:window.ScenesHandler.persist_scene(scene_id,true,true),
+				success:function(){			  	
+					if($(".player_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
+						$(".player_scenes_button.selected").click();
+					}
+					if($(".dm_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
+						$(".dm_scenes_button.selected").click();
+					}
 				}
-				if($(".dm_scenes_button.selected").parent().parent().attr("data-scene-index") == scene_id) {
-					$(".dm_scenes_button.selected").click();
-				}
-			}, 200);			
+			});		
 		}
 		else{
 			window.ScenesHandler.persist();
@@ -235,10 +237,6 @@ function edit_scene_dialog(scene_id) {
 		$("#scene_selector").removeAttr("disabled");
 		$("#scene_selector_toggle").click();
 	});
-	
-
-	
-
 
 	let grid_5 = function(enable_grid = false, enable_snap = true) {
 


### PR DESCRIPTION
Fixes #421 
This will reload maps if selected on manual grid change so grid updates are displayed properly. This will only reload the maps if the player or dm is actually on the map that is changed.

It accomplishes this by clicking the selected maps dm or player button if the buttons scene ID matches the ID of the edit menu's scene.