### PR TITLE
Fix conditions showing up when player token is selected

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1692,10 +1692,10 @@ function init_things() {
 
 	} else {
 		init_ui();
-		init_splash();on
+		init_splash();
 	}
 
-	$("#site").append("<div id='windowContainment'></div>");	            
+	$("#site").append("<div id='windowContainment'></div>");
 }
 
 /// this is used when initializing on the character page. DDB loads the page in an async modular fashion. We use this to determine if we need to call other initialization functions during this process
@@ -1743,9 +1743,7 @@ function init_character_page_sidebar() {
 		$(".ct-sidebar__portal .ct-sidebar .ct-sidebar__inner .ct-sidebar__controls .avtt-sidebar-controls").css("display", "flex")
 
 		$(".ct-sidebar__pane").on("click", ".open-conditions-button", function(clickEvent) {
-			debugger;
 			let conditionName = $(clickEvent.target).parent().find("span").text();
-			debugger;
 			console.log(conditionName + "!!!!!!!!!!!!!!!!!!!!!!");
 		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
 		  	console.log($(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}')`));

--- a/Main.js
+++ b/Main.js
@@ -1739,10 +1739,17 @@ function init_character_page_sidebar() {
 		$(".ct-sidebar").css({ "right": "0px", "top": "0px", "bottom": "0px" });		
 		$(".ct-sidebar__portal .ct-sidebar .ct-sidebar__inner .ct-sidebar__controls .avtt-sidebar-controls").css("display", "flex")
 
-		$(".ct-sidebar__pane").on("click", ".open-conditions-button", function(clickEvent) {
+		$(".ct-sidebar__pane").on("click", ".set-conditions-button", function(clickEvent) {
 			let conditionName = $(clickEvent.target).parent().find("span").text();
 		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
 		  	$(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}') ~ .ct-condition-manage-pane__condition-toggle>.ddbc-toggle-field--is-disabled`).click();
+		  	$(`#switch_gamelog`).click();
+		});
+		$(".ct-sidebar__pane").on("click", ".remove-conditions-button", function(clickEvent) {
+			let conditionName = $(clickEvent.target).parent().find("span").text();
+		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
+		  	$(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}') ~ .ct-condition-manage-pane__condition-toggle>.ddbc-toggle-field--is-enabled`).click();
+		  	$(`#switch_gamelog`).click();
 		});
 		if (needs_ui) {
 			needs_ui = false;

--- a/Main.js
+++ b/Main.js
@@ -1741,15 +1741,16 @@ function init_character_page_sidebar() {
 
 		$(".ct-sidebar__pane").on("click", ".set-conditions-button", function(clickEvent) {
 			let conditionName = $(clickEvent.target).parent().find("span").text();
-		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
+		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label, .ct-combat-tablet__cta-button, .ct-combat-mobile__cta-button').click(); 	  	
 		  	$(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}') ~ .ct-condition-manage-pane__condition-toggle>.ddbc-toggle-field--is-disabled`).click();
 		  	$(`#switch_gamelog`).click();
 		});
 		$(".ct-sidebar__pane").on("click", ".remove-conditions-button", function(clickEvent) {
 			let conditionName = $(clickEvent.target).parent().find("span").text();
-		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
+		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label, .ct-combat-tablet__cta-button, .ct-combat-mobile__cta-button').click(); 	
 		  	$(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}') ~ .ct-condition-manage-pane__condition-toggle>.ddbc-toggle-field--is-enabled`).click();
 		  	$(`#switch_gamelog`).click();
+
 		});
 		if (needs_ui) {
 			needs_ui = false;

--- a/Main.js
+++ b/Main.js
@@ -1684,9 +1684,6 @@ function init_things() {
 			setTimeout(function() {
 				init_character_page_sidebar();
 				hide_sidebar();
-				$(".ct-sidebar__pane").off().on("click", "open-conditions-button", function(clickEvent) {
-				  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
-				});
 			}, 500);
 		});
 

--- a/Main.js
+++ b/Main.js
@@ -1684,15 +1684,18 @@ function init_things() {
 			setTimeout(function() {
 				init_character_page_sidebar();
 				hide_sidebar();
+				$(".ct-sidebar__pane").off().on("click", "open-conditions-button", function(clickEvent) {
+				  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
+				});
 			}, 500);
 		});
 
 	} else {
 		init_ui();
-		init_splash();
+		init_splash();on
 	}
 
-	$("#site").append("<div id='windowContainment'></div>");
+	$("#site").append("<div id='windowContainment'></div>");	            
 }
 
 /// this is used when initializing on the character page. DDB loads the page in an async modular fashion. We use this to determine if we need to call other initialization functions during this process
@@ -1739,6 +1742,15 @@ function init_character_page_sidebar() {
 		$(".ct-sidebar").css({ "right": "0px", "top": "0px", "bottom": "0px" });		
 		$(".ct-sidebar__portal .ct-sidebar .ct-sidebar__inner .ct-sidebar__controls .avtt-sidebar-controls").css("display", "flex")
 
+		$(".ct-sidebar__pane").on("click", ".open-conditions-button", function(clickEvent) {
+			debugger;
+			let conditionName = $(clickEvent.target).parent().find("span").text();
+			debugger;
+			console.log(conditionName + "!!!!!!!!!!!!!!!!!!!!!!");
+		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
+		  	console.log($(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}')`));
+		  	$(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}') ~ .ct-condition-manage-pane__condition-toggle>.ddbc-toggle-field--is-disabled`).click();
+		});
 		if (needs_ui) {
 			needs_ui = false;
 			window.PLAYER_NAME = $(".ddbc-character-name").text();

--- a/Main.js
+++ b/Main.js
@@ -1744,9 +1744,7 @@ function init_character_page_sidebar() {
 
 		$(".ct-sidebar__pane").on("click", ".open-conditions-button", function(clickEvent) {
 			let conditionName = $(clickEvent.target).parent().find("span").text();
-			console.log(conditionName + "!!!!!!!!!!!!!!!!!!!!!!");
 		  	$('.ct-combat__statuses-group--conditions .ct-combat__summary-label').click(); 
-		  	console.log($(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}')`));
 		  	$(`.ct-sidebar__pane .ct-condition-manage-pane__condition-name:contains('${conditionName}') ~ .ct-condition-manage-pane__condition-toggle>.ddbc-toggle-field--is-disabled`).click();
 		});
 		if (needs_ui) {

--- a/Token.js
+++ b/Token.js
@@ -1625,9 +1625,10 @@ function determine_hidden_classname(tokenIds) {
 		.filter(t => t !== undefined);
 	let uniqueHiddenStates = [...new Set(allHiddenStates)];
 
+	let className = "";
 	if (uniqueHiddenStates.length === 0 || (uniqueHiddenStates.length === 1 && uniqueHiddenStates[0] === false)) {
 		// none of these tokens are hidden
-		return "none-active";
+		className = "none-active";
 	} else if (uniqueHiddenStates.length === 1 && uniqueHiddenStates[0] === true) {
 		// everything we were given is hidden. If we were given a single thing, return single, else return all
 		// return tokenIds.length === 1 ? "single-active active-condition" : "all-active active-condition";

--- a/Token.js
+++ b/Token.js
@@ -103,7 +103,7 @@ class Token {
 	            window.MB.inject_chat({
 	                player: window.PLAYER_NAME,
 	                img: window.PLAYER_IMG,
-	                text: `${window.PLAYER_NAME} would like you to set <span style="font-weight: 700; display: contents;">${conditionName}</span>. You can do that in the conditions panel.<br/><br/><button class="open-conditions-button">Open Conditions Panel</button>`,
+	                text: `<span class="flex-wrap-center-chat-message">${window.PLAYER_NAME} would like you to set <span style="font-weight: 700; display: contents;">${conditionName}</span>.<br/><br/><button class="set-conditions-button">Toggle ${conditionName} ON</button></div>`,
 	                whisper: this.options.name
 	            });
 	        } else {
@@ -116,7 +116,16 @@ class Token {
 	
 	removeCondition(conditionName) {
 		if (STANDARD_CONDITIONS.includes(conditionName)) {
+			if (this.isPlayer()) {
+	            window.MB.inject_chat({
+	                player: window.PLAYER_NAME,
+	                img: window.PLAYER_IMG,
+	                text: `<span class="flex-wrap-center-chat-message">${window.PLAYER_NAME} would like you to set <span style="font-weight: 700; display: contents;">${conditionName}</span>.<br/><br/><button class="remove-conditions-button">Toggle ${conditionName} OFF</button></div>`,
+	                whisper: this.options.name
+	            });
+	        } else {
 			array_remove_index_by_value(this.options.conditions, conditionName);
+			}
 		} else {
 			array_remove_index_by_value(this.options.custom_conditions, conditionName);
 		}

--- a/Token.js
+++ b/Token.js
@@ -94,16 +94,26 @@ class Token {
 		return this.options.conditions.includes(conditionName) || this.options.custom_conditions.includes(conditionName);
 	}
 	addCondition(conditionName) {
-		if (this.hasCondition(conditionName)) {
-			// already did
-			return;
-		}
-		if (STANDARD_CONDITIONS.includes(conditionName)) {
-			this.options.conditions.push(conditionName);
-		} else {
-			this.options.custom_conditions.push(conditionName);
-		}
+	    if (this.hasCondition(conditionName)) {
+	        // already did
+	        return;
+	    }
+	    if (STANDARD_CONDITIONS.includes(conditionName)) {
+	        if (this.isPlayer()) {
+	            window.MB.inject_chat({
+	                player: window.PLAYER_NAME,
+	                img: window.PLAYER_IMG,
+	                text: `${window.PLAYER_NAME} would like you to set <span style="font-weight: 700; display: contents;">${conditionName}</span>. You can do that in the conditions panel.<br/><br/><button class="open-conditions-button">Open Conditions Panel</button>`,
+	                whisper: this.options.name
+	            });
+	        } else {
+	            this.options.conditions.push(conditionName);
+	        }
+	    } else {
+	        this.options.custom_conditions.push(conditionName);
+	    }
 	}
+	
 	removeCondition(conditionName) {
 		if (STANDARD_CONDITIONS.includes(conditionName)) {
 			array_remove_index_by_value(this.options.conditions, conditionName);
@@ -1625,10 +1635,9 @@ function determine_hidden_classname(tokenIds) {
 		.filter(t => t !== undefined);
 	let uniqueHiddenStates = [...new Set(allHiddenStates)];
 
-	let className = "";
 	if (uniqueHiddenStates.length === 0 || (uniqueHiddenStates.length === 1 && uniqueHiddenStates[0] === false)) {
 		// none of these tokens are hidden
-		className = "none-active";
+		return "none-active";
 	} else if (uniqueHiddenStates.length === 1 && uniqueHiddenStates[0] === true) {
 		// everything we were given is hidden. If we were given a single thing, return single, else return all
 		// return tokenIds.length === 1 ? "single-active active-condition" : "all-active active-condition";

--- a/Token.js
+++ b/Token.js
@@ -120,7 +120,7 @@ class Token {
 	            window.MB.inject_chat({
 	                player: window.PLAYER_NAME,
 	                img: window.PLAYER_IMG,
-	                text: `<span class="flex-wrap-center-chat-message">${window.PLAYER_NAME} would like you to set <span style="font-weight: 700; display: contents;">${conditionName}</span>.<br/><br/><button class="remove-conditions-button">Toggle ${conditionName} OFF</button></div>`,
+	                text: `<span class="flex-wrap-center-chat-message">${window.PLAYER_NAME} would like you to remove <span style="font-weight: 700; display: contents;">${conditionName}</span>.<br/><br/><button class="remove-conditions-button">Toggle ${conditionName} OFF</button></div>`,
 	                whisper: this.options.name
 	            });
 	        } else {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -824,7 +824,7 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 	});
 	if(isPlayerTokensSelected)
 	{
-		conditionsList.append($("<div id='playerTokenSelectedWarning'>A player token is selected this column of conditions must be set on the character sheet. Selecting a condition here will message the selected player.</div>"));
+		conditionsList.append($("<div id='playerTokenSelectedWarning'>A player token is selected this column of conditions must be set on the character sheet. Selecting a condition here will whisper the selected player(s).</div>"));
 	}
 
 	let markersList = $(`<ul></ul>`);

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -249,8 +249,7 @@ function token_context_menu_expanded(tokenIds, e) {
 		$(".acMenuInput").prop('disabled', true);
 		$(".hpMenuInput").prop('disabled', true);
 	}	
-	let conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Conditions / Markers</div></div>`);
-	
+	let conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Conditions / Markers</div></div>`);	
 	conditionsRow.hover(function (hoverEvent) {
 		context_menu_flyout("conditions-flyout", hoverEvent, function(flyout) {
 			flyout.append(build_conditions_and_markers_flyout_menu(tokenIds));
@@ -807,7 +806,6 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		});
 		return conditionItem;
 	};
-
 
 	let isPlayerTokensSelected = false;
 	tokens.forEach(token => {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -249,9 +249,14 @@ function token_context_menu_expanded(tokenIds, e) {
 		$(".acMenuInput").prop('disabled', true);
 		$(".hpMenuInput").prop('disabled', true);
 	}	
-
-
 	let conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Conditions / Markers</div></div>`);
+	tokens.forEach(token => {
+		if(token.isPlayer())
+		{
+			conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Markers</div></div>`);
+		}
+	});	
+	
 	conditionsRow.hover(function (hoverEvent) {
 		context_menu_flyout("conditions-flyout", hoverEvent, function(flyout) {
 			flyout.append(build_conditions_and_markers_flyout_menu(tokenIds));
@@ -774,7 +779,7 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 	let tokens = tokenIds.map(id => window.TOKEN_OBJECTS[id]).filter(t => t !== undefined);
 	let body = $("<div></div>");
 	body.css({
-		width: "380px", // once we add Markers, make this wide enough to contain them all
+		width: "fit-content", // once we add Markers, make this wide enough to contain them all
 		padding: "5px",
 		display: "flex",
 		"flex-direction": "row"
@@ -808,14 +813,24 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		return conditionItem;
 	};
 
+
+	let isPlayerTokensSelected = false;
+	tokens.forEach(token => {
+		if(token.isPlayer())
+		{
+			isPlayerTokensSelected = true;
+		}
+	});	
 	let conditionsList = $(`<ul></ul>`);
 	conditionsList.css("width", "180px");
-	body.append(conditionsList);
-	STANDARD_CONDITIONS.forEach(conditionName => {
-		let conditionItem = buildConditionItem(conditionName);
-		conditionItem.addClass("icon-condition");
-		conditionsList.append(conditionItem);
-	});
+	if(!isPlayerTokensSelected){
+		body.append(conditionsList);
+		STANDARD_CONDITIONS.forEach(conditionName => {
+			let conditionItem = buildConditionItem(conditionName);
+			conditionItem.addClass("icon-condition");
+			conditionsList.append(conditionItem);
+		});
+	}
 
 	let markersList = $(`<ul></ul>`);
 	markersList.css("width", "185px");
@@ -826,6 +841,11 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		markersList.append(conditionItem);
 
 	});
+
+	if(isPlayerTokensSelected)
+	{
+		markersList.append($("<div id='playerTokenSelectedWarning'>A player token is selected other conditions must be set on the character sheet</div>"));
+	}
 
 	let removeAllItem = $(`<li class="icon-condition icon-close-red"><span>Remove All</span></li>`);
 	removeAllItem.on("click", function () {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -201,10 +201,10 @@ function token_context_menu_expanded(tokenIds, e) {
 		});
 		body.append(combatButton);
 
-	
-		let hiddenMenuButton = $(`<button class="`+determine_hidden_classname(tokenIds) + `context-menu-icon-condition icon-invisible material-icons">Hide/Reveal Token</button>`)
 
-		hiddenMenuButton.off().on("click", function(tokenIds){
+		let hideText = tokenIds.length > 1 ? "Hide Tokens" : "Hide Token"
+		let hiddenMenuButton = $(`<button class="${determine_hidden_classname(tokenIds)} context-menu-icon-hidden icon-invisible material-icons">${hideText}</button>`)
+		hiddenMenuButton.off().on("click", function(clickEvent){
 			let clickedItem = $(this);
 			let hideAll = clickedItem.hasClass("some-active");
 			tokens.forEach(token => {
@@ -218,7 +218,6 @@ function token_context_menu_expanded(tokenIds, e) {
 			clickedItem.removeClass("single-active all-active some-active active-condition");
 			clickedItem.addClass(determine_hidden_classname(tokenIds));
 		});
-
 		body.append(hiddenMenuButton);
 	}
 	
@@ -250,14 +249,14 @@ function token_context_menu_expanded(tokenIds, e) {
 		$(".acMenuInput").prop('disabled', true);
 		$(".hpMenuInput").prop('disabled', true);
 	}	
-
-
 	let conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Conditions / Markers</div></div>`);
+	
 	conditionsRow.hover(function (hoverEvent) {
 		context_menu_flyout("conditions-flyout", hoverEvent, function(flyout) {
 			flyout.append(build_conditions_and_markers_flyout_menu(tokenIds));
 		})
 	});
+
 	body.append(conditionsRow);
 	let adjustmentsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Token Adjustments</div></div>`);
 	adjustmentsRow.hover(function (hoverEvent) {
@@ -775,7 +774,7 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 	let tokens = tokenIds.map(id => window.TOKEN_OBJECTS[id]).filter(t => t !== undefined);
 	let body = $("<div></div>");
 	body.css({
-		width: "380px", // once we add Markers, make this wide enough to contain them all
+		width: "fit-content", // once we add Markers, make this wide enough to contain them all
 		padding: "5px",
 		display: "flex",
 		"flex-direction": "row"
@@ -809,6 +808,14 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		return conditionItem;
 	};
 
+
+	let isPlayerTokensSelected = false;
+	tokens.forEach(token => {
+		if(token.isPlayer())
+		{
+			isPlayerTokensSelected = true;
+		}
+	});	
 	let conditionsList = $(`<ul></ul>`);
 	conditionsList.css("width", "180px");
 	body.append(conditionsList);
@@ -817,6 +824,10 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		conditionItem.addClass("icon-condition");
 		conditionsList.append(conditionItem);
 	});
+	if(isPlayerTokensSelected)
+	{
+		conditionsList.append($("<div id='playerTokenSelectedWarning'>A player token is selected this column of conditions must be set on the character sheet. Selecting a condition here will message the selected player.</div>"));
+	}
 
 	let markersList = $(`<ul></ul>`);
 	markersList.css("width", "185px");

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -201,10 +201,10 @@ function token_context_menu_expanded(tokenIds, e) {
 		});
 		body.append(combatButton);
 
+	
+		let hiddenMenuButton = $(`<button class="`+determine_hidden_classname(tokenIds) + `context-menu-icon-condition icon-invisible material-icons">Hide/Reveal Token</button>`)
 
-		let hideText = tokenIds.length > 1 ? "Hide Tokens" : "Hide Token"
-		let hiddenMenuButton = $(`<button class="${determine_hidden_classname(tokenIds)} context-menu-icon-hidden icon-invisible material-icons">${hideText}</button>`)
-		hiddenMenuButton.off().on("click", function(clickEvent){
+		hiddenMenuButton.off().on("click", function(tokenIds){
 			let clickedItem = $(this);
 			let hideAll = clickedItem.hasClass("some-active");
 			tokens.forEach(token => {
@@ -218,6 +218,7 @@ function token_context_menu_expanded(tokenIds, e) {
 			clickedItem.removeClass("single-active all-active some-active active-condition");
 			clickedItem.addClass(determine_hidden_classname(tokenIds));
 		});
+
 		body.append(hiddenMenuButton);
 	}
 	
@@ -249,14 +250,9 @@ function token_context_menu_expanded(tokenIds, e) {
 		$(".acMenuInput").prop('disabled', true);
 		$(".hpMenuInput").prop('disabled', true);
 	}	
+
+
 	let conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Conditions / Markers</div></div>`);
-	tokens.forEach(token => {
-		if(token.isPlayer())
-		{
-			conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Markers</div></div>`);
-		}
-	});	
-	
 	conditionsRow.hover(function (hoverEvent) {
 		context_menu_flyout("conditions-flyout", hoverEvent, function(flyout) {
 			flyout.append(build_conditions_and_markers_flyout_menu(tokenIds));
@@ -779,7 +775,7 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 	let tokens = tokenIds.map(id => window.TOKEN_OBJECTS[id]).filter(t => t !== undefined);
 	let body = $("<div></div>");
 	body.css({
-		width: "fit-content", // once we add Markers, make this wide enough to contain them all
+		width: "380px", // once we add Markers, make this wide enough to contain them all
 		padding: "5px",
 		display: "flex",
 		"flex-direction": "row"
@@ -813,24 +809,14 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		return conditionItem;
 	};
 
-
-	let isPlayerTokensSelected = false;
-	tokens.forEach(token => {
-		if(token.isPlayer())
-		{
-			isPlayerTokensSelected = true;
-		}
-	});	
 	let conditionsList = $(`<ul></ul>`);
 	conditionsList.css("width", "180px");
-	if(!isPlayerTokensSelected){
-		body.append(conditionsList);
-		STANDARD_CONDITIONS.forEach(conditionName => {
-			let conditionItem = buildConditionItem(conditionName);
-			conditionItem.addClass("icon-condition");
-			conditionsList.append(conditionItem);
-		});
-	}
+	body.append(conditionsList);
+	STANDARD_CONDITIONS.forEach(conditionName => {
+		let conditionItem = buildConditionItem(conditionName);
+		conditionItem.addClass("icon-condition");
+		conditionsList.append(conditionItem);
+	});
 
 	let markersList = $(`<ul></ul>`);
 	markersList.css("width", "185px");
@@ -841,11 +827,6 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		markersList.append(conditionItem);
 
 	});
-
-	if(isPlayerTokensSelected)
-	{
-		markersList.append($("<div id='playerTokenSelectedWarning'>A player token is selected other conditions must be set on the character sheet</div>"));
-	}
 
 	let removeAllItem = $(`<li class="icon-condition icon-close-red"><span>Remove All</span></li>`);
 	removeAllItem.on("click", function () {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -72,7 +72,8 @@ body > button:hover,
     font-family: Roboto,Helvetica,sans-serif;
     font-weight: 400;
 }
-button.gamelog-to-everyone-button {
+button.gamelog-to-everyone-button,
+button.open-conditions-button {
     background-color: rgb(255, 255, 255);
     border: 1px solid rgb(206, 217, 224);
     border-image: initial;
@@ -1444,7 +1445,8 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     padding: 0.3em !important;
 }
 
-#conditions-flyout li {
+#conditions-flyout li,
+#playerTokenSelectedWarning {
     position: relative;
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
@@ -1487,6 +1489,13 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 }
 #conditions-flyout li:hover {
     background-color: rgba(41, 128, 185) !important;
+}
+
+#playerTokenSelectedWarning
+{
+    color: #738694;
+    font-weight: 700;
+    text-transform: uppercase;
 }
 
 .icon-condition.material-icons:before,
@@ -1559,10 +1568,21 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     content: "\e148" !important;
 }
 
+.context-menu-icon-hidden {
+    border: 1px solid white;
+    justify-content: space-between;
+}
+
 .icon-condition,
 .context-menu-icon-condition {
     margin: 4px;
     border: 1px solid white;
+}
+#tokenOptionsContainer button.context-menu-icon-hidden:before {
+    width: 16px;
+    height: 16px;
+    line-height: 16px;
+    left: 10px;
 }
 .icon-condition:before,
 .context-menu-icon-condition:before {
@@ -1571,6 +1591,7 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 }
 .markers-icon:after,
 .icon-condition:after,
+.context-menu-icon-hidden:after,
 .context-menu-icon-condition:after {
     float: right;
     margin-right: 0px;
@@ -1579,19 +1600,25 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     margin-top: -5px;
     margin-bottom: -10px;
 }
+#tokenOptionsContainer button.context-menu-icon-hidden:after {
+    margin-top: -2px;
+}
 
 .markers-icon.single-active:after,
 .icon-condition.single-active:after,
+.context-menu-icon-hidden.single-active:after,
 .context-menu-icon-condition.single-active:after {
     content: "\e876";
 }
 .markers-icon.all-active:after,
 .icon-condition.all-active:after,
+.context-menu-icon-hidden.all-active:after,
 .context-menu-icon-condition.all-active:after {
     content: "\e6b1";
 }
 .markers-icon.some-active:after,
 .icon-condition.some-active:after,
+.context-menu-icon-hidden.some-active:after,
 .context-menu-icon-condition.some-active:after {
     content: "\f1c2";
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1444,7 +1444,8 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     padding: 0.3em !important;
 }
 
-#conditions-flyout li {
+#conditions-flyout li,
+#playerTokenSelectedWarning {
     position: relative;
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
@@ -1487,6 +1488,13 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 }
 #conditions-flyout li:hover {
     background-color: rgba(41, 128, 185) !important;
+}
+
+#playerTokenSelectedWarning
+{
+    color: #738694;
+    font-weight: 700;
+    text-transform: uppercase;
 }
 
 .icon-condition.material-icons:before,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -73,7 +73,8 @@ body > button:hover,
     font-weight: 400;
 }
 button.gamelog-to-everyone-button,
-button.open-conditions-button {
+button.set-conditions-button,
+button.remove-conditions-button {
     background-color: rgb(255, 255, 255);
     border: 1px solid rgb(206, 217, 224);
     border-image: initial;
@@ -89,6 +90,12 @@ button.open-conditions-button {
     color: #5c7080;
     cursor: pointer;
     float:left;
+}
+
+span.flex-wrap-center-chat-message{
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
 }
 button.gamelog-to-everyone-button:hover {
     border: 1px solid rgb(152, 160, 164);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1444,8 +1444,7 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     padding: 0.3em !important;
 }
 
-#conditions-flyout li,
-#playerTokenSelectedWarning {
+#conditions-flyout li {
     position: relative;
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
@@ -1488,13 +1487,6 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 }
 #conditions-flyout li:hover {
     background-color: rgba(41, 128, 185) !important;
-}
-
-#playerTokenSelectedWarning
-{
-    color: #738694;
-    font-weight: 700;
-    text-transform: uppercase;
 }
 
 .icon-condition.material-icons:before,
@@ -1567,21 +1559,10 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     content: "\e148" !important;
 }
 
-.context-menu-icon-hidden {
-    border: 1px solid white;
-    justify-content: space-between;
-}
-
 .icon-condition,
 .context-menu-icon-condition {
     margin: 4px;
     border: 1px solid white;
-}
-#tokenOptionsContainer button.context-menu-icon-hidden:before {
-    width: 16px;
-    height: 16px;
-    line-height: 16px;
-    left: 10px;
 }
 .icon-condition:before,
 .context-menu-icon-condition:before {
@@ -1590,7 +1571,6 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 }
 .markers-icon:after,
 .icon-condition:after,
-.context-menu-icon-hidden:after,
 .context-menu-icon-condition:after {
     float: right;
     margin-right: 0px;
@@ -1599,25 +1579,19 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     margin-top: -5px;
     margin-bottom: -10px;
 }
-#tokenOptionsContainer button.context-menu-icon-hidden:after {
-    margin-top: -2px;
-}
 
 .markers-icon.single-active:after,
 .icon-condition.single-active:after,
-.context-menu-icon-hidden.single-active:after,
 .context-menu-icon-condition.single-active:after {
     content: "\e876";
 }
 .markers-icon.all-active:after,
 .icon-condition.all-active:after,
-.context-menu-icon-hidden.all-active:after,
 .context-menu-icon-condition.all-active:after {
     content: "\e6b1";
 }
 .markers-icon.some-active:after,
 .icon-condition.some-active:after,
-.context-menu-icon-hidden.some-active:after,
 .context-menu-icon-condition.some-active:after {
     content: "\f1c2";
 }


### PR DESCRIPTION
Fixes #476 

Conditions will only show up in the context menu when no player tokens are selected.
A warning is added at the bottom of markers if a player token is selected.

![image](https://user-images.githubusercontent.com/65363489/167967464-4dc99854-1aed-4fae-97a2-382d9d90376a.png)
![image](https://user-images.githubusercontent.com/65363489/167967506-b458dd14-da24-473e-b18a-49cb8431d053.png)
