### PR TITLE
Fix: for drag map lag in player view

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -800,6 +800,9 @@ function init_splash() {
 	setTimeout(function() {
 		init_loading_overlay_beholder();
 	}, 0)
+	window.addEventListener("scroll", function(event) {
+	   event.stopImmediatePropagation();
+	}, true);
 }
 
 // UNIFIED TOKEN HANDLING


### PR DESCRIPTION
Fixes #429

This is setup to listen to the event first then stops the propagation of the throttle scroll event listener.

edit: Better comparison videos. It is more pronounced on my monitor than in the videos below but I can still see a difference in these with regards to smoothness.

Before:
https://user-images.githubusercontent.com/65363489/164948832-db056c26-d2f6-42d0-898e-aeb521201328.mp4

After:
https://user-images.githubusercontent.com/65363489/164948834-b4034f06-ae0f-4bc2-8cef-b365e44eb1ed.mp4


