### PR TITLE
Fix: Tooltips for monster iframes.

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -515,7 +515,7 @@ function load_monster_stat(monsterid, token_id) {
 		$("#site").prepend(container);
 	}
 
-	$(iframe).on("load", function(){
+	$(iframe).on("load", function(event){
 		let tooltipCSS = $(`<style>.hovering-tooltip{ display: block !important; left: 5px !important; right: 5px !important; pointer-events: none !important; min-width: calc(100% - 10px);} </style>`);
 		$("head", $("#resizeDragMon iframe").contents()).append(tooltipCSS);
 		$(".tooltip-hover", $("#resizeDragMon iframe").contents()).on("mouseover mousemove", function(){
@@ -523,6 +523,41 @@ function load_monster_stat(monsterid, token_id) {
 		});
 		$(".tooltip-hover", $("#resizeDragMon iframe").contents()).on("mouseout", function(){
 			$("#db-tooltip-container .body .tooltip, #db-tooltip-container", $("#resizeDragMon iframe").contents()).toggleClass("hovering-tooltip", false);
+		});
+
+		// if the user right-clicks a tooltip, send it to the gamelog
+		$(event.target).contents().off("contextmenu").on("contextmenu", ".tooltip-hover", function(clickEvent) {
+			clickEvent.preventDefault();
+			clickEvent.stopPropagation();
+			
+			let toPost = $("#db-tooltip-container", $("#resizeDragMon iframe").contents()).clone();
+			debugger;
+			toPost.find(".waterdeep-tooltip").attr("style", "display:block!important");
+			toPost.find(".tooltip").attr("style", "display:block!important");
+			toPost.css({
+				"top": "0px",
+				"left": "0px",
+				"position": "relative"
+			});
+			toPost.find(".tooltip").css({
+				"max-height": "1000px",
+				"min-width": "0",
+				"max-width": "100%",
+				"width": "100%"
+			});
+			toPost.find(".tooltip-header").css({
+				"min-height": "70px",
+				"height": "auto"
+			});
+			toPost.find(".tooltip-body").css({
+				"max-height": "1000px"
+			});
+				debugger;
+			window.MB.inject_chat({
+				player: window.PLAYER_NAME,
+				img: window.PLAYER_IMG,
+				text: toPost.html()
+			});
 		});
 	});
 	

--- a/Main.js
+++ b/Main.js
@@ -518,6 +518,10 @@ function load_monster_stat(monsterid, token_id) {
 	$(iframe).on("load", function(event){
 		let tooltipCSS = $(`<style>.hovering-tooltip{ display: block !important; left: 5px !important; right: 5px !important; pointer-events: none !important; min-width: calc(100% - 10px);} </style>`);
 		$("head", $("#resizeDragMon iframe").contents()).append(tooltipCSS);
+
+		$("body", $("#resizeDragMon iframe").contents()).css('width', 'calc(100% + 670px)');
+		$("#site", $("#resizeDragMon iframe").contents()).css('padding-right', '670px');
+
 		$(".tooltip-hover", $("#resizeDragMon iframe").contents()).on("mouseover mousemove", function(){
 			$("#db-tooltip-container .body .tooltip, #db-tooltip-container", $("#resizeDragMon iframe").contents()).toggleClass("hovering-tooltip", true);	
 		});

--- a/Main.js
+++ b/Main.js
@@ -531,7 +531,6 @@ function load_monster_stat(monsterid, token_id) {
 			clickEvent.stopPropagation();
 			
 			let toPost = $("#db-tooltip-container", $("#resizeDragMon iframe").contents()).clone();
-			debugger;
 			toPost.find(".waterdeep-tooltip").attr("style", "display:block!important");
 			toPost.find(".tooltip").attr("style", "display:block!important");
 			toPost.css({
@@ -552,7 +551,6 @@ function load_monster_stat(monsterid, token_id) {
 			toPost.find(".tooltip-body").css({
 				"max-height": "1000px"
 			});
-				debugger;
 			window.MB.inject_chat({
 				player: window.PLAYER_NAME,
 				img: window.PLAYER_IMG,

--- a/Main.js
+++ b/Main.js
@@ -516,8 +516,6 @@ function load_monster_stat(monsterid, token_id) {
 	}
 
 	$(iframe).on("load", function(){
-		let iframewindow = this.contentWindow? this.contentWindow : this.contentDocument.defaultView;
-		iframewindow.CurseTips['waterdeep-tooltip'].Options.AdvancedTooltips = true;
 		let tooltipCSS = $(`<style>.hovering-tooltip{ display: block !important; left: 5px !important; right: 5px !important; pointer-events: none !important; min-width: calc(100% - 10px);} </style>`);
 		$("head", $("#resizeDragMon iframe").contents()).append(tooltipCSS);
 		$(".tooltip-hover", $("#resizeDragMon iframe").contents()).on("mouseover mousemove", function(){

--- a/Main.js
+++ b/Main.js
@@ -515,6 +515,19 @@ function load_monster_stat(monsterid, token_id) {
 		$("#site").prepend(container);
 	}
 
+	$(iframe).on("load", function(){
+		let iframewindow = this.contentWindow? this.contentWindow : this.contentDocument.defaultView;
+		iframewindow.CurseTips['waterdeep-tooltip'].Options.AdvancedTooltips = true;
+		let tooltipCSS = $(`<style>.hovering-tooltip{ display: block !important; left: 5px !important; right: 5px !important; pointer-events: none !important; min-width: calc(100% - 10px);} </style>`);
+		$("head", $("#resizeDragMon iframe").contents()).append(tooltipCSS);
+		$(".tooltip-hover", $("#resizeDragMon iframe").contents()).on("mouseover mousemove", function(){
+			$("#db-tooltip-container .body .tooltip, #db-tooltip-container", $("#resizeDragMon iframe").contents()).toggleClass("hovering-tooltip", true);	
+		});
+		$(".tooltip-hover", $("#resizeDragMon iframe").contents()).on("mouseout", function(){
+			$("#db-tooltip-container .body .tooltip, #db-tooltip-container", $("#resizeDragMon iframe").contents()).toggleClass("hovering-tooltip", false);
+		});
+	});
+	
 	/*Set draggable and resizeable on monster sheets for players. Allow dragging and resizing through iFrames by covering them to avoid mouse interaction*/
 	const monster_close_title_button=$('<div id="monster_close_title_button"><svg class="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><g transform="rotate(-45 50 50)"><rect></rect></g><g transform="rotate(45 50 50)"><rect></rect></g></svg></div>')
 	$("#resizeDragMon").append(monster_close_title_button);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -273,7 +273,7 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
     left: 271px;
     top: 67px;
     right: auto;
-    width: 410px;
+    min-width:  670px;
     height: 85%;
     position: fixed !important;
     opacity: 1;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -273,7 +273,7 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
     left: 271px;
     top: 67px;
     right: auto;
-    min-width:  670px;
+    width: 410px;
     height: 85%;
     position: fixed !important;
     opacity: 1;


### PR DESCRIPTION
First off Dndbeyond won't create tooltips on the monster page if the width of the window is <= 640. 
```
 createTooltip: function (event) {
            if (this.Disabled || !event.currentTarget.getAttribute('data-tooltip-href') || $(document).width() <= 640) {
                return false;
            }
```
The frustrating part is after they are created you can shrink the window down and they work fine. I just couldn't find a way to get it to create the stuff automatically. So if we had a way to have them created and then allow free resizing that'd be great but I couldn't figure that one out. 

I'm unsure if this is the route we want to take with the downsides but I can't think of how we'd go about different with getting the tooltips to show up in general not just in the iframe


Edit: Now fully fixes #482 

Both players and DM can send from monster stat blocks they control

![image](https://user-images.githubusercontent.com/65363489/168008063-8944c421-ee6d-4d8b-8f42-176cff566ecd.png)


