### PR TITLE
Fix: Stop group selection of player restricted tokens for players

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1016,7 +1016,8 @@ function drawing_mouseup(e) {
 			c++;
 			// TOKEN IS INSIDE THE SELECTION
 			if (window.DM || !curr.options.hidden) {
-				if($("#tokens>div[data-id='" + curr.options.id + "']").css("pointer-events")!="none" && $("#tokens>div[data-id='" + curr.options.id + "']").css("display")!="none") {
+				let tokenDiv = $("#tokens>div[data-id='" + curr.options.id + "']")
+				if(tokenDiv.css("pointer-events")!="none" && tokenDiv.css("display")!="none" && !tokenDiv.hasClass("ui-draggable-disabled")) {
 					curr.selected = true;
 				}
 			}


### PR DESCRIPTION
This stops group selection of player restricted tokens. This fixes #473 and is a qol improvement for players with multiple tokens to select. They won't accidently grab monsters.