### PR TITLE
Change grid colour and width. Scene edit form update with toggle buttons. Validate map urls on focussing out of those inputs

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -385,44 +385,51 @@ function midPointBtw(p1, p2) {
   };
 }
 
-function draw_grid(){
-	const canvas_grid = document.getElementById("grid_overlay");
-	const ctx_grid = canvas_grid.getContext("2d");
-	const incrementX = window.CURRENT_SCENE_DATA.hpps;
-	ctx_grid.lineWidth = window.CURRENT_SCENE_DATA.grid_line_width;
-	ctx_grid.strokeStyle = window.CURRENT_SCENE_DATA.grid_color;
+function clear_grid(){
+	const gridCanvas = document.getElementById("grid_overlay");
+	const gridContext = gridCanvas.getContext("2d");
+	gridContext.clearRect(0, 0, gridCanvas.width, gridCanvas.height);
+}
+
+function redraw_grid(hpps=null, vpps=null, color=null, lineWidth=null, subdivide=null){
+	const gridCanvas = document.getElementById("grid_overlay");
+	const gridContext = gridCanvas.getContext("2d");
+	clear_grid()
+	const incrementX = hpps || window.CURRENT_SCENE_DATA.hpps;
+	const incrementY = vpps || window.CURRENT_SCENE_DATA.vpps; 
+	gridContext.lineWidth = lineWidth || window.CURRENT_SCENE_DATA.grid_line_width;
+	gridContext.strokeStyle = color || window.CURRENT_SCENE_DATA.grid_color;
+	let isSubdivided = subdivide === "1" || window.CURRENT_SCENE_DATA.grid_subdivided === "1"
 	let skip = true;
 
-	ctx_grid.beginPath();
+	gridContext.beginPath();
 	for (var i = startX; i < $("#scene_map").width(); i = i + incrementX) {
-		if (window.CURRENT_SCENE_DATA.grid_subdivided == "1" && skip) {
+		if (isSubdivided && skip) {
 			skip = false;
 			continue;
 		}
 		else {
 			skip = true;
 		}
-		ctx_grid.moveTo(i, 0);
-		ctx_grid.lineTo(i, $("#scene_map").height());
+		gridContext.moveTo(i, 0);
+		gridContext.lineTo(i, $("#scene_map").height());
 	}
-	ctx_grid.stroke();
-
-	const incrementY = window.CURRENT_SCENE_DATA.vpps;
+	gridContext.stroke();
 	skip = true;
 
-	ctx_grid.beginPath();
+	gridContext.beginPath();
 	for (var i = startY; i < $("#scene_map").height(); i = i + incrementY) {
-		if (window.CURRENT_SCENE_DATA.grid_subdivided == "1" && skip) {
+		if (isSubdivided && skip) {
 			skip = false;
 			continue;
 		}
 		else {
 			skip = true;
 		}
-		ctx_grid.moveTo(0, i);
-		ctx_grid.lineTo($("#scene_map").width(), i);
+		gridContext.moveTo(0, i);
+		gridContext.lineTo($("#scene_map").width(), i);
 	}
-	ctx_grid.stroke();
+	gridContext.stroke();
 }
 
 function reset_canvas() {
@@ -510,7 +517,7 @@ function reset_canvas() {
 		//alert('inizio 1');
 
 		if (window.CURRENT_SCENE_DATA.grid == "1") {
-			draw_grid()
+			redraw_grid()
 		}
 		//alert('sopravvissuto');
 	}

--- a/Fog.js
+++ b/Fog.js
@@ -385,6 +385,46 @@ function midPointBtw(p1, p2) {
   };
 }
 
+function draw_grid(){
+	const canvas_grid = document.getElementById("grid_overlay");
+	const ctx_grid = canvas_grid.getContext("2d");
+	const incrementX = window.CURRENT_SCENE_DATA.hpps;
+	ctx_grid.lineWidth = window.CURRENT_SCENE_DATA.grid_line_width;
+	ctx_grid.strokeStyle = window.CURRENT_SCENE_DATA.grid_color;
+	let skip = true;
+
+	ctx_grid.beginPath();
+	for (var i = startX; i < $("#scene_map").width(); i = i + incrementX) {
+		if (window.CURRENT_SCENE_DATA.grid_subdivided == "1" && skip) {
+			skip = false;
+			continue;
+		}
+		else {
+			skip = true;
+		}
+		ctx_grid.moveTo(i, 0);
+		ctx_grid.lineTo(i, $("#scene_map").height());
+	}
+	ctx_grid.stroke();
+
+	const incrementY = window.CURRENT_SCENE_DATA.vpps;
+	skip = true;
+
+	ctx_grid.beginPath();
+	for (var i = startY; i < $("#scene_map").height(); i = i + incrementY) {
+		if (window.CURRENT_SCENE_DATA.grid_subdivided == "1" && skip) {
+			skip = false;
+			continue;
+		}
+		else {
+			skip = true;
+		}
+		ctx_grid.moveTo(0, i);
+		ctx_grid.lineTo($("#scene_map").width(), i);
+	}
+	ctx_grid.stroke();
+}
+
 function reset_canvas() {
 	$('#fog_overlay').width($("#scene_map").width());
 	$('#fog_overlay').height($("#scene_map").height());
@@ -462,48 +502,15 @@ function reset_canvas() {
 			ctx_grid.setLineDash([30, 5]);
 		}
 		else {
-			ctx_grid.strokeStyle = window.CURRENT_SCENE_DATA.grid_color;
+			ctx_grid.strokeStyle = "rgba(0,0,0,0.5)";
 			//ctx_grid.strokeStyle = "green";
-			ctx_grid.lineWidth = window.CURRENT_SCENE_DATA.grid_line_width;
+			ctx_grid.lineWidth = 3;
 		}
 
 		//alert('inizio 1');
 
 		if (window.CURRENT_SCENE_DATA.grid == "1") {
-			var increment = window.CURRENT_SCENE_DATA.hpps;
-			ctx_grid.lineWidth = 1;
-			var skip = true;
-
-			ctx_grid.beginPath();
-			for (var i = startX; i < $("#scene_map").width(); i = i + increment) {
-				if (window.CURRENT_SCENE_DATA.grid_subdivided == "1" && skip) {
-					skip = false;
-					continue;
-				}
-				else {
-					skip = true;
-				}
-				ctx_grid.moveTo(i, 0);
-				ctx_grid.lineTo(i, $("#scene_map").height());
-			}
-			ctx_grid.stroke();
-
-			var increment = window.CURRENT_SCENE_DATA.vpps;
-			skip = true;
-
-			ctx_grid.beginPath();
-			for (var i = startY; i < $("#scene_map").height(); i = i + increment) {
-				if (window.CURRENT_SCENE_DATA.grid_subdivided == "1" && skip) {
-					skip = false;
-					continue;
-				}
-				else {
-					skip = true;
-				}
-				ctx_grid.moveTo(0, i);
-				ctx_grid.lineTo($("#scene_map").width(), i);
-			}
-			ctx_grid.stroke();
+			draw_grid()
 		}
 		//alert('sopravvissuto');
 	}

--- a/Fog.js
+++ b/Fog.js
@@ -391,10 +391,11 @@ function clear_grid(){
 	gridContext.clearRect(0, 0, gridCanvas.width, gridCanvas.height);
 }
 
-function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=null, lineWidth=null, subdivide=null){
+function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=null, lineWidth=null, subdivide=null, dash=[]){
 	const gridCanvas = document.getElementById("grid_overlay");
 	const gridContext = gridCanvas.getContext("2d");
 	clear_grid()
+	gridContext.setLineDash(dash);
 	let startX = offsetX || window.CURRENT_SCENE_DATA.offsetx;
 	let startY = offsetY || window.CURRENT_SCENE_DATA.offsety;
 	startX = Math.round(startX)
@@ -434,6 +435,42 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 		gridContext.lineTo($("#scene_map").width(), i);
 	}
 	gridContext.stroke();
+}
+
+function draw_wizarding_box() {
+	
+	var gridCanvas = document.getElementById("grid_overlay");
+	var gridContext = gridCanvas.getContext("2d");
+	gridCanvas.width = $("#scene_map").width();
+	gridCanvas.height = $("#scene_map").height();
+
+	startX = Math.round(window.CURRENT_SCENE_DATA.offsetx);
+	startY = Math.round(window.CURRENT_SCENE_DATA.offsety);
+
+	let al1 = {
+		x: parseInt($("#aligner1").css("left")) + 29,
+		y: parseInt($("#aligner1").css("top")) + 29,
+	};
+
+	let al2 = {
+		x: parseInt($("#aligner2").css("left")) + 29,
+		y: parseInt($("#aligner2").css("top")) + 29,
+	};
+	gridContext.setLineDash([30, 5]);
+
+	gridContext.lineWidth = 2;
+	gridContext.strokeStyle = "green";
+	gridContext.beginPath();
+	gridContext.moveTo(al1.x, al1.y);
+	gridContext.lineTo(al2.x, al1.y);
+	gridContext.moveTo(al2.x, al1.y);
+	gridContext.lineTo(al2.x, al2.y);
+	gridContext.moveTo(al2.x, al2.y);
+	gridContext.lineTo(al1.x, al2.y);
+	gridContext.moveTo(al1.x, al2.y);
+	gridContext.lineTo(al1.x, al1.y);
+	gridContext.stroke();
+
 }
 
 function reset_canvas() {
@@ -481,46 +518,11 @@ function reset_canvas() {
 
 		//alert(startX+ " "+startY);
 		if (window.WIZARDING) {
-			let al1 = {
-				x: parseInt($("#aligner1").css("left")) + 29,
-				y: parseInt($("#aligner1").css("top")) + 29,
-			};
-
-			let al2 = {
-				x: parseInt($("#aligner2").css("left")) + 29,
-				y: parseInt($("#aligner2").css("top")) + 29,
-			};
-			ctx_grid.setLineDash([30, 5]);
-
-			ctx_grid.lineWidth = 2;
-			ctx_grid.strokeStyle = "green";
-			ctx_grid.beginPath();
-			ctx_grid.moveTo(al1.x, al1.y);
-			ctx_grid.lineTo(al2.x, al1.y);
-			ctx_grid.moveTo(al2.x, al1.y);
-			ctx_grid.lineTo(al2.x, al2.y);
-			ctx_grid.moveTo(al2.x, al2.y);
-			ctx_grid.lineTo(al1.x, al2.y);
-			ctx_grid.moveTo(al1.x, al2.y);
-			ctx_grid.lineTo(al1.x, al1.y);
-			ctx_grid.stroke();
-
-			ctx_grid.strokeStyle = "rgba(255,0,0,1)";
-			if (window.ScenesHandler.scene.upscaled == "1")
-				ctx_grid.lineWidth = 2;
-			else
-				ctx_grid.lineWidth = 1;
-			ctx_grid.setLineDash([30, 5]);
+			draw_wizarding_box()
 		}
-		else {
-			ctx_grid.strokeStyle = "rgba(0,0,0,0.5)";
-			//ctx_grid.strokeStyle = "green";
-			ctx_grid.lineWidth = 3;
-		}
-
 		//alert('inizio 1');
 
-		if (window.CURRENT_SCENE_DATA.grid == "1") {
+		if (window.CURRENT_SCENE_DATA.grid == "1" && !window.WIZARDING) {
 			redraw_grid()
 		}
 		//alert('sopravvissuto');

--- a/Fog.js
+++ b/Fog.js
@@ -391,10 +391,14 @@ function clear_grid(){
 	gridContext.clearRect(0, 0, gridCanvas.width, gridCanvas.height);
 }
 
-function redraw_grid(hpps=null, vpps=null, color=null, lineWidth=null, subdivide=null){
+function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=null, lineWidth=null, subdivide=null){
 	const gridCanvas = document.getElementById("grid_overlay");
 	const gridContext = gridCanvas.getContext("2d");
 	clear_grid()
+	let startX = offsetX || window.CURRENT_SCENE_DATA.offsetx;
+	let startY = offsetY || window.CURRENT_SCENE_DATA.offsety;
+	startX = Math.round(startX)
+	startY = Math.round(startY)
 	const incrementX = hpps || window.CURRENT_SCENE_DATA.hpps;
 	const incrementY = vpps || window.CURRENT_SCENE_DATA.vpps; 
 	gridContext.lineWidth = lineWidth || window.CURRENT_SCENE_DATA.grid_line_width;

--- a/Fog.js
+++ b/Fog.js
@@ -462,9 +462,9 @@ function reset_canvas() {
 			ctx_grid.setLineDash([30, 5]);
 		}
 		else {
-			ctx_grid.strokeStyle = "rgba(0,0,0,0.5)";
+			ctx_grid.strokeStyle = window.CURRENT_SCENE_DATA.grid_color;
 			//ctx_grid.strokeStyle = "green";
-			ctx_grid.lineWidth = 3;
+			ctx_grid.lineWidth = window.CURRENT_SCENE_DATA.grid_line_width;
 		}
 
 		//alert('inizio 1');

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -238,7 +238,6 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		
 		data.grid = window.CURRENT_SCENE_DATA.grid;
 		data.snap = window.CURRENT_SCENE_DATA.snap;
-		data.grid = window.CURRENT_SCENE_DATA.grid;
 		//data.scale=window.CURRENT_SCENE_DATA.scaleX;
 		data.hpps = window.CURRENT_SCENE_DATA.hpps;
 		data.vpps = window.CURRENT_SCENE_DATA.vpps;

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -94,15 +94,7 @@ function validate_image_input(element){
 	const self = element
 	const img = parse_img(self.value)
 	let hasValidationDisplayed = $(self).prev().is("span")
-	const validIcon = $(
-		`<span style="
-			position: absolute;
-			top: 0;
-			left: -20px;
-			font-size: 20px;
-			color: green;
-			font-weight: bold;"
-		class="material-icons">check_circle_outline</span>`)
+	const validIcon = $(`<span class="material-icons url-validator valid">check_circle_outline</span>`)
 
 	// optional values can be blank
 	const isOptional = $(self).attr("placeholder") === "Optional"
@@ -124,7 +116,8 @@ function validate_image_input(element){
 	const display_not_valid = () => {
 		if (hasValidationDisplayed){
 			$(self).prev().html("highlight_off")
-			$(self).prev().css("color", "red")
+			$(self).prev().removeClass("valid loading")
+			$(self).prev().addClass("invalid")
 			$(self).attr("data-valid", false)
 		}
 		
@@ -141,11 +134,16 @@ function validate_image_input(element){
 			tester.onload=imageFound;
 			tester.onerror=imageNotFound;
 			tester.src=URL;
+			$(self).prev().removeClass("valid invalid")
+			$(self).prev().addClass("loading")
+			$(self).prev().html("autorenew")
+
 		}
 		
 		function imageFound() {
+			$(self).prev().removeClass("loading invalid")
+			$(self).prev().addClass("valid")
 			$(self).prev().html("check_circle_outline")
-			$(self).prev().css("color","green")
 		}
 		
 		function imageNotFound() {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -91,17 +91,13 @@ function get_edit_form_data(scene=null){
 }
 
 function handle_form_grid_on_change(){
-	const {hpps, vpps, grid_color, grid_line_width, grid_subdivided, grid} = get_edit_form_data()
+	const {hpps, vpps, offsetx, offsety, grid_color, grid_line_width, grid_subdivided, grid} = get_edit_form_data()
 	// redraw grid with new information
 	if(grid === "1"){
-		redraw_grid(hpps, vpps, grid_color, grid_line_width, grid_subdivided )
+		redraw_grid(parseFloat(hpps), parseFloat(vpps), offsetx, offsety, grid_color, grid_line_width, grid_subdivided )
 	}
 	// redraw grid using current scene data
-	else if(grid === "0" && window.CURRENT_SCENE_DATA.grid === "1"){
-		redraw_grid()
-	}
-	// there's no grid
-	else if (window.CURRENT_SCENE_DATA.grid === "0"){
+	else if(grid === "0"){
 		clear_grid()
 	}
 }
@@ -216,8 +212,8 @@ function edit_scene_dialog(scene_id) {
 
 	const showGridControls = $("<div id='show_grid_controls'/>");
 	const gridColor = $(`<input class="spectrum" name="grid_color" value="${scene["grid_color"] || "rgba(0, 0, 0, 0.5)"}" ></input>`)
-	const gridStroke =$(`<input id="grid_line_width" name="grid_line_width" style="display:inline-block;" type="range" min="1" max="10" step="1" value="${scene["grid_line_width"] || 1}">`)
-	gridStroke.on("change", handle_form_grid_on_change)
+	const gridStroke =$(`<input id="grid_line_width" name="grid_line_width" style="display:inline-block;" type="range" min="0.5" max="10" step="0.5" value="${scene["grid_line_width"] || 0.5}">`)
+	gridStroke.on("change input", handle_form_grid_on_change)
 	showGridControls.append(
 		form_toggle("grid",null, function(event) {
 			if ($(event.currentTarget).hasClass("rc-switch-checked")) {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -246,7 +246,7 @@ function edit_scene_dialog(scene_id) {
 		containerClassName: '#edit_dialog',
 		clickoutFiresChange: false
 	});
-	form.find(".sp-replacer").css("height","22px")
+	form.find(".sp-replacer").css({"height":"22px", "margin-left":"8px", "margin-right":"8px"})
 	// redraw the grid here
 	colorPickers.on('move.spectrum', handle_form_grid_on_change);   // update the token as the player messes around with colors
 	colorPickers.on('change.spectrum', handle_form_grid_on_change); // commit the changes when the user clicks the submit button

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -57,45 +57,53 @@ function preset_importer(target, key) {
 }
 
 
-function form_row(name, title, currentValue, inputOverride=null) {
-	const row = $("<div style='width:100%;'/>");
-	const rowLabel = $("<div style='display: inline-block; width:30%'>" + title + "</div>");
-	rowLabel.css("font-weight", "bold");
-	const rowInputWrapper = $("<div style='display:inline-block; width:60%' />");
-	let rowInput
-	if(!inputOverride){
-		 rowInput = $(`<input type="text" name=${name} style='width:100%' value=${currentValue} />`);
-	}
-	else{
-		rowInput = inputOverride
-	}
-	
-	rowInputWrapper.append(rowInput);
-	row.append(rowLabel);
-	row.append(rowInputWrapper);
-	return row
-};
 
-function form_toggle(name, hoverText, callback){
-	// do something here for current value
-	const toggle = $(`<button id="${name}_toggle" name=${name} type="button" role="switch" class="rc-switch"><span class="rc-switch-inner" /></button>`)
-	toggle.on("click", callback)
-	return toggle
-}
 
-function handle_basic_form_toggle_click(event){
-	if ($(event.currentTarget).hasClass("rc-switch-checked")) {
-		// it was checked. now it is no longer checked
-		$(event.currentTarget).removeClass("rc-switch-checked");
-	  } else {
-		// it was not checked. now it is checked
-		$(event.currentTarget).removeClass("rc-switch-unknown");
-		$(event.currentTarget).addClass("rc-switch-checked");
-	  }
-}
+
 
 function edit_scene_dialog(scene_id) {
 	let scene = window.ScenesHandler.scenes[scene_id];
+
+	function form_row(name, title, inputOverride=null) {
+		const row = $("<div style='width:100%;'/>");
+		const rowLabel = $("<div style='display: inline-block; width:30%'>" + title + "</div>");
+		rowLabel.css("font-weight", "bold");
+		const rowInputWrapper = $("<div style='display:inline-block; width:60%' />");
+		let rowInput
+		if(!inputOverride){
+			 rowInput = $(`<input type="text" name=${name} style='width:100%' value="${scene[name] || ""}" />`);
+		}
+		else{
+			rowInput = inputOverride
+		}
+		
+		rowInputWrapper.append(rowInput);
+		row.append(rowLabel);
+		row.append(rowInputWrapper);
+		return row
+	};
+
+	function form_toggle(name, hoverText, callback){
+		const toggle = $(`<button id="${name}_toggle" name=${name} type="button" role="switch" class="rc-switch"><span class="rc-switch-inner" /></button>`)
+		toggle.on("click", callback)
+		if (scene[name] === "1"){
+			toggle.click()
+		}
+		return toggle
+	}
+	
+	function handle_basic_form_toggle_click(event){
+		if ($(event.currentTarget).hasClass("rc-switch-checked")) {
+			// it was checked. now it is no longer checked
+			$(event.currentTarget).removeClass("rc-switch-checked");
+		  } else {
+			// it was not checked. now it is checked
+			$(event.currentTarget).removeClass("rc-switch-unknown");
+			$(event.currentTarget).addClass("rc-switch-checked");
+		  }
+	}
+
+
 	scene.fog_of_war = "1"; // ALWAYS ON since 0.0.18
 	console.log('edit_scene_dialog');
 	$("#scene_selector").attr('disabled', 'disabled');
@@ -142,84 +150,60 @@ function edit_scene_dialog(scene_id) {
 	const form = $("<form />");
 	form.on('submit', function(e) { e.preventDefault(); });
 
-
-
 	var uuid_hidden = $("<input name='uuid' type='hidden'/>");
 	uuid_hidden.val(scene['uuid']);
 	form.append(uuid_hidden);
 
-	form.append(form_row('title', 'Scene Title', scene["title"]))
-	const playerMapRow = form_row('player_map', 'Player Map', scene["player_map"])
-	const dmMapRow = form_row('dm_map', 'Dm Map', scene["dm_map"])
+	form.append(form_row('title', 'Scene Title'))
+	const playerMapRow = form_row('player_map', 'Player Map')
+	const dmMapRow = form_row('dm_map', 'Dm Map')
 	// add in toggles for these 2 rows
 	playerMapRow.append(form_toggle("player_map_is_video", "Video map?", handle_basic_form_toggle_click))
 	dmMapRow.append(form_toggle("dm_map_is_video", "Video map?", handle_basic_form_toggle_click))
 	form.append(playerMapRow)
 	form.append(dmMapRow)
 	// add a row but override the normal input with a toggle
-	form.append(form_row(null, 'Use DM Map', null, form_toggle("dm_map_usable",null, handle_basic_form_toggle_click)))
+	form.append(form_row(null,
+						'Use DM Map',
+						form_toggle("dm_map_usable",null, handle_basic_form_toggle_click)))
 
 	wizard = $("<button><b>Super Mega Wizard</b></button>");
 	manual_button = $("<button>Manual Grid Data</button>");
 
-	grid_buttons = $("<div style='display:inline-block; width:70%'/>");
+	grid_buttons = $("<div/>");
 	grid_buttons.append(wizard);
 	grid_buttons.append(manual_button);
-	form.append($("<div><div style='display:inline-block;width:30%'><b>Grid and Scale</b></div></div>").append(grid_buttons));
+	form.append(form_row(null, 'Grid and Scale', grid_buttons))
 
-
-	var manual = $("<div/>");
+	var manual = $("<div id='manual_grid_data'/>");
 	manual.append($("<div><div style='display:inline-block; width:30%'>Grid size in original image</div><div style='display:inline-block;width:70%;'><input name='hpps'> X <input name='vpps'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Offset</div><div style='display:inline-block;width:70%;'><input name='offsetx'> X <input name='offsety'></div></div>"));
 
-	const sceneToggleSnap = $(`<button id="snap_grid_toggle" name="show_grid" type="button" role="switch" class="rc-switch"><span class="rc-switch-inner" /></button>`)
-	sceneToggleSnap.on("click", function(event) {
-		if ($(event.currentTarget).hasClass("rc-switch-checked")) {
-		  // it was checked. now it is no longer checked
-		  $(event.currentTarget).removeClass("rc-switch-checked");
-		} else {
-		  // it was not checked. now it is checked
-		  $(event.currentTarget).removeClass("rc-switch-unknown");
-		  $(event.currentTarget).addClass("rc-switch-checked");
-		}
-	  });
+	manual.append(form_row(null, 'Snap to Grid',form_toggle("snap",null, handle_basic_form_toggle_click)))
 
-	manual.append(
-		$(`<div>
-			<div style='display:inline-block; width:30%'>
-				Snap to Grid
-			</div>
-		</div>`));
-	sceneToggleSnap.insertAfter($(manual).find('div:contains("Snap to Grid")').last())
-
-	const sceneToggleGrid = $(`<button id="snap_grid_toggle" name="show_grid" type="button" role="switch" class="rc-switch"><span class="rc-switch-inner" /></button>`)
-	sceneToggleGrid.on("click", function(event) {
-		if ($(event.currentTarget).hasClass("rc-switch-checked")) {
-		  // it was checked. now it is no longer checked
-		  $(event.currentTarget).removeClass("rc-switch-checked");
-		  $("#grid_line_width").hide()
-		  manual.find(".sp-replacer").hide()
-		} else {
-		  // it was not checked. now it is checked
-		  $(event.currentTarget).removeClass("rc-switch-unknown");
-		  $(event.currentTarget).addClass("rc-switch-checked");
-		  $("#grid_line_width").show()
-		  manual.find(".sp-replacer").show()
-		}
-	  });
-	const sceneGridColor = $(`<input class="spectrum" name="grid_color" value="rgba(0, 0, 0, 0.5)" ></input>`)
-	const sceneGridStroke =$(`<input name="grid_line_width" style="display:none;" type="range" min="1" max="60" value="6">`)
-
-	manual.append(
-		$(`<div>
-			<div style='display:inline-block; width:30%'>
-				Show Grid
-			</div>			
-		</div>`));
-	sceneToggleGrid.insertAfter($(manual).find('div:contains("Show Grid")').last())
-	sceneGridColor.insertAfter($(manual).find(sceneToggleGrid))
-	sceneGridStroke.insertAfter($(manual).find(sceneToggleGrid))
-
+	const showGridControls = $("<div/>");
+	const gridColor = $(`<input class="spectrum" name="grid_color" value="${scene["grid_color"] || "rgba(0, 0, 0, 0.5)"}" ></input>`)
+	const gridStroke =$(`<input id="grid_line_width" name="grid_line_width" style="display:none;" type="range" min="1" max="5" step="1" value="${scene["grid_line_width"] || 1}">`)
+	showGridControls.append(
+		form_toggle("grid",null, function(event) {
+			if ($(event.currentTarget).hasClass("rc-switch-checked")) {
+			// it was checked. now it is no longer checked
+			$(event.currentTarget).removeClass("rc-switch-checked");
+			$("#grid_line_width").hide()
+			manual.find(".sp-replacer").hide()
+			} else {
+			// it was not checked. now it is checked
+			$(event.currentTarget).removeClass("rc-switch-unknown");
+			$(event.currentTarget).addClass("rc-switch-checked");
+			$("#grid_line_width").show()
+			manual.find(".sp-replacer").show()
+			}
+		})
+	)
+	showGridControls.append(gridColor)
+	showGridControls.append(gridStroke)
+	manual.append(form_row(null, 'Show Grid', showGridControls))
+	
 	manual.append($("<div><div style='display:inline-block; width:30%'>Units per square</div><div style='display:inline-block; width:70'%'><input name='fpsq'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Distance Unit (i.e. feet)</div><div style='display:inline-block; width:70'%'><input name='upsq'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Grid is a subdivided 10 units</div><div style='display:inline-block; width:70'%'><input name='grid_subdivided'></div></div>"));
@@ -258,7 +242,7 @@ function edit_scene_dialog(scene_id) {
 		scene.fog_of_war = "1";
 
 
-	const submitButton = $("<button>Save And Switch</button>");
+	const submitButton = $("<button type='button'>Save And Switch</button>");
 
 	if(window.CLOUD)
 		submitButton.html("Save");
@@ -267,16 +251,13 @@ function edit_scene_dialog(scene_id) {
 		console.group("Saving scene changes")
 		form.find("input, button.rc-switch").each(function() {
 			const inputName = $(this).attr('name');
-			let inputValue
+			let inputValue = $(this).val();
 
 			if ( ((inputName === 'player_map') || (inputName==='dm_map')) ) {
 				inputValue = parse_img(inputValue);
 			}
 			else if ($(this).is("button")){
 				inputValue = $(this).hasClass("rc-switch-checked") ? "1" : "0"
-			}
-			else{
-				inputValue = $(this).val();
 			}
 
 			scene[inputName] = inputValue;

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -90,17 +90,7 @@ function get_edit_form_data(scene=null){
 	return data
 }
 
-function handle_form_grid_on_change(){
-	const {hpps, vpps, offsetx, offsety, grid_color, grid_line_width, grid_subdivided, grid} = get_edit_form_data()
-	// redraw grid with new information
-	if(grid === "1"){
-		redraw_grid(parseFloat(hpps), parseFloat(vpps), offsetx, offsety, grid_color, grid_line_width, grid_subdivided )
-	}
-	// redraw grid using current scene data
-	else if(grid === "0"){
-		clear_grid()
-	}
-}
+
 
 function edit_scene_dialog(scene_id) {
 	let scene = window.ScenesHandler.scenes[scene_id];
@@ -131,6 +121,23 @@ function edit_scene_dialog(scene_id) {
 			toggle.click()
 		}
 		return toggle
+	}
+
+	function handle_form_grid_on_change(){
+		// not editting this scene, don't show live updates to grid
+		if (scene.id !== window.CURRENT_SCENE_DATA.id){
+			return
+		}
+	
+		const {hpps, vpps, offsetx, offsety, grid_color, grid_line_width, grid_subdivided, grid} = get_edit_form_data()
+		// redraw grid with new information
+		if(grid === "1"){
+			redraw_grid(parseFloat(hpps), parseFloat(vpps), offsetx, offsety, grid_color, grid_line_width, grid_subdivided )
+		}
+		// redraw grid using current scene data
+		else if(grid === "0"){
+			clear_grid()
+		}
 	}
 
 	scene.fog_of_war = "1"; // ALWAYS ON since 0.0.18
@@ -194,8 +201,9 @@ function edit_scene_dialog(scene_id) {
 	// add a row but override the normal input with a toggle
 	form.append(form_row(null,
 						'Use DM Map',
-						form_toggle("dm_map_usable",null, handle_basic_form_toggle_click)))
-
+						form_toggle("dm_map_usable",null, handle_basic_form_toggle_click)
+						)
+				);
 	wizard = $("<button><b>Super Mega Wizard</b></button>");
 	manual_button = $("<button>Manual Grid Data</button>");
 
@@ -221,16 +229,15 @@ function edit_scene_dialog(scene_id) {
 				$(event.currentTarget).removeClass("rc-switch-checked");
 				gridStroke.hide()	
 				manual.find(".sp-replacer").hide()
-				handle_form_grid_on_change()
+				
 			} else {
 				// it was not checked. now it is checked
 				$(event.currentTarget).removeClass("rc-switch-unknown");
 				$(event.currentTarget).addClass("rc-switch-checked");
 				gridStroke.show()	
 				manual.find(".sp-replacer").show()
-				// hpps=null, vpps=null, color=null, lineWidth=null, subdivide=null
-				handle_form_grid_on_change()
 			}
+				handle_form_grid_on_change()
 		})
 	)
 	showGridControls.append(gridColor)
@@ -295,24 +302,12 @@ function edit_scene_dialog(scene_id) {
 		$("#scene_selector_toggle").click();
 	});
 
-	let grid_5 = function(enable_grid = false, enable_snap = true) {
+	let grid_5 = function() {
 
-		console.log("enable_grid " + enable_grid + " enable_snap" + enable_snap);
 
 		$("#scene_selector_toggle").show();
 		$("#tokens").show();
 		window.WIZARDING = false;
-
-		if (enable_snap)
-			window.ScenesHandler.scene.snap = "1";
-		else
-			window.ScenesHandler.scene.snap = "0";
-
-		if (enable_grid)
-			window.ScenesHandler.scene.grid = "1";
-		else
-			window.ScenesHandler.scene.grid = "0";
-
 		window.ScenesHandler.scene.fpsq = "5";
 		window.ScenesHandler.scene.upsq = "ft";
 		window.ScenesHandler.scene.grid_subdivided = "0";
@@ -338,8 +333,6 @@ function edit_scene_dialog(scene_id) {
 			$("#tokens").show();
 			$("#wizard_popup").empty().append("You're good to go! AboveVTT is now super-imposing a grid that divides the original grid map in half. If you want to hide this grid just edit the manual grid data.");
 			window.ScenesHandler.scene.grid_subdivided = "1";
-			window.ScenesHandler.scene.snap = "1";
-			window.ScenesHandler.scene.grid = "1";
 			window.ScenesHandler.scene.fpsq = "5";
 			window.ScenesHandler.scene.upsq = "ft";
 			window.ScenesHandler.scene.hpps /= 2;
@@ -383,10 +376,8 @@ function edit_scene_dialog(scene_id) {
 		window.WIZARDING = false;
 		$("#scene_selector_toggle").show();
 		$("#tokens").show();
-		$("#wizard_popup").empty().append("You're good to go! Token will be of the correct scale and snapping is enabled. We don't currently support overimposing a grid in this scale..'");
+		$("#wizard_popup").empty().append("You're good to go! Token will be of the correct scale. We don't currently support overimposing a grid in this scale..'");
 		window.ScenesHandler.scene.grid_subdivided = "0";
-		window.ScenesHandler.scene.snap = "1";
-		window.ScenesHandler.scene.grid = "0";
 		window.ScenesHandler.scene.fpsq = "5";
 		window.ScenesHandler.scene.upsq = "ft";
 		window.ScenesHandler.scene.hpps /= 3;
@@ -407,10 +398,8 @@ function edit_scene_dialog(scene_id) {
 		window.WIZARDING = false;
 		$("#scene_selector_toggle").show();
 		$("#tokens").show();
-		$("#wizard_popup").empty().append("You're good to go! Token will be of the correct scale and snapping is enabled.");
+		$("#wizard_popup").empty().append("You're good to go! Token will be of the correct scale.");
 		window.ScenesHandler.scene.grid_subdivided = "0";
-		window.ScenesHandler.scene.snap = "1";
-		window.ScenesHandler.scene.grid = "1";
 		window.ScenesHandler.scene.fpsq = "5";
 		window.ScenesHandler.scene.upsq = "ft";
 		window.ScenesHandler.scene.hpps /= 4;
@@ -432,12 +421,6 @@ function edit_scene_dialog(scene_id) {
 		/*window.ScenesHandler.persist();*/
 		window.ScenesHandler.switch_scene(scene_id, function() {
 			$("#tokens").hide();
-
-			if (!just_rescaling)
-				window.CURRENT_SCENE_DATA.grid = "1";
-			else
-				window.CURRENT_SCENE_DATA.grid = "0";
-
 			window.CURRENT_SCENE_DATA.grid_subdivided = "0";
 			window.CURRENT_SCENE_DATA.scale_factor=1;
 			var aligner1 = $("<canvas id='aligner1'/>");
@@ -517,11 +500,6 @@ function edit_scene_dialog(scene_id) {
 
 			let regrid = function(e) {
 
-				window.WIZARDING = true;
-				if (!just_rescaling)
-					window.CURRENT_SCENE_DATA.grid = 1;
-				else
-					window.CURRENT_SCENE_DATA.grid = 0;
 				let al1 = {
 					x: parseInt(aligner1.css("left")) + 29,
 					y: parseInt(aligner1.css("top")) + 29,
@@ -550,7 +528,15 @@ function edit_scene_dialog(scene_id) {
 				window.CURRENT_SCENE_DATA.vpps = ppsy;
 				window.CURRENT_SCENE_DATA.offsetx = offsetx;
 				window.CURRENT_SCENE_DATA.offsety = offsety;
-				reset_canvas();
+				let width
+				if (window.ScenesHandler.scene.upscaled == "1")
+					width = 2;
+				else
+					width = 1;
+				const dash = [30, 5]
+				const color = "rgba(255, 0, 0,0.5)";
+				// nulls will take the window.current_scene_data from above
+				redraw_grid(null,null,null,null,color,width,null,dash)
 				redraw_canvas();
 			};
 
@@ -561,7 +547,6 @@ function edit_scene_dialog(scene_id) {
 			aligner2.draggable({
 				stop: regrid,
 				start: function(event) {
-					window.CURRENT_SCENE_DATA.grid = 0;
 					reset_canvas(); redraw_canvas();
 					click2.x = event.clientX;
 					click2.y = event.clientY;
@@ -569,6 +554,8 @@ function edit_scene_dialog(scene_id) {
 					$("#aligner2").attr('original-left', parseInt($("#aligner2").css("left")));
 				},
 				drag: function(event, ui) {
+					clear_grid()
+					draw_wizarding_box()
 					let zoom = window.ZOOM;
 
 					let original = ui.originalPosition;
@@ -619,7 +606,6 @@ function edit_scene_dialog(scene_id) {
 			aligner1.draggable({
 				stop: regrid,
 				start: function(event) {
-					window.CURRENT_SCENE_DATA.grid = 0;
 					reset_canvas(); redraw_canvas();
 					click1.x = event.clientX;
 					click1.y = event.clientY;
@@ -629,7 +615,8 @@ function edit_scene_dialog(scene_id) {
 					$("#aligner2").attr('original-left', parseInt($("#aligner2").css("left")));
 				},
 				drag: function(event, ui) {
-
+					clear_grid()
+					draw_wizarding_box()
 					let zoom = window.ZOOM;
 
 					let original = ui.originalPosition;
@@ -680,20 +667,13 @@ function edit_scene_dialog(scene_id) {
 					aligner1.remove();
 					aligner2.remove();
 
-					if (just_rescaling) {
-						grid_5(false, false);
-					}
-					else if (!square) {
-						$("#wizard_popup").empty().append("Nice!! How many units (i.e. feet) per square ? <button id='grid_5'>5</button> <button id='grid_10'>10</button> <button id='grid_15'>15</button> <button id='grid_20'>20</button>");
-						$("#grid_5").click(function() { grid_5(); });
-						$("#grid_10").click(function() { grid_10(); });
-						$("#grid_15").click(function() { grid_15(); });
-						$("#grid_20").click(function() { grid_20(); });
-						$("#grid_100").click(function() { grid_100(); });
-					}
-					else { // just creating a 5 foot grid
-						grid_5(true);
-					}
+					$("#wizard_popup").empty().append("Nice!! How many units (i.e. feet) per square ? <button id='grid_5'>5</button> <button id='grid_10'>10</button> <button id='grid_15'>15</button> <button id='grid_20'>20</button>");
+					$("#grid_5").click(function() { grid_5(); });
+					$("#grid_10").click(function() { grid_10(); });
+					$("#grid_15").click(function() { grid_15(); });
+					$("#grid_20").click(function() { grid_20(); });
+					$("#grid_100").click(function() { grid_100(); });
+				
 
 				}
 			);
@@ -774,11 +754,13 @@ function edit_scene_dialog(scene_id) {
 	cancel.click(function() {
 		// redraw or clear grid based on scene data
 		// discarding any changes that have been made to live modification of grid
-		if(window.CURRENT_SCENE_DATA.grid === "1"){
-			redraw_grid()
-		}
-		else{
-			clear_grid()
+		if (scene.id === window.CURRENT_SCENE_DATA.id){
+			if(window.CURRENT_SCENE_DATA.grid === "1"){
+				redraw_grid()
+			}
+			else{
+				clear_grid()
+			}
 		}
 		$("#edit_dialog").remove();
 		$("#scene_selector").removeAttr("disabled");

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -168,12 +168,34 @@ function edit_scene_dialog(scene_id) {
 	manual.append($("<div><div style='display:inline-block; width:30%'>Grid size in original image</div><div style='display:inline-block;width:70%;'><input name='hpps'> X <input name='vpps'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Offset</div><div style='display:inline-block;width:70%;'><input name='offsetx'> X <input name='offsety'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Snap to Grid(1 to enable)</div><div style='display:inline-block; width:70'%'><input name='snap'></div></div>"));
-	manual.append($("<div><div style='display:inline-block; width:30%'>Show Grid(1 to enable)</div><div style='display:inline-block; width:70'%'><input name='grid'></div></div>"));
+	manual.append($(
+		`<div>
+			<div style='display:inline-block; width:30%'>
+				Show Grid(1 to enable)
+			</div>
+		<div style='display:inline-block; width:70'%'>
+			<input name='grid'>
+		</div>
+			<input class="spectrum" name="gridColor" value="rgba(0, 0, 0, 0.5)" >
+		</div>`));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Units per square</div><div style='display:inline-block; width:70'%'><input name='fpsq'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Distance Unit (i.e. feet)</div><div style='display:inline-block; width:70'%'><input name='upsq'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Grid is a subdivided 10 units</div><div style='display:inline-block; width:70'%'><input name='grid_subdivided'></div></div>"));
 	manual.append($("<div><div style='display:inline-block; width:30%'>Image Scale Factor</div><div style='display:inline-block; width:70'%'><input name='scale_factor'></div></div>"));
 	manual.hide();
+
+	let colorPickers = manual.find('input.spectrum');
+	colorPickers.spectrum({
+		type: "color",
+		showInput: true,
+		showInitial: true,
+		containerClassName: '#edit_dialog',
+		clickoutFiresChange: false
+	});
+	// redraw the grid here
+	// colorPickers.on('move.spectrum', colorPickerChange);   // update the token as the player messes around with colors
+	// colorPickers.on('change.spectrum', colorPickerChange); // commit the changes when the user clicks the submit button
+	// colorPickers.on('hide.spectrum', colorPickerChange);   // the hide event includes the original color so let's change it back when we get it
 
 	manual.find("input").each(function() {
 		$(this).css("width", "60px");

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -6,7 +6,7 @@ body > button,
 #addscene,
 .scene button,
 #combat_tracker_inside button,
-#edit_dialog button,
+#edit_dialog button:not(.rc-switch),
 #mega_importer button,
 #prewiz td button,
 #wizard_popup button,
@@ -49,7 +49,7 @@ body > button:hover,
 #addscene:hover,
 .scene button:hover,
 #combat_tracker_inside button:hover,
-#edit_dialog button:hover,
+#edit_dialog button:not(.rc-switch):hover,
 #mega_importer button:hover,
 #prewiz td button:hover,
 #wizard_popup button:hover,
@@ -2278,10 +2278,12 @@ h5.token-image-modal-footer-title:after {
     background-color: #ccc;
     cursor: pointer;
     transition: all 0.3s cubic-bezier(0.35, 0, 0.25, 1);
+    background-image: none !important;
 }
 .rc-switch-checked {
     border: 1px solid #1b9af0;
     background-color: #1b9af0;
+    background-image: none !important;
 }
 .rc-switch-checked:after {
     left: 22px;
@@ -2300,6 +2302,7 @@ h5.token-image-modal-footer-title:after {
     top: 1px;
     border-radius: 50% 50%;
     background-color: #fff;
+    background-image: none !important;
     content: " ";
     cursor: pointer;
     box-shadow: 0 2px 5px rgba(0,0,0,0.26);
@@ -2335,6 +2338,7 @@ h5.token-image-modal-footer-title:after {
     transform: scale(1.1);
     -webkit-animation-name: rcSwitchOn;
     animation-name: rcSwitchOn;
+    background-image: none !important;
 }
 
 .sidebar-hovertext:before {
@@ -2359,9 +2363,16 @@ h5.token-image-modal-footer-title:after {
     width: 90%;
 }
 
+#edit_scene_form .sidebar-hovertext:before{
+    width: 100%;
+}
+
 .sidebar-hovertext:hover:before {
     opacity: 1;
     visibility: visible;
+}
+#edit_scene_form .sidebar-hovertext:hover:before{
+    width: 100%;
 }
 .sidebar-panel-content .sidebar-panel-footer .footer-input-wrapper:empty {
     padding: 0px;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3062,3 +3062,13 @@ button.avtt-roll-button {
     left: auto !important;
     right: 340px !important;
 }
+
+.chat-error-shake {
+    position: relative;
+    animation: shake .1s linear;
+    animation-iteration-count: 1;
+}
+@keyframes shake {
+    0% { left: -1px; }
+    100% { right: -1px; }
+}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3072,3 +3072,27 @@ button.avtt-roll-button {
     0% { left: -1px; }
     100% { right: -1px; }
 }
+
+.url-validator {
+    position: absolute;
+    top: -2px;
+    left: -24px;
+}
+
+.url-validator.invalid {
+    color: red;
+}
+
+.url-validator.valid {
+    color: green;
+}
+
+.url-validator.loading {
+    color:blue;
+    animation: spin 4s infinite linear;
+}
+
+@keyframes spin {
+    0%  {-webkit-transform: rotate(0deg);}
+    100% {-webkit-transform: rotate(360deg);}   
+}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2363,16 +2363,15 @@ h5.token-image-modal-footer-title:after {
     width: 90%;
 }
 
-#edit_scene_form .sidebar-hovertext:before{
-    width: 100%;
+#edit_scene_form .sidebar-hovertext:before,
+#edit_scene_form .sidebar-hovertext:hover:before{
+    width: fit-content;
+    white-space: nowrap;
 }
 
 .sidebar-hovertext:hover:before {
     opacity: 1;
     visibility: visible;
-}
-#edit_scene_form .sidebar-hovertext:hover:before{
-    width: 100%;
 }
 .sidebar-panel-content .sidebar-panel-footer .footer-input-wrapper:empty {
     padding: 0px;


### PR DESCRIPTION
Adds colour picker and line width to edit scene dialog.
Allows live update of grid changes (color/width)

- General cleanup of edit dialog, moved away from checkboxes in favour of toggles like a bunch of other places #consistency
- Moved away from using 1/0 as input options (under the hood it's still 1/0 as to not break existing scenes)
- Added colour picker and line width inputs
- Cleanup of grid rendering
- Moved snap/colour up to the main block so now the buttons are more for scaling rather than all grid options
- Removed chunks from grid wizard that were overriding snap/grid choices

https://www.youtube.com/watch?v=IfRcMtsICFY
