### PR TITLE
Dice rolling improvements

### DIFF
--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -1,0 +1,445 @@
+
+$(function() {
+    window.diceRoller = new DiceRoller();
+});
+
+const allDiceRegex = /\d+d(?:100|20|12|10|8|6|4)(?:kh\d+|kl\d+)|\d+d(?:100|20|12|10|8|6|4)/g; // ([numbers]d[diceTypes]kh[numbers] or [numbers]d[diceTypes]kl[numbers]) or [numbers]d[diceTypes]
+const allowedCharactersRegex = /^[dkhl\s\d+\-]*$/g; // any of these [d, kh, kl, spaces, numbers, +, -] // Should we support [*, /] ?
+
+class DiceRoll {
+    // `${action}: ${rollType}` is how the gamelog message is displayed
+
+    // don't allow changing these. They can only be set from within the constructor.
+    #fullExpression = "";
+    get expression() { return this.#fullExpression; }
+
+    #individualDiceExpressions = [];
+    get diceExpressions() { return this.#individualDiceExpressions; }
+
+    #calculatedExpressionConstant = 0;
+    get calculatedConstant() { return this.#calculatedExpressionConstant; }
+
+    #separatedDiceToRoll = {};
+    get diceToRoll() { return this.#separatedDiceToRoll; }
+
+    // these can be changed after the object is constructed.
+
+    action;        // "Rapier", "Fire Bolt", etc. defaults to "custom"
+    #diceRollType; // "To Hit", "Damage", etc. defaults to "roll"
+    get rollType() { return this.#diceRollType }
+    set rollType(newRollType) {
+        const validRollTypes = ["to hit", "damage", "save", undefined]; // undefined is in the list to allow clearing it
+        if (validRollTypes.includes(newRollType)) {
+            this.#diceRollType = newRollType;
+        } else {
+            console.warn(`not setting rollType. Expected one of ${JSON.stringify(validRollTypes)}, but received "${newRollType}"`);
+        }
+    }
+
+    name;       // monster name, player name, etc.
+    avatarUrl;  // the url of the image to render in the gamelog message
+
+    entityType; // "character", "monster", etc
+    entityId;   // the id of the character, monster, etc
+
+    // DDB parses the object after we give it back to them.
+    // expressions that are more complex tend to have incorrect expressions displayed because DDB handles that.
+    // We need to adjust the outgoing message according to how we expect DDB to parse it
+    isComplex() {
+        if (this.diceExpressions.length !== 1) {
+            return true; // more than 1 expression messes with the parsing that DDB does
+        }
+
+        if (this.expression.indexOf(this.diceExpressions[0]) !== 0) {
+            return true; // 1-1d4 messes with the parsing that DDB does, but 1d4-1 is just fine
+        }
+
+        let advantageMatch = this.diceExpressions[0].match(/kh\d+/g);
+        if (advantageMatch?.length > 1 || (advantageMatch?.length === 1 && !this.diceExpressions[0].endsWith("kh1"))) {
+            // anything other than kh1 is complex. Such as kh10 or kh2
+            return true;
+        }
+        let disAdvantageMatch = this.diceExpressions[0].match(/kl\d+/g);
+        if (disAdvantageMatch?.length > 1 || (disAdvantageMatch?.length === 1 && !this.diceExpressions[0].endsWith("kl1"))) {
+            // anything other than kl1 is complex. Such as kl10 or kl2
+            return true;
+        }
+
+        // not sure what else to look for yet, but this appears to be something like "1d20", "1d20-1", "1d20kh1+3". all of which are correctly parsed by DDB
+        return false;
+    }
+
+    isAdvantage() {
+        return !this.isComplex() && this.expression.startsWith("2d") && this.diceExpressions[0].endsWith("kh1");
+    }
+
+    isDisadvantage() {
+        return !this.isComplex() && this.expression.startsWith("2d") && this.diceExpressions[0].endsWith("kl1");
+    }
+
+    /**
+     *
+     * @param expression {string} dice expression to parse and roll. EG: "1d20+4". This is the only required value
+     * @param action {string|undefined} the action this roll represents. EG: "Rapier", "Fire Bolt", "dex", etc. defaults to "custom"
+     * @param rollType {string|undefined} the type of roll this is. EG: "to hit", "damage", "save" etc. defaults to "roll"
+     * @param name {string|undefined} the name of the creature/player associated with this roll. This is displayed above the roll box in the gamelog. The character sheet defaults to the PC.name, the encounters page defaults to ""
+     * @param avatarUrl {string|undefined} the url for the image to be displayed in the gamelog. This is displayed to the left of the roll box in the gamelog. The character sheet defaults to the PC.avatar, the encounters page defaults to ""
+     * @param entityType {string|undefined} the type of entity associated with this roll. EG: "character", "monster", "user" etc. Generic rolls from the character sheet defaults to "character", generic rolls from the encounters page defaults to "user"
+     * @param entityId {string|undefined} the id of the entity associated with this roll. If {entityType} is "character" this should be the id for that character. If {entityType} is "monster" this should be the id for that monster. If {entityType} is "user" this should be the id for that user.
+     */
+    constructor(expression, action = undefined, rollType = undefined, name = undefined, avatarUrl = undefined, entityType = undefined, entityId = undefined) {
+
+        let parsedExpression = expression.replaceAll(/\s+/g, ""); // remove all spaces
+        if (!parsedExpression.match(allowedCharactersRegex)) {
+            console.warn("Not parsing expression because it contains an invalid character", expression);
+            throw "Invalid Expression";
+        }
+
+        // find all dice expressions in the expression. converts "1d20+1d4" to ["1d20", "1d4"]
+        let separateDiceExpressions = parsedExpression.match(allDiceRegex)
+        if (!separateDiceExpressions) {
+            console.warn("Not parsing expression because there are no valid dice expressions within it", expression);
+            throw "Invalid Expression";
+        }
+
+        this.#fullExpression = parsedExpression;
+        this.#individualDiceExpressions = separateDiceExpressions;
+
+        if (action) this.action = action;
+        if (rollType) this.rollType = rollType;
+        if (name) this.name = name;
+        if (avatarUrl) this.avatarUrl = avatarUrl;
+        if (entityType) this.entityType = entityType;
+        if (entityId) this.entityId = entityId;
+
+        // figure out what constants we need to add or subtract. For example 1d20+4 has a constant of +4. 1d20+1+1d4-3 has a constant of -2/
+        let strippedExpression = this.expression.toString() // make sure we use a copy of it
+        this.#individualDiceExpressions.forEach(diceExpression => {
+            strippedExpression = strippedExpression.replace(diceExpression, "");
+        });
+        let constantEquation = strippedExpression
+            .match(/[+\-]\d+/g) // find any numbers preceded by [+, -] // Should we support [*, /] ?
+            ?.reduce((total, current) => total + current); // combine anything we find into a single string; ex: "-2+3"
+        if (constantEquation) {
+            let calculatedConstant = parseInt(eval(constantEquation.toString())); // execute the equation to get a single number
+            if (!isNaN(calculatedConstant)) {
+                this.#calculatedExpressionConstant = calculatedConstant;
+            }
+        }
+
+        // figure out how many of each DiceType we need to roll
+        this.#individualDiceExpressions.forEach(diceExpression => {
+            let diceType = diceExpression.match(/d\d+/g);
+            let numberOfDice = parseInt(diceExpression.split("d")[0]);
+            console.debug("diceExpression: ", diceExpression, ", diceType: ", diceType, ", numberOfDice: ", numberOfDice);
+            if (this.#separatedDiceToRoll[diceType] === undefined) {
+                this.#separatedDiceToRoll[diceType] = numberOfDice;
+            } else {
+                this.#separatedDiceToRoll[diceType] += numberOfDice;
+            }
+        });
+    }
+}
+
+class DiceRoller {
+
+    timeoutDuration = 10000; // 10 second timeout seems reasonable. If the message gets dropped we don't want to be stuck waiting forever.
+
+    /// PRIVATE VARIABLES
+    #pendingDiceRoll = undefined;
+    #pendingMessage = undefined;
+    #timeoutId = undefined;
+
+    /** @returns {boolean} true if a roll has been or will be initiated, and we're actively waiting for DDB messages to come in so we can parse them */
+    get #waitingForRoll() {
+        // we're about to roll dice so we need to know if we should capture DDB messages.
+        // This also blocks other attempts to roll until we've finished processing
+        return this.#timeoutId !== undefined;
+    }
+
+    constructor() {
+        const key = Symbol.for('@dndbeyond/message-broker-lib');
+        if (key) {
+            this.ddbMB = window[key];
+        } else {
+            console.warn("DiceRoller failed to get Symbol.for('@dndbeyond/message-broker-lib')");
+        }
+        if (this.ddbMB) {
+            // wrap the original dispatch function so we can block messages when we need to
+            this.ddbDispatch = this.ddbMB.dispatch.bind(this.ddbMB);
+            this.ddbMB.dispatch = this.#wrappedDispatch.bind(this);
+        } else {
+            console.warn("DiceRoller failed to get ddbMB");
+        }
+    }
+
+    /// PUBLIC FUNCTIONS
+
+    /**
+     * Attempts to parse the expression, and roll DDB dice.
+     * If dice are rolled, the results will be processed to make sure the expression is properly calculated.
+     * @param diceRoll {DiceRoll} the dice expression to parse and roll. EG: 1d20+4
+     * @returns {boolean} whether or not dice were rolled
+     */
+    roll(diceRoll) {
+        try {
+            if (diceRoll === undefined || diceRoll.expression === undefined || diceRoll.expression.length === 0) {
+                console.warn("DiceRoller.parseAndRoll received an invalid diceRoll object", diceRoll);
+                return false;
+            }
+
+            if (this.#waitingForRoll) {
+                console.warn("parseAndRoll called while we were waiting for another roll to finish up");
+                return false;
+            }
+
+            console.group("DiceRoller.parseAndRoll");
+            console.log("attempting to parse diceRoll", diceRoll);
+
+            this.#resetVariables();
+
+            // we're about to roll dice so we need to know if we should capture DDB messages.
+            // This also blocks other attempts to roll until we've finished processing
+            let self = this;
+            this.#timeoutId = setTimeout(function () {
+                console.warn("DiceRoller timed out after 10 seconds!");
+                self.#resetVariables();
+            }, this.timeoutDuration);
+
+            // don't hold a reference to the object we were given in case it gets altered while we're waiting.
+            this.#pendingDiceRoll = new DiceRoll(diceRoll.expression, diceRoll.action, diceRoll.rollType, diceRoll.name, diceRoll.avatarUrl, diceRoll.entityType, diceRoll.entityId);
+
+            this.clickDiceButtons(diceRoll);
+            console.groupEnd();
+            return true;
+        } catch (error) {
+            console.warn("failed to parse and send expression as DDB roll; expression: ", expression, error);
+            this.#resetVariables();
+            console.groupEnd();
+            return false;
+        }
+    }
+
+    /**
+     * clicks the DDB dice and then clicks the roll button
+     * @param diceRoll {DiceRoll} the DiceRoll object to roll
+     */
+    clickDiceButtons(diceRoll) {
+
+        if (diceRoll === undefined) {
+            console.warn("clickDiceButtons was called without a diceRoll object")
+            return;
+        }
+
+        if ($(".dice-toolbar").hasClass("rollable")) {
+            // clear any that are already selected so we don't roll too many dice
+            $(".dice-toolbar__dropdown-die").click();
+        }
+
+        if ($(".dice-toolbar__dropdown").length > 0) {
+            if (!$(".dice-toolbar__dropdown").hasClass("dice-toolbar__dropdown-selected")) {
+                // make sure it's open
+                $(".dice-toolbar__dropdown-die").click();
+            }
+            for(let diceType in diceRoll.diceToRoll) {
+                let numberOfDice = diceRoll.diceToRoll[diceType];
+                for (let i = 0; i < numberOfDice; i++) {
+                    $(`.dice-die-button[data-dice='${diceType}']`).click();
+                }
+            }
+        }
+
+        if ($(".dice-toolbar").hasClass("rollable")) {
+            let theirRollButton = $(".dice-toolbar__target").children().first();
+            if (theirRollButton.length > 0) {
+                // we found a DDB dice roll button. Click it and move on
+                theirRollButton.click();
+            }
+        }
+    }
+
+    /// PRIVATE FUNCTIONS
+
+    /** reset all variables back to their default values */
+    #resetVariables() {
+        console.log("resetting local variables");
+        clearTimeout(this.#timeoutId);
+        this.#timeoutId = undefined;
+        this.#pendingMessage = undefined;
+        this.#pendingDiceRoll = undefined;
+    }
+
+    /** wraps all messages that are sent by DDB, and processes any that we need to process, else passes it along as-is */
+    #wrappedDispatch(message) {
+        console.group("DiceRoller.#wrappedDispatch");
+        if (!this.#waitingForRoll) {
+            console.debug("not capturing: ", message);
+            this.ddbDispatch(message);
+        } else if (message.eventType === "dice/roll/pending") {
+            console.log("capturing pending message: ", message);
+            let ddbMessage = { ...message };
+            this.#swapDiceRollMetadata(ddbMessage);
+            this.#pendingMessage = ddbMessage;
+            this.ddbDispatch(ddbMessage);
+        } else if (message.eventType === "dice/roll/fulfilled" && this.#pendingMessage?.data?.rollId === message.data.rollId) {
+            console.log("capturing fulfilled message: ", message)
+            let alteredMessage = this.#swapRollData(message);
+            console.log("altered fulfilled message: ", alteredMessage);
+            this.ddbDispatch(alteredMessage);
+            this.#resetVariables();
+        }
+        console.groupEnd();
+    }
+
+    /** iterates over the rolls of a DDB message, calculates #pendingDiceRoll.expression, and swaps any data necessary to make the message match the expression result */
+    #swapRollData(ddbMessage) {
+        console.group("DiceRoller.#swapRollData");
+        try {
+            let alteredMessage = { ...ddbMessage };
+            alteredMessage.data.rolls.forEach(r => {
+
+                // so we need to parse r.diceNotationStr to figure out the order of the results
+                // then iterate over r.result.values to align the dice and their values
+                // then work through this.#pendingDiceRoll.expression, and replace each expression with the correct number of values
+                // then figure out any constants (such as +4), and update r.diceNotation.constant, and r.result.constant
+                // then update r.result.text, and r.result.total
+
+                // 1. match dice types with their results so we can properly replace each dice expression with the correct result
+                // all DDB dice types will be grouped together. For example: "1d4+2d6-3d8+4d10-5d20+1d100-2d20kh1+2d20kl1-1d3" turns into "9d20+5d10+3d8+2d6+1d4"
+                // all the values are in the same order as the DDB expression so iterate over the expression, and pull out the values that correspond
+                let matchedValues = {}; // { d20: [1, 18], ... }
+                let rolledExpressions = r.diceNotationStr.match(allDiceRegex);
+                let valuesToMatch = r.result.values;
+                rolledExpressions.forEach(diceExpression => {
+                    let diceType = diceExpression.match(/d\d+/g);
+                    let numberOfDice = parseInt(diceExpression.split("d")[0]);
+                    if (matchedValues[diceType] === undefined) {
+                        matchedValues[diceType] = [];
+                    }
+                    matchedValues[diceType] = matchedValues[diceType].concat(valuesToMatch.slice(0, numberOfDice));
+                    valuesToMatch = valuesToMatch.slice(numberOfDice);
+                })
+                console.debug("matchedValues: ", JSON.stringify(matchedValues));
+
+                // 2. replace each dice expression in #pendingDiceRoll.expression with the corresponding dice roll results
+                // For example: "2d20kh1+1d4-3" with rolled results of [9, 18, 2] will turn into "18+2-3"
+                // we also need to collect the results that we use which will end up being [18, 2] in this example
+                let replacedExpression = this.#pendingDiceRoll.expression.toString(); // make sure we have a new string that we alter so we don't accidentally mess up the original
+                let replacedValues = []; // will go into the roll object and DDB also parses these.
+                this.#pendingDiceRoll.diceExpressions.forEach(diceExpression => {
+                    let diceType = diceExpression.match(/d\d+/g);
+                    let numberOfDice = parseInt(diceExpression.split("d")[0]);
+                    let calculationValues = matchedValues[diceType].slice(0, numberOfDice);
+                    matchedValues[diceType] = matchedValues[diceType].slice(numberOfDice);
+                    console.debug(diceExpression, "calculationValues: ", calculationValues);
+
+                    if (diceExpression.includes("kh")) {
+                        // "keep highest" was used so figure out how many to keep
+                        let numberToKeep = parseInt(diceExpression.split("kh")[1]);
+                        // then sort and only take the highest values
+                        calculationValues = calculationValues.sort((a, b) => b - a).slice(0, numberToKeep);
+                        console.debug(diceExpression, "kh calculationValues: ", calculationValues);
+                    } else if (diceExpression.includes("kl")) {
+                        // "keep lowest" was used so figure out how many to keep
+                        let numberToKeep = parseInt(diceExpression.split("kl")[1]);
+                        // then sort and only take the lowest values
+                        calculationValues = calculationValues.sort((a, b) => a - b).slice(0, numberToKeep);
+                        console.debug(diceExpression, "kl calculationValues: ", calculationValues);
+                    }
+
+                    // finally, replace the diceExpression with the results that we have. For example 2d20 with results [2, 9] will result in "(2+9)", 1d20 with results of [3] will result in "3"
+                    let replacementString = calculationValues.length > 1 ? "(" + calculationValues.join("+") + ")" : calculationValues.join("+"); // if there are more than one make sure they get totalled together
+                    replacedExpression = replacedExpression.replace(diceExpression, replacementString);
+                    replacedValues = replacedValues.concat(calculationValues);
+                });
+
+                // now that we've replaced all the dice expressions with their results, we need to execute the expression to get the final result
+                let calculatedTotal = eval(replacedExpression);
+                console.log("pendingExpression: ", this.#pendingDiceRoll.expression, ", replacedExpression: ", replacedExpression, ", calculatedTotal:", calculatedTotal, ", replacedValues: ", replacedValues);
+
+                // we successfully processed the expression, now let's update the message object
+                r.diceNotationStr = this.#pendingDiceRoll.expression; // this doesn't appear to actually do anything
+                r.diceNotation.constant = this.#pendingDiceRoll.calculatedConstant;
+                r.result.constant = this.#pendingDiceRoll.calculatedConstant;
+                r.result.text = replacedExpression;
+                r.result.total = calculatedTotal;
+                if (this.#pendingDiceRoll.isComplex()) {
+                    r.result.values = replacedValues;
+                }
+                if (this.#pendingDiceRoll.rollType) {
+                    r.rollType = this.#pendingDiceRoll.rollType;
+                }
+                // need to update the replacedValues above based on kh and kl if we do this
+                if (this.#pendingDiceRoll.isAdvantage()) {
+                    r.rollKind = "advantage";
+                } else if (this.#pendingDiceRoll.isDisadvantage()) {
+                    r.rollKind = "disadvantage";
+                }
+                this.#pendingDiceRoll.resultTotal = calculatedTotal;
+                this.#pendingDiceRoll.resultValues = replacedValues;
+                this.#pendingDiceRoll.expressionResult = replacedExpression;
+            });
+
+            this.#swapDiceRollMetadata(alteredMessage);
+
+            console.groupEnd();
+            return alteredMessage;
+        } catch (error) {
+            console.warn("Failed to swap roll data", error);
+            console.groupEnd();
+            return ddbMessage // we failed to parse the message so return the original message
+        }
+    }
+
+    #swapDiceRollMetadata(ddbMessage) {
+
+        if (this.#pendingDiceRoll?.isComplex()) {
+            // We manipulated this enough that DDB won't properly display the formula.
+            // We'll look for this later to know that we should swap some HTML after this render
+            ddbMessage.avttExpression = this.#pendingDiceRoll.expression;
+            ddbMessage.avttExpressionResult = this.#pendingDiceRoll.expressionResult;
+            console.log("DiceRoll ddbMessage.avttExpression: ", ddbMessage.avttExpression);
+        }
+
+        if (["character", "monster"].includes(this.#pendingDiceRoll.entityType)) {
+            ddbMessage.entityType = this.#pendingDiceRoll.entityType;
+            ddbMessage.data.context.entityType = this.#pendingDiceRoll.entityType;
+        }
+        if (this.#pendingDiceRoll.entityId !== undefined) {
+            ddbMessage.entityId = this.#pendingDiceRoll.entityId;
+            ddbMessage.data.context.entityId = this.#pendingDiceRoll.entityId;
+        }
+        const isValid = (str) => { return typeof str === "string" && true && str.length > 0 };
+        if (isValid(this.#pendingDiceRoll.action)) {
+            ddbMessage.data.action = this.#pendingDiceRoll.action;
+        }
+        if (isValid(this.#pendingDiceRoll.avatarUrl)) {
+            ddbMessage.data.context.avatarUrl = this.#pendingDiceRoll.avatarUrl;
+        }
+        if (isValid(this.#pendingDiceRoll.name)) {
+            ddbMessage.data.context.name = this.#pendingDiceRoll.name;
+        }
+    }
+}
+
+function replace_gamelog_message_expressions(listItem) {
+
+    let expressionSpan = listItem.find(".tss-1wcf5kt-Line-Notation span");
+    if (expressionSpan.length > 0) {
+        let avttExpression = listItem.attr("data-avtt-expression");
+        if (avttExpression !== undefined && avttExpression.length > 0) {
+            expressionSpan.text(avttExpression);
+            expressionSpan.attr("title", avttExpression);
+            console.log("injected avttExpression", avttExpression);
+        }
+    }
+
+    let expressionResultSpan = listItem.find(".tss-16k6xf2-Line-Breakdown span");
+    if (expressionResultSpan.length > 0) {
+        let avttExpressionResult = listItem.attr("data-avtt-expression-result");
+        if (avttExpressionResult !== undefined && avttExpressionResult.length > 0) {
+            expressionResultSpan.text(avttExpressionResult);
+            console.log("injected avttExpressionResult", avttExpressionResult);
+        }
+    }
+}

--- a/Load.js
+++ b/Load.js
@@ -70,6 +70,7 @@ let scripts = [
 	{ src: "Token.js" },
 	{ src: "TokenMenu.js" },
 	// Files that execute when loaded
+	{ src: "DiceRoller.js" },
 	{ src: "ajaxQueue/ajaxQueueIndex.js", type: "module" },
 	{ src: "Main.js" }
 ]

--- a/Main.js
+++ b/Main.js
@@ -2498,6 +2498,14 @@ function init_ui() {
 
 	init_help_menu();
 
+	$("ol.tss-jmihpx-GameLogEntries").on("DOMNodeInserted", function(addedEvent) {
+		let injectedElement = $(addedEvent.target);
+		if (injectedElement.hasClass("tss-1wcf5kt-Line-Notation") || injectedElement.hasClass("tss-16k6xf2-Line-Breakdown")) {
+			let gamelogItem = injectedElement.closest("li");
+			replace_gamelog_message_expressions(gamelogItem);
+		}
+	});
+
 	if (window.DM) {
 		// LOAD DDB CHARACTER TOOLS FROM THE PAGE ITSELF. Avoid loading external scripts as requested by firefox review
 		let old=$("[src*=mega-menu]:nth-of-type(2)");

--- a/Main.js
+++ b/Main.js
@@ -417,7 +417,6 @@ function deselect_all_sidebar_tabs() {
 }
 
 function change_sidbar_tab(clickedTab, isCharacterSheetInfo = false) {
-
 	deselect_all_sidebar_tabs();
 	clickedTab.addClass("selected-tab").removeClass("notification");
 	clickedTab.find(".sidebar-tab-image").addClass("ct-primary-box__tab--extras ddbc-tab-list__nav-item ddbc-tab-list__nav-item--is-active");
@@ -429,6 +428,8 @@ function change_sidbar_tab(clickedTab, isCharacterSheetInfo = false) {
 		console.log('in teoria fatto show');
 		init_monster_panel();
 	}
+
+
 
 	// switch back to gamelog if they change tabs
 	if (!isCharacterSheetInfo) {
@@ -1652,6 +1653,7 @@ function init_above(){
 		}
 	}
 	)
+
 }
 
 function init_things() {
@@ -1742,8 +1744,8 @@ function init_things() {
 		init_ui();
 		init_splash();
 	}
+
 	$("#site").append("<div id='windowContainment'></div>");
-		
 }
 
 /// this is used when initializing on the character page. DDB loads the page in an async modular fashion. We use this to determine if we need to call other initialization functions during this process
@@ -2337,10 +2339,6 @@ function init_ui() {
 	wrapper.width(window.width);
 	wrapper.height(window.height);
 
-
-
-
-
 	wrapper.append(VTT);
 	$("body").append(wrapper);
 
@@ -2520,6 +2518,7 @@ function init_ui() {
 		},10000);
 		setTimeout(get_pclist_player_data,25000);
 	}
+
 }
 
 const DRAW_COLORS = ["#D32F2F", "#FB8C00", "#FFEB3B", "#9CCC65", "#039BE5", 

--- a/Main.js
+++ b/Main.js
@@ -2123,55 +2123,70 @@ function inject_chat_buttons() {
 			const commandRegex = /([^\d]+$)/;
 
 			if(text.startsWith("/r")) {
-				// remove the roll and extract the roll/actiontype which leaves the expression
+				// remove the roll and extract the /actiontype which leaves the expression
 				const rollRegex = /(\/r|\/roll)\s/g
 				const command = text.match(commandRegex);
-				const [actionType, rollType] = command?.[1].split(":") || [undefined, undefined]
+				const [action, rollType] = command?.[1].split(":") || [undefined, undefined]
 				let expression = text.replace(commandRegex, "");
 				expression = expression.replace(rollRegex, "");
-				send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, actionType);
-				console.groupEnd()
-				return
+				let diceRoll = new DiceRoll(expression, action, rollType);
+				if (!window.diceRoller.roll(diceRoll)) {
+					send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
+				}
+				console.groupEnd();
+				return;
 			}
 
 			if(text.startsWith("/hit")) {
 				const rollType = "to hit"
-				const actionType = text.match(commandRegex)?.[1] || undefined;
+				const action = text.match(commandRegex)?.[1] || undefined;
 				let expression = text.replace(commandRegex, "");
 				expression = expression.replace("/hit", "");
-				send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, actionType);
-				console.groupEnd()
-				return
+				let diceRoll = new DiceRoll(expression, action, rollType);
+				if (!window.diceRoller.roll(diceRoll)) {
+					send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
+				}
+				console.groupEnd();
+				return;
 			}
 
 			if(text.startsWith("/dmg")) {
 				const rollType = "damage"
-				const actionType = text.match(commandRegex)?.[1] || undefined;
+				const action = text.match(commandRegex)?.[1] || undefined;
 				let expression = text.replace(commandRegex, "");
 				expression = expression.replace("/dmg", "");
-				send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, actionType);
-				console.groupEnd()
-				return
+				let diceRoll = new DiceRoll(expression, action, rollType);
+				if (!window.diceRoller.roll(diceRoll)) {
+					send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
+				}
+				console.groupEnd();
+				return;
 			}
 
 			if(text.startsWith("/skill")) {
 				const rollType = "check"
-				const actionType = text.match(commandRegex)?.[1] || undefined;
+				const action = text.match(commandRegex)?.[1] || undefined;
 				let expression = text.replace(commandRegex, "");
 				expression = expression.replace("/skill", "");
-				send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, actionType);
-				console.groupEnd()
-				return
+				let diceRoll = new DiceRoll(expression, action, rollType);
+				if (!window.diceRoller.roll(diceRoll)) {
+					send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
+				}
+				console.groupEnd();
+				return;
 			}
 
 			if(text.startsWith("/save")) {
 				const rollType = "save"
-				const actionType = text.match(commandRegex)?.[1] || undefined;
+				const action = text.match(commandRegex)?.[1] || undefined;
 				let expression = text.replace(commandRegex, "");
 				expression = expression.replace("/save", "");
-				send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, actionType);
-				console.groupEnd()
-				return
+				let diceRoll = new DiceRoll(expression, action, rollType);
+				if (!window.diceRoller.roll(diceRoll)) {
+					send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
+				}
+				console.groupEnd();
+				return;
 			}
 			if(text.startsWith("/w")) {
 				let matches = text.match(/\[(.*?)\] (.*)/);
@@ -3202,6 +3217,20 @@ function init_my_dice_details(){
  */
 // send_rpg_dice_to_ddb(expression, displayName, imgUrl, modifier, damageType, dmOnly)
 function send_rpg_dice_to_ddb(expression, displayName, imgUrl, rollType="roll", damageType, actionType="custom", sendTo="everyone") {
+
+	let diceRoll = new DiceRoll(expression);
+	diceRoll.action = actionType;
+	diceRoll.rollType = rollType;
+	diceRoll.name = displayName;
+	diceRoll.avatarUrl = imgUrl;
+	// diceRoll.entityId = monster.id;
+	// diceRoll.entityType = monsterData.id;
+
+	if (window.diceRoller.roll(diceRoll)) {
+		console.log("send_rpg_dice_to_ddb rolled via diceRoller");
+		return true;
+	}
+
 	console.group("send_rpg_dice_to_ddb")
 	console.log("with values", expression, displayName, imgUrl, rollType, damageType, actionType, sendTo)
 	

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -765,33 +765,13 @@ class MessageBroker {
 					if (gamelogItem.find(".gamelog-to-everyone-button").length === 0) {
 						const sendToEveryone = $(`<button class="gamelog-to-everyone-button">Send To Everyone</button>`);
 						sendToEveryone.click(function (clickEvent) {
-							//TODO once PR #408 goes in use this block and make any required tweaks
-							// also remove the related css for re_sent_roll
-							// let resendMessage = msg;
-							// resendMessage.id = uuid();
-							// resendMessage.data.rollId = uuid();
-							// resendMessage.messageScope = "gameId";
-							// resendMessage.messageTarget = find_game_id();
-							// resendMessage.dateTime = Date.now();
-							// window.diceRoller.ddbDispatch(resendMessage);
-								
-							const thisGameLogItem = $(this).parent().parent()
-							
-							let rollDetails = $(thisGameLogItem).find(".tss-8-Other-ref.tss-1qn6fu1-Message-Other-Flex").clone()
-							// it's collapsed
-							if (!rollDetails.length) {
-								rollDetails = $(thisGameLogItem).find(".tss-8-Collapsed-ref.tss-8-Other-ref.tss-11w0h4e-Message-Collapsed-Other-Flex").clone()
-							}
-							$(rollDetails).find(".tss-iqf1z5-Container-Flex").addClass("re_sent_roll")
-							$(rollDetails).find(".tss-d12ile-Target-Other").remove()
-							data = {
-								player: $(gamelogItem).find(".tss-1tj70tb-Sender")?.text() ||  window.PLAYER_NAME,
-								img: $(gamelogItem).find(".tss-1e4a2a1-AvatarPortrait")?.attr("src") || window.PLAYER_IMG,
-								text: $(rollDetails).html(),
-								dmonly: false,
-							};
-							window.MB.inject_chat(data);
-							sendToEveryone.html("Send Again")
+							let resendMessage = msg;
+							resendMessage.id = uuid();
+							resendMessage.data.rollId = uuid();
+							resendMessage.messageScope = "gameId";
+							resendMessage.messageTarget = find_game_id();
+							resendMessage.dateTime = Date.now();
+							window.diceRoller.ddbDispatch(resendMessage);
 						});
 						gamelogItem.find("time").before(sendToEveryone);
 					 }

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -723,6 +723,12 @@ class MessageBroker {
 			
 			if (msg.eventType == "dice/roll/fulfilled") {
 				notify_gamelog();
+				if (msg.avttExpression !== undefined && msg.avttExpressionResult !== undefined) {
+					let gamelogItem = $("ol.tss-jmihpx-GameLogEntries li").first();
+					gamelogItem.attr("data-avtt-expression", msg.avttExpression);
+					gamelogItem.attr("data-avtt-expression-result", msg.avttExpressionResult);
+					replace_gamelog_message_expressions(gamelogItem);
+				}
 				if (!window.DM)
 					return;
 				

--- a/MonsterDice.js
+++ b/MonsterDice.js
@@ -1,104 +1,138 @@
 
-/// this injects roll buttons into the monster details page
-function scan_monster(target, stats, token_id=false) {
+/**
+ * Adds in rolling buttons and spell tracker inputs to monster frames that are not encounter frames.
+ * Specifically monster frames that appear to the player
+ * @param {$} target jqeury selected element to put rolling buttons into
+ * @param {object} stats stats of the monster
+ * @param {string} tokenId id of the token
+ */
+function scan_monster(target, stats, tokenId) {
+	console.group("scan_monster")
+	console.log("adding in avtt dice buttons")
+	// remove homebrew panels
+	target.find(".homebrew-creation-actions").remove();
+	target.find(".homebrew-previous-versions").remove();
+	target.find(".homebrew-details-footer").remove();
+	target.find("footer").remove()
+	target.find("#footer-push").remove();
+	target.find("#footer").remove();
+	$("iframe")
 	target.find(".integrated-dice__container").hide();
-	target.find(".mon-stat-block__description-block-content p").each(function(idx, element) {
+	// attempt to the tokens name first, failing tha
+	const creatureName = window.TOKEN_OBJECTS[tokenId]?.options.name || target.find(".mon-stat-block__name-link").text(); // Wolf, Owl, etc
+	const creatureAvatar = stats.data.avatarUrl
+	const displayName = `${pc.name} (${creatureName})`;
 
-		$(element).find("span[data-rolltype='to hit']").each(function() {
-			newblock = $("<div/>");
-			newblock.css("display", "inline-block");
+	const clickHandler = function(clickEvent) {
+		roll_button_clicked(clickEvent, displayName, creatureAvatar)
+	};
 
+	const rightClickHandler = function(contextmenuEvent) {
+		roll_button_contextmenu_handler(contextmenuEvent, displayName, creatureAvatar);
+	}
 
+	replace_ability_scores_with_avtt_rollers(target, ".ability-block__stat" ,".ability-block__heading", true)
+	replace_saves_skill_with_avtt_rollers(target, ".mon-stat-block__tidbit", ".mon-stat-block__tidbit-label", ".mon-stat-block__tidbit-data", true )
 
-			modifier = $(this).text();
-
-			newblock.append("<button data-exp='1d20' data-mod='" + modifier + "' class='above-roll20'>" + modifier + "</button><button class='above-roll20' data-exp='2d20kh1' data-mod='" + modifier + "'>A</button><button class='above-roll20' data-exp='2d20kl1' data-mod='" + modifier + "'>D</button> to hit");
-
-			$(this).replaceWith(newblock);
-			newblock = $("<div/>");
-			newblock.css("display", "inline-block");
-
-
-		});
-		
-		$(element).find("span[data-rolltype='damage']").each(function(){
-			newblock = $("<div/>");
-			newblock.css("display", "inline-block");
-			dice_notation=$(this).attr('data-dicenotation');
-			dice_damagetype=$(this).attr('data-rolldamagetype')
-			newblock.append(`<button data-rolldamagetype='${dice_damagetype}' data-exp='${dice_notation}' data-mod='' class='above-roll20'>${dice_notation}</button><button data-rolldamagetype='${dice_damagetype}' data-exp='${dice_notation}' class='above-roll20' data-mod='CRIT'>CRIT</button>`);
-			$(this).replaceWith(newblock);
-
-		})
-
-
-		// these covers "text parsing" for things that do not support the new DDB roll notations
-		description = $(element).html();
-		description = description.replace(/([\+-][0-9]+) to hit/, "<button data-exp='1d20' data-mod='$1' class='above-roll20'>$1</button><button class='above-roll20' data-exp='2d20kh1' data-mod='$1'>A</button><button class='above-roll20' data-exp='2d20kl1' data-mod='$1'>D</button> to hit");
-		//Spell Slots, or technically anything with 'slot'... might be able to refine the regex a bit better...
-		//TEMPORARILY DISABLED  description = description.replace(/([0-9]) slot/, '<input style="font-size: 14px; width: 40px; appearance: none;" type="number" value="$1">/$1</input> slot');
-		//Actions which go #/Day... again probably could refine the regex a bit better.
-		//TEMPORARILY DISABLED  description = description.replace(/([0-9])\/Day/i, '<input style="font-size: 14px; width: 40px; appearance: none;" type="number" value="$1">/$1</input>Day');
-		//Legendary actions which go #/Day... again probably could refine the regex a bit better.
-		//TEMPORARILY DISABLED description = description.replace(/can take ([0-9]) legendary actions/i, '<input id=legendary_actions style="font-size: 14px; width: 40px; appearance: none;" type="number" value="$1">can take $1 legendary actions</input>');
-		
-		description = description.replaceAll(/\(([0-9]+d[0-9]+( [\+-] [0-9]+)?)\)/g, "(<button data-exp='$1' data-mod='' class='above-roll20'>$1</button><button data-exp='$1' class='above-roll20' data-mod='CRIT'>CRIT</button>)");
-		$(element).html(description);
-		
-		
+	// replace all "to hit" and "damage" rolls
+	$(target).find(".mon-stat-block p").each(function() {
+		let currentElement = $(this)
+		if (currentElement.find(".avtt-roll-button").length == 0) {
+			$(currentElement).find("span").each(function (){
+				console.log("this",$(this))
+				const modMatch = $(this).attr("data-dicenotation")?.match(/(\+|-).*/gm)
+				const modifier = modMatch ? modMatch.shift() : "+0"
+				const dice = $(this).attr("data-dicenotation")?.replace(/(\+|-).*/gm, "")
+				const rollType = $(this).attr("data-rolltype")?.replace(" ","-")
+				const actionType = $(this).attr("data-rollaction")?.replace(" ","-") || "custom"
+				const text = $(this)?.text()
+				if (rollType === "damage"){
+					$(this).after(`<button data-exp=${dice} data-mod="${modifier}CRIT" data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType} critical">Crit</button>`)
+				} else if (rollType === "to-hit"){
+					$(this).after(`<button data-exp="2d20kh1" data-mod=${modifier} data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType} advantage">Adv</button>
+								   <button data-exp="2d20kl1" data-mod=${modifier} data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType} disadvantage">Dis</button>`)
+				}
+				$(this).replaceWith(`<button data-exp=${dice} data-mod=${modifier} data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType}">${text}</button>`)				
+			})
+		}
 	});
 
-	statnew = target.find(".ability-block").html().replaceAll(/\(([\+\-]?[0-9]+)\)/g, "<br><button data-exp='1d20' data-mod='$1' class='above-roll20'>$1</button><button class='above-roll20' data-exp='2d20kh1' data-mod='$1'>A</button><button class='above-roll20' data-exp='2d20kl1' data-mod='$1'>D</button>");
-	target.find(".ability-block").html(statnew);
+	// the iframe all these button exist in doesn't have the styling from above.css so add the styling here
+	$(target).find(".avtt-roll-button").css(
+	{
+		"color": "#b43c35",
+		"border": "1px solid #b43c35",
+		"border-radius": "4px",
+		"background-color":" #fff",
+		"white-space":" nowrap",
+		"font-size": "14px",
+		"font-weight": "600",
+		"font-family":"Roboto Condensed,Open Sans,Helvetica,sans-serif",
+		"line-height": "18px",
+		"letter-spacing": "1px",
+		"padding": "1px 4px 0"
+	}
+	)
 
-	tidbits = target.find(".mon-stat-block__tidbits").html();
-	newtidbits = tidbits.replaceAll(/([\+\-] ?[0-9][0-9]?)/g, "<button data-exp='1d20' data-mod='$1' class='above-roll20'>$1</button><button class='above-roll20' data-exp='2d20kh1' data-mod='$1'>A</button><button class='above-roll20' data-exp='2d20kl1' data-mod='$1'>D</button>");
-	target.find(".mon-stat-block__tidbits").html(newtidbits);
 
-
-	console.log('set handler');
-	target.on("click", ".above-roll20", function(e) {
-		dice = $(this).attr('data-exp');
-		mod = $(this).attr('data-mod');
-
-		if (mod && mod == "CRIT") {
-			mod = dice.replace(/^([0-9]+d[0-9]+).*$/, "$1");
-		}
-
-		if (mod && mod.charAt(0) != "+")
-			mod = "+" + mod;
-		else
-			mod = mod;
-
-		expression = dice + mod;
-		console.log(expression);
-		let sentAsDDB = send_rpg_dice_to_ddb(expression);
-		if (sentAsDDB) {
-			return;
-		}
-		roll = new rpgDiceRoller.DiceRoll(expression);
-
-		let output_beauty = roll.output.replace(/=(.*)/, "= <b>$1</b>")
-		
-
-		if($(this).attr('data-rolldamagetype')){
-			output_beauty+= " <b>"+$(this).attr('data-rolldamagetype')+"</b>";
-		}
-		
-		data = {
-				player: stats.data.name,
-				img: stats.data.avatarUrl,
-				text: output_beauty,
-				dmonly:true,
-			};
-		window.MB.inject_chat(data);
-		notify_gamelog();
-	});
+	$(target).find(".avtt-roll-button").click(clickHandler);
+	$(target).find(".avtt-roll-button").on("contextmenu", rightClickHandler);
+	add_ability_tracker_inputs(target, tokenId)
+	
+	console.groupEnd()
 }
 
-// this is intended to be used with the encounterHandler only. It will need some rework if we want to use it for non-encounter stat blocks
-function add_ability_tracker_inputs(target, tokenId) {
+/**
+ * Adds in tracker input slot on elements that appear as "2/Day each"
+ * @param {$} target 
+ * @param {string} tokenId 
+ */
+function add_ability_tracker_inputs_on_each(target, tokenId){
+	const token = window.TOKEN_OBJECTS[tokenId];
+	target.find(".mon-stat-block__description-block-content > p").each(function() {
+		let element = $(this);
+		if (element.find(".injected-input").length == 0) {
+			const matchForEachSlot = element.text().match(/([0-9])\/Day each:/i)
+			if (matchForEachSlot){
+				const numberFound = parseInt(matchForEachSlot[1]);
+				element.children().each(function (indexInArray, valueOfElement) { 
+					const key  = $(valueOfElement).text()
+					const remaining = token.get_tracked_ability(key, numberFound);
 
+					$(valueOfElement).after(createCountTracker(tokenId, key.replace(/\s/g, ""), remaining, "", ""))
+				});			
+			}
+			
+		}
+	});	
+}
+
+/**
+ * Creates the input tracker used for spell/legendaries and then calls token.track_ability
+ * @param {object} token 
+ * @param {string} key 
+ * @param {string} remaining 
+ * @param {string} foundDescription 
+ * @param {string} descriptionPostfix 
+ * @returns 
+ */
+function createCountTracker(token, key, remaining, foundDescription, descriptionPostfix) {
+	const input = $(`<input class="injected-input" data-token-id="${token.id}" data-tracker-key="${key}" type="number" value="${remaining}" style="font-size: 14px; width: 40px; appearance: none; border: 1px solid #d8e1e8; border-radius: 3px;"> ${foundDescription} ${descriptionPostfix}</input>`);
+	input.off("change").on("change", function(changeEvent) {
+		const updatedValue = changeEvent.target.value;
+		console.log(`add_ability_tracker_inputs ${key} changed to ${updatedValue}`);
+		token.track_ability(key, updatedValue);
+	});
+	return input
+}
+
+/**
+ * Adds spell/feature/legendary tracker inputs to a monster block
+ * @param {$} target 
+ * @param {string} tokenId 
+ * @returns 
+ */
+function add_ability_tracker_inputs(target, tokenId) {
 	let token = window.TOKEN_OBJECTS[tokenId];
 	if (token === undefined) {
 		// nothing to track if we don't have a token
@@ -116,12 +150,7 @@ function add_ability_tracker_inputs(target, tokenId) {
 				let foundDescription = includeMatchingDescription ? foundMatches.input.substring(0, foundMatches.index) : descriptionPostfix; // `1st level `, `2nd level `, etc.
 				let key = foundDescription.replace(/\s/g, ""); // `1stlevel`, `2ndlevel`, etc.
 				let remaining = token.get_tracked_ability(key, numberFound);
-				let input = $(`<input class="injected-input" data-token-id="${tokenId}" data-tracker-key="${key}" type="number" value="${remaining}" style="font-size: 14px; width: 40px; appearance: none; border: 1px solid #d8e1e8; border-radius: 3px;"> ${foundDescription} ${descriptionPostfix}</input>`);
-				input.off("change").on("change", function(changeEvent) {
-					let updatedValue = changeEvent.target.value;
-					console.log(`add_ability_tracker_inputs ${key} changed to ${updatedValue}`);
-					token.track_ability(key, updatedValue);
-				});
+				const input = createCountTracker(token, key, remaining, foundDescription, descriptionPostfix)
 				element.append(`<br>`);
 				element.append(input);
 			}
@@ -137,9 +166,88 @@ function add_ability_tracker_inputs(target, tokenId) {
 			processInput(element, /can take ([0-9]) legendary actions/i, "Legendary Actions remaining", false);
 		}
 	});	
+	add_ability_tracker_inputs_on_each(target, tokenId)
 }
 
-function scan_player_creature_pane(target, tokenId) {
+/**
+ * replaces ability scores with rolling buttons
+ * used by both the extra pane scanning and monster frame scanning
+ * they're both slightly different and have different selectors as well button count
+ * @param {$} target jquery selected target to add buttons into
+ * @param {string} outerSelector an outer selector to find against
+ * @param {string} innerSelector and inner selector to find against
+ * @param {bool} addAdvDisButton whether to add in additional Crit/Adv/Dis buttons (currently only used by monster frame)
+ */
+function replace_ability_scores_with_avtt_rollers(target, outerSelector, innerSelector, addAdvDisButton) {
+	$(target).find(outerSelector).each(function() {
+		const currentElement = $(this)
+		if (currentElement.find(".avtt-roll-button").length == 0) {
+			const abilityType = $(this).find(innerSelector).html()
+			const rollType="check"
+			// matches (+1) 
+			let updated = currentElement.html()
+				.replaceAll(/(\([\+\-] ?[0-9][0-9]?\))/g, `<button data-exp='1d20' data-mod='$1' data-rolltype=${rollType} data-actiontype=${abilityType} class='avtt-roll-button' title="${abilityType} ${rollType}">$1</button>`); 
+			$(currentElement).html(updated);
+			
+			if (addAdvDisButton){
+				// matches just the +1
+				const modMatch = currentElement.text().match(/[\+\-] ?[0-9]?/g)
+				const modifier = modMatch ? modMatch.shift() : ""
+				currentElement.find(".avtt-roll-button").after(`<button data-exp="2d20kh1" data-mod=${modifier} data-rolltype=${rollType} data-actiontype=${abilityType} class='avtt-roll-button' title="${abilityType} ${rollType} advantage">Adv</button><button data-exp="2d20kl1" data-mod=${modifier}' data-rolltype=${rollType} data-actiontype=${abilityType} class='avtt-roll-button' title="${abilityType}${rollType} disadvantage">Dis</button>`)
+				$(this).css("display","flex")
+			}
+
+		}
+	});
+}
+
+/**
+ * replaces "tidbits" with avtt roller buttons
+ * tidbits are skills/saving throws as well as additional monster stat items that don't have buttons added to
+ * @param {$} target jquery selected element
+ * @param {string} outerSelector an outer selector to find against
+ * @param {string} labelSelector a selector for the tidbit label
+ * @param {string} dataSelector a selector for the data section of the tidbit
+ * @param {bool} addAdvDisButton 
+ */
+function replace_saves_skill_with_avtt_rollers(target, outerSelector, labelSelector, dataSelector, addAdvDisButton){
+// replace saving throws, skills, etc
+$(target).find(outerSelector).each(function() {
+	let currentElement = $(this)
+	if (currentElement.find(".avtt-roll-button").length == 0) {
+		const label = $(currentElement).find(labelSelector).html()
+		if (label === "Saving Throws" || label === "Skills"){
+			// get the tidbits in the form of ["DEX +3", "CON +4"] or ["Athletics +6", "Perception +3"]
+			const tidbitData = $(currentElement).find(dataSelector).text().trim().split(",")
+			const allTidBits = []
+			tidbitData.forEach((tidbit) => {
+				// can only be saving throw or skills here, which is either save/check respectively
+				const rollType = label === "Saving Throws" ? "save" : "check"
+				// will be DEX/CON/ATHLETICS/PERCEPTION
+				const actionType = tidbit.trim().split(" ")[0]
+				// matches "+1"
+				const modMatcher = tidbit.match(/([\+\-] ?[0-9][0-9]?)/)
+				const modifier = modMatcher ? modMatcher.shift() : ""
+				if (addAdvDisButton){
+					allTidBits.push(tidbit.replace(/([\+\-] ?[0-9][0-9]?)/, `<button data-exp='1d20' data-mod='$1' data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType}">$1</button>`))
+					allTidBits.push(
+					`<button data-exp='2d20kh1' data-mod=${modifier} data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType} advantage">Adv</button><button data-exp='2d20kl1' data-mod=${modifier} data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType} disadvantage">Dis</button>`)
+				} else{
+					allTidBits.push(tidbit.replace(/([\+\-] ?[0-9][0-9]?)/, `<button data-exp='1d20' data-mod='$1' data-rolltype=${rollType} data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} ${rollType}">$1</button>`) )
+				}
+			})
+			const thisTidBitData = $(currentElement).find(dataSelector)
+			$(thisTidBitData).html(allTidBits);				
+		}
+	}
+});}
+
+
+/**
+ * Scans the player sheet to add in roller buttons to the extra tab
+ * @param {$} target jquery selected element
+ */
+function scan_player_creature_pane(target) {
 	console.group("scan_player_creature_pan")
 
 	let creatureType = target.find(".ct-sidebar__header .ct-sidebar__header-parent").text(); // wildshape, familiar, summoned, etc
@@ -160,33 +268,9 @@ function scan_player_creature_pane(target, tokenId) {
 		roll_button_contextmenu_handler(contextmenuEvent, displayName, creatureAvatar);
 	}
 
-	// replace ability scores modifiers
-	$(target).find(".ddbc-creature-block__abilities .ddbc-creature-block__ability-modifier").each(function() {
-		let currentElement = $(this)
-		if (currentElement.find(".avtt-roll-button").length == 0) {
-			let innerHtml = currentElement.html();
-			let foundModifiers = innerHtml.match(/([\+\-] ?[0-9][0-9]?)/g);
-			if (foundModifiers.length > 0) {
-				let mod = foundModifiers[0];
-				let button = $(`<button data-exp='1d20' data-mod='${mod}' data-rolltype='tohit' class='avtt-roll-button'>${innerHtml}</button>`);
-				button.click(clickHandler);
-				button.on("contextmenu", rightClickHandler)
-				$(currentElement).html(button);
-			}
-		}
-	});
 
-	// replace saving throws, skills, etc
-	$(target).find(".ddbc-creature-block__tidbits .ddbc-creature-block__tidbit-data").each(function() {
-		let currentElement = $(this)
-		if (currentElement.find(".avtt-roll-button").length == 0) {
-			let updated = currentElement.html()
-				.replaceAll(/([\+\-] ?[0-9][0-9]?)/g, "<button data-exp='1d20' data-mod='$1' data-rolltype='tohit' class='avtt-roll-button'>$1</button>"); // <button class='avtt-roll-button' data-exp='2d20kh1' data-mod='$1'>A</button><button class='avtt-roll-button' data-exp='2d20kl1' data-mod='$1'>D</button>
-			$(currentElement).html(updated);
-			$(currentElement).find(".avtt-roll-button").click(clickHandler);
-			$(currentElement).find(".avtt-roll-button").on("contextmenu", rightClickHandler);
-		}
-	});
+	replace_ability_scores_with_avtt_rollers(target, ".ddbc-creature-block__ability-stat", ".ddbc-creature-block__ability-heading")
+	replace_saves_skill_with_avtt_rollers(target, ".ddbc-creature-block__tidbit",".ddbc-creature-block__tidbit-label", ".ddbc-creature-block__tidbit-data" )
 
 	// replace all "to hit" and "damage" rolls
 	$(target).find(".ct-creature-pane__block p").each(function() {
@@ -196,53 +280,47 @@ function scan_player_creature_pane(target, tokenId) {
 			// to account for all the nuances of DNDB dice notation.
 			// numbers can be swapped for any number in the following comment
 			// matches "1d10", " 1d10 ", "1d10+1", " 1d10+1 ", "1d10 + 1" " 1d10 + 1 "
-			const damageRollRegex = /([0-9]+d[0-9]+\s?([\+-]\s?[0-9]+)?)/g
+			const damageRollRegex = /(([0-9]+d[0-9]+)\s?([\+-]\s?[0-9]+)?)/g
 			// matches " +1 " or " + 1 "
 			const hitRollRegex = /\s([\+-]\s?[0-9]+)\s/g
+			let actionType = currentElement.find("strong").html() || "custom"
 			let updated = currentElement.html()
-				.replaceAll(damageRollRegex, "<button data-exp='$1' data-mod='' data-rolltype='damage' class='avtt-roll-button'>$1</button>")
-				.replaceAll(hitRollRegex, "<button data-exp='1d20' data-mod='$1' data-rolltype='tohit' class='avtt-roll-button'>$1</button>")
+				.replaceAll(damageRollRegex, `<button data-exp='$2' data-mod='$3' data-rolltype='damage' data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} damage">$1</button>`)
+				.replaceAll(hitRollRegex, `<button data-exp='1d20' data-mod='$1' data-rolltype='to hit' data-actiontype=${actionType} class='avtt-roll-button' title="${actionType} to hit">$1</button>`)
 			$(currentElement).html(updated);
-			$(currentElement).find(".avtt-roll-button").click(clickHandler);
-			$(currentElement).find(".avtt-roll-button").on("contextmenu", rightClickHandler);
 		}
 	});
+	$(target).find(".avtt-roll-button").click(clickHandler);
+	$(target).find(".avtt-roll-button").on("contextmenu", rightClickHandler);
 	console.groupEnd()
 }
 
-// exp: 1d20, modifier: +1, damageType: bludgeoning
-function roll_our_dice(displayName, imgUrl, expression, modifier, damageType, dmOnly) {
-	let dice = expression;
-	// rpgDiceRoller.DiceRoll expects a modifier, so if none is supplied give a +0
-	let mod = modifier || "+0";
+/**
+ * Stepping stone function to go on to send the dice expressions to DDB via MB
+ * makes adjustments to the expression if it's a crit
+ * notifies the user if successfully sent to DDB combat log
+ * @param {string} displayName how to display the dice roll
+ * @param {string} imgUrl the image url to use in the dice roll
+ * @param {string} expression dice expression
+ * @param {string} modifier dice modifier
+ * @param {string} rollType usually "to hit" or "damage" but can also be custom / anything else
+ * @param {string} damageType not actually used by DND just yet so this is a placeholder
+ * @param {string} actionType the action being performed
+ * @param {string} sendTo everyone/DM, open only exists when using extra tab context menu
+ */
+function roll_our_dice(displayName, imgUrl, expression, modifier, rollType, damageType, actionType, sendTo) {
+	console.group("rolling_our_dice", expression, modifier)
 
-	if (mod && mod == "CRIT") {
-		mod = dice.replace(/^([0-9]+d[0-9]+).*$/, "$1");
-	}
-
-	if (mod && mod.charAt(0) != "+") {
-		mod = "+" + mod;
-	} else {
-		mod = mod;
-	}
-	let roll = new rpgDiceRoller.DiceRoll(dice + mod);
-	let output_beauty = roll.output.replace(/=(.*)/, "= <b>$1</b>")
-	
-	if(damageType){
-		output_beauty += ` <b>${damageType}</b>`;
+	const isCrit = modifier.includes("CRIT")
+	modifier = modifier.replace(/[\(\)']+/g, "")
+	if (isCrit){
+		expression = `${expression}+${expression}`
+		modifier = modifier.replace("CRIT", "")
 	}
 	
-	let data = {
-		player: displayName,
-		img: imgUrl,
-		text: output_beauty,
-		dmonly: dmOnly,
-	};
-	window.MB.inject_chat(data);
-	if (is_characters_page()) {
-		// TODO: there's gotta be a better way
-		notify_gamelog();
-	}
+	const result = send_rpg_dice_to_ddb(expression+modifier, displayName, imgUrl, rollType, damageType,  actionType, sendTo)
+	result ? notify_gamelog() : console.warn("Message could not be sent to DDB")
+	console.groupEnd()
 }
 
 function find_currently_open_character_sheet() {
@@ -276,7 +354,7 @@ function display_roll_button_contextmenu(contextmenuEvent, isDamageRoll, rollBut
 					<ul class="MuiList-root MuiList-padding MuiList-subheader">
 						<li class="jss3"></li>
 						
-						<li class="dm-only-option sendto-options">
+						<li class="sendto-options">
 							<ul class="jss4">
 								<li class="MuiListSubheader-root MuiListSubheader-sticky MuiListSubheader-gutters">Send To:</li>
 								<div data-sendto="everyone" class="MuiButtonBase-root MuiListItem-root jss6 MuiListItem-gutters MuiListItem-button" tabindex="0" role="button" aria-disabled="false">
@@ -295,7 +373,7 @@ function display_roll_button_contextmenu(contextmenuEvent, isDamageRoll, rollBut
 							</ul>
 						</li>
 						
-						<hr class="MuiDivider-root dm-only-option">
+						<hr class="MuiDivider-root">
 						
 						<li class="rollwith-options">
 							<ul class="jss4">
@@ -356,12 +434,6 @@ function display_roll_button_contextmenu(contextmenuEvent, isDamageRoll, rollBut
 		top: `${top}px`,
 		left: `${left}px`
 	});
-	
-	if (!window.DM) {
-		// only DMs get the ability to roll to self
-		overlay.find(".dm-only-option").hide();
-	}
-
 	if (isDamageRoll) {
 		// damage rolls allow a "crit damage" option
 		overlay.find(".rollwith-options").hide();
@@ -429,24 +501,34 @@ function roll_button_contextmenu_handler(contextmenuEvent, displayName, imgUrl) 
 	let modifier = pressedButton.attr('data-mod');
 	let damageType = pressedButton.attr('data-rolldamagetype');
 	let rollType = pressedButton.attr('data-rolltype');
+	let actionType = pressedButton.attr('data-actiontype');
 
-	display_roll_button_contextmenu(contextmenuEvent, rollType == "damage", function(sendTo, rollWith, rollAs) {
+	display_roll_button_contextmenu(contextmenuEvent, rollType === "damage", function(sendTo, rollWith, rollAs) {
 		if (rollWith == "advantage") {
 			expression = "2d20kh1";
 		} else if (rollWith == "disadvantage") {
 			expression = "2d20kl1";
 		}
 		if (rollAs == "crit") {
-			modifier = "CRIT";
+			modifier = `${modifier}CRIT`;
 		}
-		roll_our_dice(displayName, imgUrl, expression, modifier, damageType, sendTo == "self");
+		// displayName, imgUrl, expression, modifier, rollType, damageType, actionType, dmOnly
+		roll_our_dice(displayName, imgUrl, expression, modifier, rollType, damageType, actionType, sendTo);
 	});
 }
 
+/**
+ * click handler for all avtt roller buttons
+ * @param {event} clickEvent 
+ * @param {string} displayName display name to send to combat log
+ * @param {string} imgUrl image url to sent to combat log
+ */
 function roll_button_clicked(clickEvent, displayName, imgUrl) {
 	let pressedButton = $(clickEvent.currentTarget);
 	let expression = pressedButton.attr('data-exp');
 	let modifier = pressedButton.attr('data-mod');
 	let damageType = pressedButton.attr('data-rolldamagetype');
-	roll_our_dice(displayName, imgUrl, expression, modifier, damageType, false);
+	let rollType = pressedButton.attr('data-rolltype');
+	let actionType = pressedButton.attr('data-actiontype');
+	roll_our_dice(displayName, imgUrl, expression, modifier, rollType, damageType, actionType);
 }

--- a/Token.js
+++ b/Token.js
@@ -1485,7 +1485,7 @@ function menu_callback(key, options, event) {
 				console.log(`attempting to open monster stat block with monsterId ${$(this).attr('data-monster')} and tokenId ${$(this).attr('data-id')}`);
 				open_monster_stat_block_with_id($(this).attr('data-monster'), $(this).attr('data-id'));
 			} else {
-				load_monster_stat($(this).attr('data-monster'), token_id=$(this).attr('data-id'));	
+				load_monster_stat($(this).attr('data-monster'), $(this).attr('data-id'));	
 			}
 		}
 		else {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -31,6 +31,25 @@ body > button,
     font-size: 12px;
 }
 
+.re_sent_roll{
+    pointer-events: none;
+    color: rgb(92, 112, 128);
+}
+
+/* this can be removed once /roll/fulfilled todo has been completed */
+.re_sent_roll.tss-3-Other-ref.tss-3-Target-ref.tss-11yjuwm-Total-Other-Target-Flex{
+        position: relative;
+        align-self: stretch;
+        display: flex;
+        -webkit-box-align: center;
+        align-items: center;
+        flex-direction: column;
+        -webkit-box-pack: center;
+        justify-content: center;
+        font-size: 2rem;
+        font-weight: bold;
+}
+
 #cpick{
     display: block;
     margin-left: 27px;
@@ -74,10 +93,7 @@ body > button:hover,
 }
 button.gamelog-to-everyone-button {
     background-color: rgb(255, 255, 255);
-    border-top: none;
-    border-right: 1px solid rgb(206, 217, 224);
-    border-bottom: 1px solid rgb(206, 217, 224);
-    border-left: 1px solid rgb(206, 217, 224);
+    border: 1px solid rgb(206, 217, 224);
     border-image: initial;
     border-radius: 0px 0px 4px 4px;
     padding: 4px 10px;
@@ -89,6 +105,13 @@ button.gamelog-to-everyone-button {
     line-height: 16px;
     letter-spacing: 0.4px;
     color: #5c7080;
+    cursor: pointer;
+    float:left;
+}
+button.gamelog-to-everyone-button:hover {
+    border: 1px solid rgb(152, 160, 164);
+    background-color: rgb(220, 219, 219);
+    color: #33404b;
 }
 
 .material-icons.md-10 { font-size: 10px; }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -31,25 +31,6 @@ body > button,
     font-size: 12px;
 }
 
-.re_sent_roll{
-    pointer-events: none;
-    color: rgb(92, 112, 128);
-}
-
-/* this can be removed once /roll/fulfilled todo has been completed */
-.re_sent_roll.tss-3-Other-ref.tss-3-Target-ref.tss-11yjuwm-Total-Other-Target-Flex{
-        position: relative;
-        align-self: stretch;
-        display: flex;
-        -webkit-box-align: center;
-        align-items: center;
-        flex-direction: column;
-        -webkit-box-pack: center;
-        justify-content: center;
-        font-size: 2rem;
-        font-weight: bold;
-}
-
 #cpick{
     display: block;
     margin-left: 27px;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2352,6 +2352,12 @@ h5.token-image-modal-footer-title:after {
     width: 90%;
 }
 
+.chat-text-wrapper.sidebar-hovertext:before{
+ bottom: 100px;
+ text-align: left;
+ white-space: pre;
+}
+
 .sidebar-hovertext:hover:before {
     opacity: 1;
     visibility: visible;

--- a/manifest.json
+++ b/manifest.json
@@ -80,6 +80,7 @@
 		"ScenesPanel.js",
 		"mousetrap.1.6.5.min.js",
 		"KeypressHandler.js",
+		"DiceRoller.js",
 		"Main.js"
 	]
 }


### PR DESCRIPTION
This is a feature branch which combines the following PRs: 
* https://github.com/cyruzzo/AboveVTT/pull/399
* https://github.com/cyruzzo/AboveVTT/pull/406
* https://github.com/cyruzzo/AboveVTT/pull/408

# Make our dice rolling look like dndbeyond, includes rolling via chat box and player monster frames (extra tab/monster sheets). Added actions, types and more commands to chatbox rolling. Added "X/each" spell slot trackers to monster sheets

- Fixed up RPG dice roller to make it look like dndbeyond dice rolls
- Added custom actions/types via chat box
- Added helper text and /help command to chat box that opens the docs on dice rolling
- Uplifted dice buttons on monster sheets that aren't from encounters (now that players can have access to a monsters sheet)
resolves #302 

Some more user readable notes:

- Rolling via chat now has more commands and those rolls look like DNDBeyond rolling
- Rolling from extra tab now shows as DNDBeyond would if they even allowed rolling from there..
- Buttons on the monster sheet owned by players more closely align with the standard DDB styling and they also have all the information that you would expect in the combat log when rolled
- Spell slots trackers for for "X/each"
- Video.. apologies for the super quiet audio, youtube has clamped it down for whatever reason will get better at this :D https://www.youtube.com/watch?v=w4HftubO1ek



# rolling to "self" gives option to send to players

resolves #272 
re did the monitor message function as an observer
watches combat log and adds in button on expanded rolls
hides button before it collapses
shows button again if opened


# Add ability to roll DDB dice with modifiers
## What
This adds the ability to roll DDB dice with modifiers.  
`DiceRoller.js` was added, but it isn't implement in this PR. It will be implemented by some of the other open PRs.

## How It Works
`DiceRoller` works by 
1. Parsing an expression (such as 1d20+4)
2. Clicks the DDB dice buttons and then the DDB roll button
3. Captures the corresponding "dice/roll/pending" message
a. If the message metadata needs to be altered it will do so
b. The captured message is then sent as expected
5. Captures the corresponding "dice/roll/fulfilled" message
a. Parses the dice roll results
b. Calculates the original expression using the dice roll results
c. The captured message is then sent as expected

## How To Use It
Create a `DiceRoll` object, and pass it to `window.diceRoller.roll`.

### Example 1
The most basic use is to simply call it with an expression. This will roll dice on behalf of the Player or DM, and will use all the default metadata that DDB uses. This code will result in the screenshot below

    var diceRoll = new DiceRoll("2d20kh1+2");
    window.diceRoller.roll(diceRoll);


<img width="340" alt="Screen Shot 2022-04-18 at 11 03 41 AM" src="https://user-images.githubusercontent.com/584771/163836666-93f2bdbc-9e6b-4019-99d3-6c2853c8496f.png">



### Example 2
To roll on behalf of a monster, you would call it like this

    var diceRoll = new DiceRoll("1d20-3");
    diceRoll.action = "Big Fist";
    diceRoll.rollType = "damage";
    diceRoll.entityId = monsterData.id;
    diceRoll.name = monsterData.name;
    diceRoll.avatarUrl = monsterData.avatarUrl;
    window.diceRoller.roll(diceRoll);

<img width="340" alt="Screen Shot 2022-04-18 at 11 04 00 AM" src="https://user-images.githubusercontent.com/584771/163836710-bf985795-4744-4a22-941d-3e3983f65046.png">


## Demo
Here's a video demonstrating the expression "2d20kh1+2" which is rolling with advantage and a +2 modifier. The DDB dice rolled a 10 and a 4, resulting in the final expression of 10+2=12
![avtt-diceRoller](https://user-images.githubusercontent.com/584771/163837645-d1a1ecc4-323d-4d77-af93-d952e69fd36e.gif)
