### PR TITLE
Move selected tokens or hpbar inputs focused to the top to make accessing hp changes easier

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -836,6 +836,7 @@ class Token {
 				
 				var zindexdiff=Math.round(17/ (this.options.size/window.CURRENT_SCENE_DATA.hpps));
 				old.css("z-index", 32+zindexdiff);
+				old.css("--z-index-diff", zindexdiff);
 
 				var bar_height = Math.floor(this.options.size * 0.2);
 
@@ -952,6 +953,7 @@ class Token {
 			console.log("Diff: "+zindexdiff);
 			
 			tok.css("z-index", 32+zindexdiff);
+			tok.css("--z-index-diff", zindexdiff);
 			tok.width(this.options.size);
 			tok.height(this.options.size);
 			tok.addClass('token');

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1059,7 +1059,7 @@ div#combat_button{
 }
 
 .tokenselected{
-    z-index: 100 !important;
+    z-index: calc(100 + var(--z-index-diff)) !important;
 }
 
 .ac {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1059,7 +1059,8 @@ div#combat_button{
 }
 
 .tokenselected,
-.token:focus-within{
+.token:focus-within,
+.token:active{
     z-index: calc(100 + var(--z-index-diff)) !important;
 }
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1058,7 +1058,8 @@ div#combat_button{
     border: 5px #f7bfbfd5 solid
 }
 
-.tokenselected{
+.tokenselected,
+.token:focus-within{
     z-index: calc(100 + var(--z-index-diff)) !important;
 }
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1058,6 +1058,9 @@ div#combat_button{
     border: 5px #f7bfbfd5 solid
 }
 
+.tokenselected{
+    z-index: 100 !important;
+}
 
 .ac {
     position: absolute;


### PR DESCRIPTION
Edit: If we put in #470 only the CSS changes will be needed however the `calc(100`  will need to be `calc(15000` or higher.
This will give a 5000 range up or down and any selected token will be still on top. The tokens will be contained to `#tokens` z-index in 457. This allows for the larger gap without screwing up the fog layer z-indexing. 

I can take this down and put up a corrected version if you decide to merge 457.

----

Closes #450 

This moves the token to the top if the token is selected, the hpbar is focused and when active to make it feel more consistent

https://user-images.githubusercontent.com/65363489/165870992-39635c05-7d6a-4f73-8a5d-49352e2f9368.mp4

