### PR TITLE
Add: Shortcut (Ctrl+right click) To open both the context menu and extended token configuration.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1232,12 +1232,6 @@ class Token {
 				draw_selected_token_bounding_box(); // update rotation bounding box
 			});
 
-			tok.mouseup(function (e) {
-				if (e.which === 3 && (e.ctrlKey || e.metaKey)) {
-				    token_context_menu_expanded([tok.attr("data-id")]);			    
-				}
-			});
-			
 			console.groupEnd()
 		}
 		// HEALTH AURA / DEAD CROSS
@@ -1857,6 +1851,10 @@ function token_menu() {
 		selector: '.VTTToken',
 
 		build: function(element, e) {
+
+			if (e.which === 3 && (e.ctrlKey || e.metaKey) && window.DM) {
+				token_context_menu_expanded([element.attr("data-id")]);			    
+			}
 
 			if ($(element).hasClass("tokenselected") && window.MULTIPLE_TOKEN_SELECTED) {
 				if (!window.DM) {

--- a/Token.js
+++ b/Token.js
@@ -1231,6 +1231,12 @@ class Token {
 				window.MULTIPLE_TOKEN_SELECTED = (count > 1);
 				draw_selected_token_bounding_box(); // update rotation bounding box
 			});
+
+			tok.mouseup(function (e) {
+			  if (e.which === 3 && e.ctrlKey) {
+			      token_context_menu_expanded([tok.attr("data-id")]);			    
+			  }
+			});
 			
 			console.groupEnd()
 		}

--- a/Token.js
+++ b/Token.js
@@ -1233,9 +1233,9 @@ class Token {
 			});
 
 			tok.mouseup(function (e) {
-			  if (e.which === 3 && (e.ctrlKey || e.metaKey)) {
-			      token_context_menu_expanded([tok.attr("data-id")]);			    
-			  }
+				if (e.which === 3 && (e.ctrlKey || e.metaKey)) {
+				    token_context_menu_expanded([tok.attr("data-id")]);			    
+				}
 			});
 			
 			console.groupEnd()

--- a/Token.js
+++ b/Token.js
@@ -1233,7 +1233,7 @@ class Token {
 			});
 
 			tok.mouseup(function (e) {
-			  if (e.which === 3 && e.ctrlKey) {
+			  if (e.which === 3 && (e.ctrlKey || e.metaKey)) {
 			      token_context_menu_expanded([tok.attr("data-id")]);			    
 			  }
 			});


### PR DESCRIPTION
Closes #423 
Right click will open the context menu as usual.
Ctrl + right click will open both the context menu and extended configuration options.

I think this is a happy middle ground for spliting options while giving a bit of QoL boost to those who wild shape, polymorph etc. a lot. I think this will be more and more useful if/as we add more to the configure menu.