### PR TITLE
Fix: When editing a scene clicking save should now refresh the scene if it is active. It will no longer require you to manually reload the scene for players or dm's.

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -50,8 +50,12 @@ function get_canvas_max_area() {
 class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 	reload(callback = null) {
-		this.switch_scene(this.current_scene_id, null);
-	}
+        if (window.CLOUD) {
+            window.MB.handleScene({data: window.CURRENT_SCENE_DATA});
+        } else {
+            this.switch_scene(this.current_scene_id, null);
+        }
+    }
 
 	switch_scene(sceneid, callback = null) { // THIS FUNCTION SHOULD DIE AFTER EVERYTHING IS IN THE CLOUD
 		this.current_scene_id = sceneid;

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -50,12 +50,12 @@ function get_canvas_max_area() {
 class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 	reload(callback = null) {
-        if (window.CLOUD) {
-            window.MB.handleScene({data: window.CURRENT_SCENE_DATA});
-        } else {
-            this.switch_scene(this.current_scene_id, null);
-        }
-    }
+		if (window.CLOUD) {
+			window.MB.handleScene({data: window.CURRENT_SCENE_DATA});
+		} else {
+			this.switch_scene(this.current_scene_id, null);
+		}
+	}
 
 	switch_scene(sceneid, callback = null) { // THIS FUNCTION SHOULD DIE AFTER EVERYTHING IS IN THE CLOUD
 		this.current_scene_id = sceneid;

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -218,6 +218,7 @@ function edit_scene_dialog(scene_id) {
 		});
 		if(window.CLOUD){
 			window.ScenesHandler.persist_scene(scene_id,true,true);
+			window.ScenesHandler.reload();
 		}
 		else{
 			window.ScenesHandler.persist();


### PR DESCRIPTION
This will fix #421 

It will refresh the viewed scenes on saving a scene edit such as the grid or maps. 

Thank you so much Mikedave for the digging and help with finding the solution. Put up a new PR to keep it cleaner.

