### PR TITLE
Fix: When a hidden token is added to combat it should now properly always default to being hidden in the combat tracker.

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -343,7 +343,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			function(){
 				token.options.ct_show = undefined;
 				ct_remove_token(token);
-				ct_persist();
 			}
 		);
 		if(window.DM)
@@ -429,7 +428,8 @@ function ct_persist(){
 	  data.push( {
 		'data-target': $(this).attr("data-target"),
 		'init': $(this).find(".init").val(),
-		'current': ($(this).attr("data-current")=="1")
+		'current': ($(this).attr("data-current")=="1"),
+		'data-ct-show': window.TOKEN_OBJECTS[$(this).attr("data-target")].options.ct_show
 	   });
 	});
 	data.push({'data-target': 'round',
@@ -458,6 +458,8 @@ function ct_load(data=null){
 				let token;
 				if(data[i]['data-target'] in window.TOKEN_OBJECTS){
 					token=window.TOKEN_OBJECTS[data[i]['data-target']];
+					token.options.ct_show = data[i]['data-ct-show'];
+					debugger;
 				}
 				else{
 					token={
@@ -486,7 +488,7 @@ function ct_load(data=null){
 function ct_remove_token(token,persist=true) {
 
 	if (persist == true) {
-		token.sync();
+		token.sync()
 		if (token.persist != null) token.persist();
 	}
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -253,14 +253,14 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	entry.attr("ishidden", token.options.hidden);
 	entry.addClass("CTToken");
 	
-
-	if(token.options.hidden) {
-		token.options.ct_show = false;
+	if (typeof(token.options.ct_show) == 'undefined'){
+		if(token.options.hidden) {
+			token.options.ct_show = false;
+		}
+		else {
+			token.options.ct_show = true;
+		}	
 	}
-	else {
-		token.options.ct_show = true;
-	}	
-
 
 	if (token.options.ct_show == true || window.DM){
 		if ((token.options.name) && (window.DM || !token.options.monster || token.options.revealname)) {
@@ -341,6 +341,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		del=$('<button class="removeTokenCombatButton" style="font-size:10px;"><svg class="delSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg></button>');
 		del.click(
 			function(){
+				token.options.ct_show = 'undefined';
 				ct_remove_token(token);
 				ct_persist();
 			}

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -253,9 +253,14 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	entry.attr("ishidden", token.options.hidden);
 	entry.addClass("CTToken");
 	
-	if (typeof(token.options.ct_show) == 'undefined'){
-		token.options.ct_show = true;
+
+	if(token.options.hidden) {
+		token.options.ct_show = false;
 	}
+	else {
+		token.options.ct_show = true;
+	}	
+
 
 	if (token.options.ct_show == true || window.DM){
 		if ((token.options.name) && (window.DM || !token.options.monster || token.options.revealname)) {

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -341,7 +341,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		del=$('<button class="removeTokenCombatButton" style="font-size:10px;"><svg class="delSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg></button>');
 		del.click(
 			function(){
-				token.options.ct_show = 'undefined';
+				token.options.ct_show = undefined;
 				ct_remove_token(token);
 				ct_persist();
 			}

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -459,7 +459,6 @@ function ct_load(data=null){
 				if(data[i]['data-target'] in window.TOKEN_OBJECTS){
 					token=window.TOKEN_OBJECTS[data[i]['data-target']];
 					token.options.ct_show = data[i]['data-ct-show'];
-					debugger;
 				}
 				else{
 					token={
@@ -488,7 +487,7 @@ function ct_load(data=null){
 function ct_remove_token(token,persist=true) {
 
 	if (persist == true) {
-		token.sync()
+		token.sync();
 		if (token.persist != null) token.persist();
 	}
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -191,7 +191,10 @@ function token_context_menu_expanded(tokenIds, e) {
 			if (clickedButton.hasClass("remove-from-ct")) {
 				clickedButton.removeClass("remove-from-ct").addClass("add-to-ct");
 				clickedButton.html(addButtonInternals);
-				tokens.forEach(t => ct_remove_token(t, false));
+				tokens.forEach(t =>{
+					t.options.ct_show = undefined;
+					ct_remove_token(t, false)
+				});
 			} else {
 				clickedButton.removeClass("add-to-ct").addClass("remove-from-ct");
 				clickedButton.html(removeButtonInternals);


### PR DESCRIPTION
Fixes #496 

This will always add hidden tokens as hidden from players in the combat tracker. 