### PR TITLE
Add option for hp inputs only being shown on hover or token select

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -137,6 +137,12 @@ function init_settings(){
 			disabledDescription: "New player tokens will have their HP/AC visible to other players. Each player will be able to see their own HP/AC as well as HP/AC of other players."
 		},
 		{
+			name: 'hidehpbar',
+			label: 'Only show HP values on hover',
+			enabledDescription: "HP values will only be shown when you hover or select a token",
+			disabledDescription: "Enable this to hide HP values except when you hover or select a token."
+		},
+		{
 			name: 'disableborder',
 			label: 'Disable Border',
 			enabledDescription: 'New tokens will not have a border around them',

--- a/Token.js
+++ b/Token.js
@@ -510,6 +510,13 @@ class Token {
 			maxhp_input.keydown(function(e) { if (e.keyCode == '13') self.update_from_page(); e.preventDefault(); });
 		}
 
+		if(this.options.hidehpbar) {
+			hpbar.toggleClass("hponhover", true);
+		}
+		else {
+			hpbar.toggleClass("hponhover", false)
+		}
+
 		return hpbar;
 	}
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1812,6 +1812,7 @@ function token_context_menu_expanded(tokenIds) {
 		{ name: "restrictPlayerMove", label: "Restrict Player Movement", enabledDescription:"Token is not moveable by players", disabledDescription: "Token is moveable by any player" },
 		{ name: "disablestat", label: "Disable HP/AC", enabledDescription:"Token stats are not visible", disabledDescription: "Token stats are visible to at least the DM" },
 		{ name: "hidestat", label: "Hide Player HP/AC from players", enabledDescription:"Token stats are hidden from players", disabledDescription: "Token stats are visible to players" },
+		{ name: "hidehpbar", label: "Only show HP values on hover", enabledDescription:"HP values will only be shown when you hover or select a token", disabledDescription: "Enable this to hide HP values except when you hover or select a token." },
 		{ name: "disableborder", label: "Disable Border", enabledDescription:"Token has no border", disabledDescription: "Token has a random coloured border"  },
 		{ name: "disableaura", label: "Disable Health Meter", enabledDescription:"Token has no health glow", disabledDescription: "Token has health glow corresponding with their current health" },
 		{ name: "revealname", label: "Show name to players", enabledDescription:"Token on hover name is visible to players", disabledDescription: "Token name is hidden to players" },

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1083,6 +1083,17 @@ div#combat_button{
 .hpbar {
     z-index: 3;
 }
+
+.hponhover {
+    visibility:  hidden;
+    transition:  0.2s ease-in-out 0.5s;
+}
+.token:hover .hponhover,
+.token:focus-within .hponhover,
+.tokenselected .hponhover {
+    visibility:  visible;
+    transition:  0.05s ease-in-out 0.3s
+}
 /* Classes for main buttons on campaign page */
 .above-vtt-content-div {
     display: inline-block;


### PR DESCRIPTION
Closes #448 

This adds an option that when enabled will:

Have the hpbar be visible if the token is selected, the inputs focused or the token is hovered.
Have the fade delay be approximately the same as the name

Example video: https://www.youtube.com/watch?v=b0Exi8hIz6k


Edit: Thought I spotted a bug so went draft but it was user error 😂