### PR TITLE
Fix: Set width or height of tokens that retain their aspect ratio to fit larger size tokens when the image isn't big enough

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -414,7 +414,15 @@ class Token {
 			'max-height': tokenHeight + 'px',
 		});
 
-
+		if(!this.options.legacyaspectratio) {
+			if(token.children('img').width() >= token.children('img').height()) {
+				token.children('img').css("min-width", tokenWidth + 'px');
+			}
+			else {
+				token.children('img').css("min-height", tokenHeight + 'px');
+			}
+		}
+		
 		console.groupEnd()
 	}
 

--- a/Token.js
+++ b/Token.js
@@ -408,21 +408,29 @@ class Token {
 			token.css('--token-hpbar-display', 'block');
 		}
 		token.attr("data-border-color", this.options.color);
-	
-		token.children('img').css({		
-		    'max-width': tokenWidth + 'px',
-			'max-height': tokenHeight + 'px',
-		});
-
 		if(!this.options.legacyaspectratio) {
-			if(token.children('img').width() >= token.children('img').height()) {
+			if(token.children('img').width() == token.children('img').height()){
+				token.children('img').css("min-width", tokenWidth + 'px');
+				token.children('img').css("min-height", tokenHeight + 'px');
+			}
+			else if(token.children('img').width() > token.children('img').height()) {
 				token.children('img').css("min-width", tokenWidth + 'px');
 			}
 			else {
 				token.children('img').css("min-height", tokenHeight + 'px');
 			}
 		}
+		else {
+			token.children('img').css("min-width", "");
+			token.children('img').css("min-height", "");
+		}
 		
+		token.children('img').css({		
+		    'max-width': tokenWidth + 'px',
+			'max-height': tokenHeight + 'px',
+		});
+
+
 		console.groupEnd()
 	}
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3386,7 +3386,9 @@ button.avtt-roll-button {
 /*end combat tracker face lift*/
 
 .token>img {
-    transition: max-height 0.2s linear, max-width 0.2s linear;
+    transition: max-height 0.2s linear, max-width 0.2s linear, min-height 0.2s linear, min-width 0.2s linear;
+    min-height: 0px;
+    min-width: 0px;
     filter:  drop-shadow(var(--token-border-color) -1px 0px 1px) drop-shadow(var(--token-border-color) 1px 0px 1px) drop-shadow(var(--token-border-color) 0px 1px 1px) drop-shadow(var(--token-border-color) 0px -1px 1px) drop-shadow(var(--token-hp-aura-color) 1px 0px 2px) drop-shadow(var(--token-hp-aura-color) 0px 1px 2px) drop-shadow(var(--token-hp-aura-color) 0px -1px 2px) drop-shadow(var(--token-hp-aura-color) -1px 0px 2px) drop-shadow(var(--token-temp-hp) 1px 0px 2px) drop-shadow(var(--token-temp-hp) -1px 0px 2px) drop-shadow(var(--token-temp-hp) 0px -1px 2px) drop-shadow(var(--token-temp-hp) 0px 1px 2px);
 }
 .token>img:not(.preserve-aspect-ratio) {


### PR DESCRIPTION
This checks which side is longer and sets that side's min-width to fit the token size if `ignore aspect ratio` is disabled. This ensures that a 1.0 scale image fits it's token size properly when the token is larger than the img src. It does this by stretching token images on the longer sides axis to maintain aspect ratio. 

Closes #483