### PR TITLE
Fix:  In DM view stop the player sheet from sliding to the side when the sidebar is closed

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -238,14 +238,7 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
 #sheet.thin {
     width: 420px;
 }
-#sheet.sidebar_hidden.open {
-    transform: translateX(-1030px);
-    transition: 0.5s ease-in-out;
-}
-#sheet.open {
-    transform: translateX(-1370px);
-    z-index: 99999999;
-}
+
 
 /*for resizable and moveable monsters and sheets in DM view*/
 


### PR DESCRIPTION
This fixes #436

https://user-images.githubusercontent.com/65363489/165018498-40eacbf6-405e-4039-ad80-01015e2de0c8.mp4

