### PR TITLE
stop storing combat tracker info on the token

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -241,13 +241,7 @@ function ct_reorder(persist=true) {
 
 
 function ct_add_token(token,persist=true,disablerolling=false){
-	// TODO: check if the token is already in the tracker..
-	
-	
-	token.options.combat = true;
-	//token.sync();
-	if (token.persist != null) token.persist();
-	
+
 	selector="#combat_area tr[data-target='"+token.options.id+"']";
 	if($(selector).length>0)
 		return;
@@ -415,6 +409,14 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	}
 }
 
+function ct_list_tokens() {
+	let tokenIds = [];
+	$('#combat_area tr').each(function () {
+		tokenIds.push($(this).attr("data-target"));
+	})
+	return tokenIds;
+}
+
 function ct_persist(){
 	var data= [];
 	$('#combat_area tr').each( function () {
@@ -477,7 +479,6 @@ function ct_load(data=null){
 
 function ct_remove_token(token,persist=true) {
 
-	token.options.combat = false;
 	if (persist == true) {
 		token.sync();
 		if (token.persist != null) token.persist();

--- a/Token.js
+++ b/Token.js
@@ -111,6 +111,9 @@ class Token {
 			array_remove_index_by_value(this.options.custom_conditions, conditionName);
 		}
 	}
+	isInCombatTracker() {
+		return ct_list_tokens().includes(this.options.id);
+	}
 
 	size(newsize) {
 		this.update_from_page();
@@ -2100,10 +2103,6 @@ function undo_delete_tokens() {
 	for (id in window.TOKEN_OBJECTS_RECENTLY_DELETED) {
 		let options = window.TOKEN_OBJECTS_RECENTLY_DELETED[id];
 		window.ScenesHandler.create_update_token(options);
-		if (options.combat) {
-			// the deleted token was removed from the combat tracker so add it back in
-			ct_add_token(window.TOKEN_OBJECTS[id]);
-		}
 	}
 	window.TOKEN_OBJECTS_RECENTLY_DELETED = {};
 }

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -176,7 +176,7 @@ function token_context_menu_expanded(tokenIds, e) {
 		let addButtonInternals = `Add to Combat Tracker<span class="material-icons icon-person-add"></span>`;
 		let removeButtonInternals = `Remove From Combat Tracker<span class="material-icons icon-person-remove"></span>`;
 		let combatButton = $(`<button></button>`);
-		let inCombatStatuses = [...new Set(tokens.map(t => t.options.combat))];
+		let inCombatStatuses = [...new Set(tokens.map(t => t.isInCombatTracker()))];
 		if (inCombatStatuses.length === 1 && inCombatStatuses[0] === true) {
 			// they are all in the combat tracker. Make it a remove button
 			combatButton.addClass("remove-from-ct");


### PR DESCRIPTION
Closes #487 


* This adds a `ct_list_tokens` function that collects and returns the tokenIds that are in the combat tracker. 
* It also adds a convenience function `token.isInCombatTracker()` to easily determine if a given token is in the combat tracker.
* All references to `token.options.combat` has been removed