### PR TITLE
Fixes not being able to put markers on monsters

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -645,7 +645,9 @@ class Token {
 			}
 		}
 		else{
-			this.options.custom_conditions.pop("Inspiration")
+			if (this.options.custom_conditions.includes("Inspiration")){
+				this.options.custom_conditions.pop("Inspiration")
+			}
 		}
 		
 		


### PR DESCRIPTION
Fixes: #463

This bug only exists in main not the live version.

It also stops markers from going on player tokens if they don't have inspiration. This fixes that as well.