### PR TITLE
Fix: grid toggles will no longer always show as on

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -278,7 +278,18 @@ function edit_scene_dialog(scene_id) {
 						form_toggle("dm_map_usable",null, false, handle_basic_form_toggle_click)
 						)
 				);
-	form.append(form_row(null, 'Snap to Grid',form_toggle("snap",null, true, handle_basic_form_toggle_click)))
+	form.append(form_row(null, 'Snap to Grid',form_toggle("snap", null, false, function(event) {
+		if ($(event.currentTarget).hasClass("rc-switch-checked")) {
+			// it was checked. now it is no longer checked
+			$(event.currentTarget).removeClass("rc-switch-checked");
+			window.CURRENT_SCENE_DATA.snap = "0";		
+		} else {
+			// it was not checked. now it is checked
+			$(event.currentTarget).removeClass("rc-switch-unknown");
+			$(event.currentTarget).addClass("rc-switch-checked");
+			window.CURRENT_SCENE_DATA.snap = "1";
+		}
+	})));
 
 
 	const showGridControls = $("<div id='show_grid_controls'/>");
@@ -288,7 +299,7 @@ function edit_scene_dialog(scene_id) {
 		type="range" min="0.5" max="10" step="0.5" value="${scene["grid_line_width"] || 0.5}">`)
 	gridStroke.on("change input", handle_form_grid_on_change)
 	showGridControls.append(
-		form_toggle("grid", null, true, function(event) {
+		form_toggle("grid", null, false, function(event) {
 			if ($(event.currentTarget).hasClass("rc-switch-checked")) {
 				// it was checked. now it is no longer checked
 				$(event.currentTarget).removeClass("rc-switch-checked");


### PR DESCRIPTION
Fixes #499

Grid toggles for scenes no longer will always show as on. This also adds the grid toggle setting to apply automatically to the DM view when toggled.

This does not fix the player view needing to be refreshed to take effect. Although the DM can just click players again to force a refresh it is not great for potatos. That can be a separate fix as that issue already existed.