### PR TITLE
Fix: Draggable custom token and custom token images from sidebar

### DIFF
--- a/MonsterPanel.js
+++ b/MonsterPanel.js
@@ -532,7 +532,7 @@ function make_element_draggable_token(element, randomImage = false) {
 				let width = Math.round(window.CURRENT_SCENE_DATA.hpps) * tokenSize;
 				let helperWidth = width / (1.0 / window.ZOOM);
 				$(ui.helper).css('width', `${helperWidth}px`);
-				$(this).draggable('instance').offset.click = {
+				$(element).draggable('instance').offset.click = {
 					left: Math.floor(ui.helper.width() / 2),
 					top: Math.floor(ui.helper.height() / 2)
 				};	


### PR DESCRIPTION
Related to #287   Fixes #441

Custom tokens ("my tokens") and custom token images should now be able to be dragged out onto the map correctly. The monster avatar still doesn't function but this is a good step before the token unification panel update.



https://user-images.githubusercontent.com/65363489/165378505-a720ff32-53e2-4771-b306-83f787cceaee.mp4


