### PR TITLE
Move Scenes list to sidebar

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -104,6 +104,10 @@ Mousetrap.bind('esc', function () {     //deselect all buttons
     $('#select-button').click();
     $("#tokenOptionsClickCloseDiv").click();
     $(".draggable-token-creation").addClass("drag-cancelled");
+    $(".draggable-sidebar-item-reorder").addClass("drag-cancelled");
+    try {
+        $( '.ui-draggable-dragging' ).draggable("option", { revert: true }).trigger( 'mouseup' ).draggable("option", {revert: false })
+    } catch (whoCares) { }
 });
 
 

--- a/Main.js
+++ b/Main.js
@@ -691,6 +691,20 @@ function init_controls() {
 		b2ImageDivWrapper.append(b2ImageDiv);
 		b2.append(b2ImageDivWrapper);
 		sidebarControls.append(b2);
+
+		if (window.CLOUD) {
+			let b3 = $("<div id='switch_scenes' class='tab-btn hasTooltip button-icon blue-tab' data-name='Scenes' data-target='#scenes-panel'></div>").click(switch_control);
+			let b3ImageDiv = $('<div></div>');
+			let b3ImageDivWrapper = $('<div class="sidebar-tab-image" style="width:100%;height:100%;"></div>');
+			let b3Image = `${window.EXTENSION_PATH}assets/icons/photo.svg`;
+			b3ImageDiv.css({
+				"mask": `url(${b3Image}) no-repeat center / contain`,
+				"-webkit-mask": `url(${b3Image}) no-repeat center / contain`
+			});
+			b3ImageDivWrapper.append(b3ImageDiv);
+			b3.append(b3ImageDivWrapper);
+			sidebarControls.append(b3);
+		}
 	} else {
 		let b2 = $("<div id='switch_characters' class='tab-btn hasTooltip button-icon blue-tab' data-name='Players' data-target='#players-panel'></div>").click(switch_control);
 		let b2ImageDiv = $('<div></div>');

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -420,6 +420,7 @@ class MessageBroker {
 					window.ScenesHandler.scenes=msg.data;
 					window.PLAYER_SCENE_ID=msg.playersSceneId;
 					refresh_scenes();
+					did_update_scenes();
 				}
 			}
 
@@ -855,7 +856,7 @@ class MessageBroker {
 			// This is used when the "Send to Gamelog" button sends HTML over the websocket.
 			// If there are special characters, then the _dndbeyond_message_broker_client fails to parse the JSON
 			// To work around this, we base64 encode the html here, and then decode it in MessageBroker.convertChat
-			return "base64" + window.btoa(unescape(encodeURIComponent(text)));
+			return "base64" + b64EncodeUnicode(text);
 		} else {
 			console.warn("There's at least one connection below version 0.66; not encoding message text to prevent that user from seeing base64 encoded text in the gamelog");
 			return text;
@@ -868,7 +869,7 @@ class MessageBroker {
 			// This is used when the "Send to Gamelog" button sends HTML over the websocket.
 			// If there are special characters, then the _dndbeyond_message_broker_client fails to parse the JSON
 			// To work around this, we base64 encode the html in encode_message_text, and then decode it here after the message has been received
-			text = decodeURIComponent(escape(window.atob(text.replace("base64", ""))));
+			text = b64DecodeUnicode(text.replace("base64", ""));
 		}
 		return text;
 	}
@@ -1059,6 +1060,7 @@ class MessageBroker {
 			if (window.EncounterHandler !== undefined) {
 				fetch_and_cache_scene_monster_items(true);
 			}
+			did_update_scenes();
 			console.groupEnd()
 		});
 

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -596,6 +596,13 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		window.MB.sendMessage("custom/myVTT/update_scene",sceneData,dontswitch);
 	}
 
+	delete_scene(sceneId) { // not the index, but the actual id
+		if(!window.CLOUD) return;
+		window.MB.sendMessage("custom/myVTT/delete_scene",{ id: sceneId });
+		let sceneIndex = window.ScenesHandler.scenes.findIndex(s => s.id === sceneId);
+		window.ScenesHandler.scenes.splice(sceneIndex, 1);
+	}
+
 	persist() {
 		if(window.CLOUD)
 			return;

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -11,6 +11,14 @@ function init_sidebar_tabs() {
     tokensPanel = new SidebarPanel("tokens-panel", false);
     sidebarContent.append(tokensPanel.build());
     init_tokens_panel();
+
+    if (window.CLOUD) {
+      $("#scenes-panel").remove();
+      scenesPanel = new SidebarPanel("scenes-panel", false);
+      sidebarContent.append(scenesPanel.build());
+      init_scenes_panel();
+    }
+
   } else {
     $("#players-panel").remove();
     playersPanel = new SidebarPanel("players-panel", false);
@@ -332,12 +340,14 @@ function build_toggle_input(name, labelText, enabled, enabledHoverText, disabled
  */
 class SidebarListItem {
 
+  // the types of items that are supported
   static TypeFolder = "folder";
   static TypeMyToken = "myToken";
   static TypePC = "pc";
   static TypeMonster = "monster";
   static TypeBuiltinToken = "builtinToken";
   static TypeEncounter = "encounter";
+  static TypeScene = "scene";
 
   static PathRoot = "/";
   static PathPlayers = "/Players";
@@ -345,7 +355,9 @@ class SidebarListItem {
   static PathMyTokens = "/My Tokens";
   static PathAboveVTT = "/AboveVTT Tokens";
   static PathEncounters = "/Encounters";
+  static PathScenes = "/Scenes";
 
+  // folder names within the tokens panel
   static NamePlayers = "Players";
   static NameMonsters = "Monsters";
   static NameMyTokens = "My Tokens";
@@ -454,6 +466,19 @@ class SidebarListItem {
     return item;
   }
 
+  static Scene(sceneData) {
+    let name = "Untitled Scene";
+    if ((typeof sceneData.title == 'string') && sceneData.title.length > 0) {
+      name = sceneData.title;
+    }
+    let scenePath = sceneData.folderPath || "";
+    let item = new SidebarListItem(name, sceneData.player_map, SidebarListItem.TypeScene, sanitize_folder_path(`${SidebarListItem.PathScenes}/${scenePath}`));
+    console.debug(`SidebarListItem.Scene ${item.fullPath()}`);
+    item.sceneId = sceneData.id;
+    item.isVideo = sceneData.player_map_is_video == "1"; // explicity using `==` instead of `===` in case it's ever `1` or `"1"`
+    return item;
+  }
+
   /**
    * A comparator for sorting by folder, then alphabetically.
    * @param lhs {SidebarListItem}
@@ -505,8 +530,11 @@ class SidebarListItem {
   /** @returns {boolean} whether or not this item represents a Builtin Token */
   isTypeBuiltinToken() { return this.type === SidebarListItem.TypeBuiltinToken }
 
-  /** @returns {boolean} whether or not this item represents an encounter */
+  /** @returns {boolean} whether or not this item represents an Encounter */
   isTypeEncounter() { return this.type === SidebarListItem.TypeEncounter }
+
+  /** @returns {boolean} whether or not this item represents a Scene */
+  isTypeScene() { return this.type === SidebarListItem.TypeScene }
 
   /** @returns {boolean} whether or not this item is listed in the tokens panel */
   isTokensPanelItem() {
@@ -524,11 +552,12 @@ class SidebarListItem {
   canEdit() {
     switch (this.type) {
       case SidebarListItem.TypeFolder:
-        return this.folderPath.startsWith(SidebarListItem.PathMyTokens);
+        return this.folderPath.startsWith(SidebarListItem.PathMyTokens) || this.folderPath.startsWith(SidebarListItem.PathScenes);
       case SidebarListItem.TypeMyToken:
       case SidebarListItem.TypePC:
       case SidebarListItem.TypeMonster:
       case SidebarListItem.TypeEncounter:
+      case SidebarListItem.TypeScene:
         return true;
       case SidebarListItem.TypeBuiltinToken:
       default:
@@ -540,8 +569,10 @@ class SidebarListItem {
   canDelete() {
     switch (this.type) {
       case SidebarListItem.TypeFolder:
-        return this.folderPath.startsWith(SidebarListItem.PathMyTokens);
+        // TODO: allow deleting scenes folders
+        return this.folderPath.startsWith(SidebarListItem.PathMyTokens) || this.folderPath.startsWith(SidebarListItem.PathScenes);
       case SidebarListItem.TypeMyToken:
+      case SidebarListItem.TypeScene:
         return true;
       case SidebarListItem.TypePC:
       case SidebarListItem.TypeMonster:
@@ -556,6 +587,10 @@ class SidebarListItem {
   folderDepth() {
     return this.fullPath().split("/").length;
   }
+  isRootFolder() {
+    // "/foo".split("/").length === 2; if the logic in folderDepth() changes, make sure this changes, too
+    return this.folderDepth() === 2;
+  }
 
   /** @returns {string} the name of the folder that contains this item. Returns an empty string if the item is not in any folder */
   containingFolderName() {
@@ -565,6 +600,13 @@ class SidebarListItem {
     }
     return folderParts[folderParts.length - 1];
   }
+
+
+  /** @returns {boolean} true if the name partially matches the searchTerm or if the containing folder name partially matches the searchTerm */
+  nameOrContainingFolderMatches(searchTerm) {
+    return this.name.toLowerCase().includes(searchTerm.toLowerCase()) // any item with a partially matching name
+    || this.containingFolderName().toLowerCase().includes(searchTerm.toLowerCase()) // all items within a folder with a partially matching name
+  }
 }
 
 /**
@@ -572,6 +614,9 @@ class SidebarListItem {
  * @returns {string} the sanitized path
  */
 function sanitize_folder_path(dirtyPath) {
+  if (dirtyPath === undefined) {
+    return SidebarListItem.PathRoot;
+  }
   let cleanPath = dirtyPath.replaceAll("///", "/").replaceAll("//", "/");
   // remove trailing slashes before adding one at the beginning. Otherwise, we return an empty string
   if (cleanPath.endsWith("/")) {
@@ -594,7 +639,15 @@ function find_sidebar_list_item(html) {
 
   let encounterId = html.attr("data-encounter-id");
   if (encounterId !== undefined && encounterId !== null && encounterId !== "") {
-    let foundItem = window.tokenListItems.find(item => item.isTypeEncounter() && item.encounterId === encounterId);
+    foundItem = window.tokenListItems.find(item => item.isTypeEncounter() && item.encounterId === encounterId);
+    if (foundItem !== undefined) {
+      return foundItem;
+    }
+  }
+
+  let sceneId = html.attr("data-scene-id")
+  if (typeof sceneId === "string" && sceneId.length > 0) {
+    foundItem = window.sceneListItems.find(item => item.sceneId == sceneId);
     if (foundItem !== undefined) {
       return foundItem;
     }
@@ -604,10 +657,11 @@ function find_sidebar_list_item(html) {
   if (html.attr("data-monster") !== undefined) {
     // explicitly using '==' instead of '===' to allow (33253 == '33253') to return true
     foundItem = window.monsterListItems.find(item => item.monsterData.id == html.attr("data-monster"));
+    if (foundItem !== undefined) {
+      return foundItem;
+    }
   }
-  if (foundItem !== undefined) {
-    return foundItem;
-  }
+
   return find_sidebar_list_item_from_path(fullPath);
 }
 
@@ -616,15 +670,30 @@ function find_sidebar_list_item(html) {
  * @returns {SidebarListItem|undefined} SidebarListItem if found, else undefined
  */
 function find_sidebar_list_item_from_path(fullPath) {
-  let foundItem = tokens_rootfolders.find(item => item.fullPath() === fullPath);
+
+  const matchingPath = function(item) { return item.fullPath() === fullPath };
+
+  let foundItem;
+  if (fullPath.startsWith(SidebarListItem.PathScenes)) {
+    foundItem = window.sceneListItems.find(matchingPath);
+    if (foundItem === undefined) {
+      foundItem = window.sceneListFolders.find(matchingPath);
+    }
+    if (foundItem !== undefined) {
+      return foundItem;
+    }
+  }
+
+  // check all the tokens items
+  foundItem = tokens_rootfolders.find(matchingPath);
   if (foundItem === undefined) {
-    foundItem = window.tokenListItems.find(item => item.fullPath() === fullPath);
+    foundItem = window.tokenListItems.find(matchingPath);
   }
   if (foundItem === undefined) {
-    foundItem = window.monsterListItems.find(item => item.fullPath() === fullPath);
+    foundItem = window.monsterListItems.find(matchingPath);
   }
   if (foundItem === undefined) {
-    foundItem = Object.values(cached_monster_items).find(item => item.fullPath() === fullPath);
+    foundItem = Object.values(cached_monster_items).find(matchingPath);
   }
   if (foundItem === undefined) {
     console.warn(`find_sidebar_list_item found nothing at path: ${fullPath}`);
@@ -690,7 +759,7 @@ function encode_full_path(fullPath) {
       // already encoded. just return it
       return fullPath;
     }
-    return `base64${btoa(fullPath)}`;
+    return `base64${b64EncodeUnicode(fullPath)}`;
   } catch (e) {
     console.error("encode_full_path failed", fullPath, e);
     return "";
@@ -706,7 +775,7 @@ function decode_full_path(fullPath) {
   try {
     if (fullPath === undefined) return "";
     if (fullPath.startsWith("base64")) {
-      return atob(fullPath.replace("base64", ""));
+      return b64DecodeUnicode(fullPath.replace("base64", ""));
     }
     // no need to decode
     return fullPath;
@@ -733,26 +802,26 @@ function matches_full_path(html, fullPath) {
  */
 function build_sidebar_list_row(listItem) {
 
-  let row = $(`<div class="tokens-panel-row" title="${listItem.name}"></div>`);
+  let row = $(`<div class="sidebar-list-item-row" title="${listItem.name}"></div>`);
   set_full_path(row, listItem.fullPath());
 
-  let rowItem = $(`<div class="tokens-panel-row-item"></div>`);
+  let rowItem = $(`<div class="sidebar-list-item-row-item"></div>`);
   row.append(rowItem);
   rowItem.on("click", did_click_row);
 
-  let imgHolder = $(`<div class="tokens-panel-row-img"></div>`);
+  let imgHolder = $(`<div class="sidebar-list-item-row-img"></div>`);
   rowItem.append(imgHolder);
   let img = $(`<img src="${parse_img(listItem.image)}" alt="${listItem.name} image" class="token-image" />`);
   imgHolder.append(img);
 
-  let details = $(`<div class="tokens-panel-row-details"></div>`);
+  let details = $(`<div class="sidebar-list-item-row-details"></div>`);
   rowItem.append(details);
-  let title = $(`<div class="tokens-panel-row-details-title">${listItem.name}</div>`);
+  let title = $(`<div class="sidebar-list-item-row-details-title">${listItem.name}</div>`);
   details.append(title);
-  let subtitle = $(`<div class="tokens-panel-row-details-subtitle"></div>`);
+  let subtitle = $(`<div class="sidebar-list-item-row-details-subtitle"></div>`);
   details.append(subtitle);
 
-  if (!listItem.isTypeFolder()) {
+  if (!listItem.isTypeFolder() && !listItem.isTypeScene()) {
     let addButton = $(`
         <button class="token-row-button token-row-add" title="Add Token to Scene">
             <svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.2 10.8V18h3.6v-7.2H18V7.2h-7.2V0H7.2v7.2H0v3.6h7.2z"></path></svg>
@@ -766,7 +835,7 @@ function build_sidebar_list_row(listItem) {
     case SidebarListItem.TypeEncounter: // explicitly allowing encounter to fall through because we want them to be treated like folders
     case SidebarListItem.TypeFolder:
       subtitle.hide();
-      row.append(`<div class="folder-token-list"></div>`);
+      row.append(`<div class="folder-item-list"></div>`);
       row.addClass("folder");
       console.log(`folder.collapsed: ${listItem.collapsed}`, listItem);
       if (listItem.collapsed === true) {
@@ -776,7 +845,7 @@ function build_sidebar_list_row(listItem) {
         // add buttons for creating subfolders and tokens
         let addFolder = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
         rowItem.append(addFolder);
-        addFolder.on("click", function(clickEvent) {
+        addFolder.on("click", function (clickEvent) {
           clickEvent.stopPropagation();
           let clickedRow = $(clickEvent.target).closest(".list-item-identifier");
           let clickedItem = find_sidebar_list_item(clickedRow);
@@ -784,10 +853,39 @@ function build_sidebar_list_row(listItem) {
         });
         let addToken = $(`<button class="token-row-button" title="Create New Token"><span class="material-icons">person_add_alt_1</span></button>`);
         rowItem.append(addToken);
-        addToken.on("click", function(clickEvent) {
+        addToken.on("click", function (clickEvent) {
           let clickedRow = $(clickEvent.target).closest(".list-item-identifier");
           let clickedItem = find_sidebar_list_item(clickedRow);
           create_token_inside(clickedItem);
+        });
+        if (listItem.isRootFolder()) {
+          let reorderButton = $(`<button class="token-row-button reorder-button" title="Reorder Scenes"><span class="material-icons">reorder</span></button>`);
+          rowItem.append(reorderButton);
+          reorderButton.on("click", function (clickEvent) {
+            clickEvent.stopPropagation();
+            if ($(clickEvent.currentTarget).hasClass("active")) {
+              disable_draggable_change_folder(SidebarListItem.TypeMyToken);
+            } else {
+              enable_draggable_change_folder(SidebarListItem.TypeMyToken);
+            }
+          });
+        }
+      } else if (listItem.fullPath().startsWith(SidebarListItem.PathScenes)) {
+        // add buttons for creating subfolders and scenes
+        let addFolder = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
+        rowItem.append(addFolder);
+        addFolder.on("click", function (clickEvent) {
+          clickEvent.stopPropagation();
+          let clickedRow = $(clickEvent.target).closest(".list-item-identifier");
+          let clickedItem = find_sidebar_list_item(clickedRow);
+          create_folder_inside(clickedItem);
+        });
+        let addScene = $(`<button class="token-row-button" title="Create New Scene"><span class="material-icons">add_photo_alternate</span></button>`);
+        rowItem.append(addScene);
+        addScene.on("click", function (clickEvent) {
+          let clickedRow = $(clickEvent.target).closest(".list-item-identifier");
+          let clickedItem = find_sidebar_list_item(clickedRow);
+          create_scene_inside(clickedItem.fullPath());
         });
       } else if (listItem.fullPath() === SidebarListItem.PathMonsters) {
         // add monster filter button on the root monsters folder
@@ -850,7 +948,7 @@ function build_sidebar_list_row(listItem) {
       row.append(expandButton);
       expandButton.on("click", function (clickEvent) {
         clickEvent.stopPropagation();
-        let r = $(clickEvent.target).closest(".tokens-panel-row");
+        let r = $(clickEvent.target).closest(".sidebar-list-item-row");
         console.log(r);
         if (r.hasClass("expanded")) {
           r.removeClass("expanded");
@@ -901,6 +999,10 @@ function build_sidebar_list_row(listItem) {
         subtitle.append(`<div class="subtitle-attibute"><span class="material-icons" style="color:darkred">block</span>No Access</div>`);
       }
 
+      if (listItem.monsterData.isLegacy === true) {
+        subtitle.append(`<div class="legacy-monster"><span>Legacy</span></div>`);
+      }
+
       if ((typeof listItem.monsterData.quantity == "number") && listItem.monsterData.quantity > 1 && title.find(".monster-quantity").length === 0) {
         title.prepend(`
             <div class="monster-quantity">
@@ -915,6 +1017,47 @@ function build_sidebar_list_row(listItem) {
       subtitle.hide();
       // TODO: Style specifically for Builtin
       row.css("cursor", "default");
+      break;
+    case SidebarListItem.TypeScene:
+      row.attr("data-scene-id", listItem.sceneId);
+      row.addClass("scene-item");
+      if (listItem.isVideo) {
+        imgHolder.html(`<span class="material-icons scene-list-item-is-video">play_circle_outline</span>`);
+      } else {
+        imgHolder.hover(function (hoverEvent) {
+          sidebar_flyout(hoverEvent, function(flyout) {
+            let imgsrc = $(hoverEvent.currentTarget).find("img").attr("src")
+            flyout.append(`<img class='list-item-image-flyout' src="${imgsrc}" alt="scene map preview" />`);
+          });
+        });
+      }
+      let switch_dm = $(`<button class='dm_scenes_button token-row-button' title="Move DM To This Scene"></button>`);
+      switch_dm.append(svg_dm());
+      if(window.CURRENT_SCENE_DATA && window.CURRENT_SCENE_DATA.id === listItem.sceneId){
+        switch_dm.addClass("selected-scene");
+      }
+      switch_dm.on("click", function(clickEvent) {
+        clickEvent.stopPropagation();
+        $("#scenes-panel .dm_scenes_button.selected-scene").removeClass("selected-scene");
+        $(clickEvent.currentTarget).addClass("selected-scene");
+        window.MB.sendMessage("custom/myVTT/switch_scene", { sceneId: listItem.sceneId, switch_dm: true });
+        add_zoom_to_storage();
+      });
+      let switch_players = $(`<button class='player_scenes_button token-row-button' title="Move Players To This Scene"></button>`);
+      switch_players.append(svg_everyone());
+      if(window.PLAYER_SCENE_ID === listItem.sceneId){
+        switch_players.addClass("selected-scene");
+      }
+      switch_players.on("click", function(clickEvent) {
+        clickEvent.stopPropagation();
+        window.PLAYER_SCENE_ID = listItem.sceneId;
+        $("#scenes-panel .player_scenes_button.selected-scene").removeClass("selected-scene");
+        $(clickEvent.currentTarget).addClass("selected-scene");
+        window.MB.sendMessage("custom/myVTT/switch_scene", { sceneId: listItem.sceneId });
+        add_zoom_to_storage()
+      });
+      rowItem.append(switch_dm);
+      rowItem.append(switch_players);
       break;
   }
 
@@ -937,6 +1080,7 @@ function build_sidebar_list_row(listItem) {
  * @param clickEvent {Event} the click event
  */
 function did_click_row(clickEvent) {
+  clickEvent.stopPropagation();
   console.log("did_click_row", clickEvent);
   let clickedRow = $(clickEvent.target).closest(".list-item-identifier");
   let clickedItem = find_sidebar_list_item(clickedRow);
@@ -968,7 +1112,7 @@ function did_click_row(clickEvent) {
       }
       break;
     case SidebarListItem.TypeMyToken:
-      // display_token_item_configuration_modal(clickedItem);
+      // display_sidebar_list_item_configuration_modal(clickedItem);
       break;
     case SidebarListItem.TypePC:
       open_player_sheet(clickedItem.sheet);
@@ -985,6 +1129,9 @@ function did_click_row(clickEvent) {
     case SidebarListItem.TypeBuiltinToken:
       // display_builtin_token_details_modal(clickedItem);
       break;
+    case SidebarListItem.TypeScene:
+      // nothing to do here.
+      break;
   }
 }
 
@@ -999,7 +1146,7 @@ function did_click_row_gear(clickEvent) {
   let clickedRow = $(clickEvent.target).closest(".list-item-identifier");
   let clickedItem = find_sidebar_list_item(clickedRow);
   console.log("did_click_row_gear", clickedItem);
-  display_token_item_configuration_modal(clickedItem);
+  display_sidebar_list_item_configuration_modal(clickedItem);
 }
 
 /**
@@ -1019,6 +1166,61 @@ function did_click_add_button(clickEvent) {
 }
 
 /**
+ * Displays a SidebarPanel as a modal that allows the user to configure the given listItem
+ * @param listItem {SidebarListItem} the item to configure
+ */
+function display_sidebar_list_item_configuration_modal(listItem) {
+  switch (listItem?.type) {
+    case SidebarListItem.TypeEncounter:
+      // TODO: support editing in an iframe on the page?
+      window.open(`https://www.dndbeyond.com/encounters/${listItem.encounterId}/edit`, '_blank');
+      break;
+    case SidebarListItem.TypeFolder:
+      if (listItem.folderPath.startsWith(SidebarListItem.PathMyTokens) || listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+        display_folder_configure_modal(listItem);
+      } else {
+        console.warn("Only allowed to folders within the My Tokens folder and Scenes");
+        return;
+      }
+      break;
+    case SidebarListItem.TypeBuiltinToken:
+      display_builtin_token_details_modal(listItem);
+      break;
+    case SidebarListItem.TypeMyToken:
+    case SidebarListItem.TypePC:
+    case SidebarListItem.TypeMonster:
+      display_token_configuration_modal(listItem);
+      break;
+    case SidebarListItem.TypeScene:
+      let index = window.ScenesHandler.scenes.findIndex(s => s.id === listItem.sceneId);
+      if (index >= 0) {
+        edit_scene_dialog(index);
+      } else {
+        console.error("Failed to find scene index for scene with id", listItem.sceneId);
+        alert("An unexpected error occurred");
+      }
+      break;
+    default:
+      console.warn("display_sidebar_list_item_configuration_modal not supported for listItem", listItem);
+  }
+}
+
+function create_folder_inside(listItem) {
+  if (!listItem.isTypeFolder()) {
+    console.warn("create_folder_inside called with an incorrect item type", listItem);
+    return;
+  }
+
+  if (listItem.fullPath().startsWith(SidebarListItem.PathMyTokens)) {
+    create_mytoken_folder_inside(listItem);
+  } else if (listItem.fullPath().startsWith(SidebarListItem.PathScenes)) {
+    create_scene_folder_inside(listItem.fullPath());
+  } else {
+    console.warn("create_folder_inside called with an incorrect item type", listItem);
+  }
+}
+
+/**
  * Displays a SidebarPanel as a modal that allows the user to configure a folder
  * @param listItem {SidebarListItem} the item to configure
  */
@@ -1031,6 +1233,12 @@ function display_folder_configure_modal(listItem) {
   let sidebarId = "folder-configuration-modal";
   let sidebarModal = new SidebarPanel(sidebarId, true);
   let listItemFullPath = listItem.fullPath();
+  let container;
+  if (listItemFullPath.startsWith(SidebarListItem.PathScenes)) {
+    container = scenesPanel.body;
+  } else {
+    container = tokensPanel.body;
+  }
 
   display_sidebar_modal(sidebarModal);
 
@@ -1048,7 +1256,7 @@ function display_folder_configure_modal(listItem) {
           $(input).select();
         } else {
           close_sidebar_modal();
-          expand_all_folders_up_to(updateFullPath);
+          expand_all_folders_up_to(updateFullPath, container);
         }
       }
   ));
@@ -1061,7 +1269,7 @@ function display_folder_configure_modal(listItem) {
     let foundItem = find_sidebar_list_item($(event.currentTarget));
     delete_folder_and_move_children_up_one_level(foundItem);
     close_sidebar_modal();
-    expand_all_folders_up_to(fullPath);
+    expand_all_folders_up_to(fullPath, container);
   });
   let deleteFolderAndChildrenButton = $(`<button class="token-image-modal-remove-all-button" title="Delete this folder and everything in it">Delete folder and<br />everything in it</button>`);
   set_full_path(deleteFolderAndChildrenButton, listItemFullPath);
@@ -1071,10 +1279,29 @@ function display_folder_configure_modal(listItem) {
     let foundItem = find_sidebar_list_item($(event.currentTarget));
     delete_folder_and_delete_children(foundItem);
     close_sidebar_modal();
-    expand_all_folders_up_to(fullPath);
+    expand_all_folders_up_to(fullPath, container);
   });
 
   sidebarModal.body.find(`input[name="folderName"]`).select();
+}
+
+function rename_folder(item, newName, alertUser = true) {
+  if (!item.isTypeFolder()) {
+    console.warn("rename_folder called with an incorrect item type", item);
+    if (alertUser !== false) {
+      alert("An unexpected error occurred");
+    }
+    return;
+  }
+
+  if (item.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+    return rename_mytoken_folder(item, newName, alertUser);
+  } else if (item.folderPath.startsWith(SidebarListItem.PathScenes)) {
+    return rename_scene_folder(item, newName, alertUser);
+  } else if (alertUser !== false) {
+    alert("An unexpected error occurred");
+  }
+
 }
 
 /**
@@ -1096,6 +1323,12 @@ function delete_item(listItem) {
       array_remove_index_by_value(mytokens, myToken);
       did_change_mytokens_items();
       break;
+    case SidebarListItem.TypeScene:
+      if (confirm(`Are you sure that you want to delete the scene named "${listItem.name}"?`)) {
+        window.ScenesHandler.delete_scene(listItem.sceneId);
+        did_update_scenes();
+      }
+      break;
     case SidebarListItem.TypePC:
       console.warn("Not allowed to delete player", listItem);
       break;
@@ -1109,29 +1342,303 @@ function delete_item(listItem) {
 }
 
 /**
- * removes the .collapsed class from all folders leading up to the secified path
+ * removes the .collapsed class from all folders leading up to the specified path
  * @param fullPath {string} the path to expand
+ * @param container {*|jQuery|HTMLElement} the element that contains the folder structure. EX: tokensPanel.body
  */
-function expand_all_folders_up_to(fullPath) {
-
-  console.group("expand_all_folders_up_to");
-  if (!fullPath.startsWith(SidebarListItem.PathMyTokens)) {
-    let myTokensPath = sanitize_folder_path(SidebarListItem.PathMyTokens + fullPath);
-    console.log(`fullPath: ${fullPath}, myTokensPath: ${myTokensPath}`);
-    let folderElement = find_html_row_from_path(myTokensPath, tokensPanel.body);
-    console.log(folderElement);
-    let parents = folderElement.parents(".collapsed")
-    console.log(parents);
-    parents.removeClass("collapsed");
-    console.log(parents);
-  } else {
-    console.log(`fullPath: ${fullPath}`);
-    let folderElement = find_html_row_from_path(fullPath, tokensPanel.body);
-    console.log(folderElement);
-    let parents = folderElement.parents(".collapsed")
-    console.log(parents);
-    parents.removeClass("collapsed");
-    console.log(parents);
-  }
+function expand_all_folders_up_to(fullPath, container) {
+  console.groupCollapsed("expand_all_folders_up_to", fullPath);
+  console.debug(`fullPath: ${fullPath}`);
+  let folderElement = find_html_row_from_path(fullPath, container);
+  console.debug(folderElement);
+  let parents = folderElement.parents(".collapsed")
+  console.debug(parents);
+  parents.removeClass("collapsed");
+  console.debug(parents);
   console.groupEnd();
+}
+
+/**
+ * deletes a folder and all items/folders within it. "items" refers to the mytokens, scenes, etc. that the item represents
+ * @param listItem {SidebarListItem} the item representing the folder you want to delete
+ */
+function delete_folder_and_delete_children(listItem) {
+  if (!listItem.isTypeFolder()) {
+    console.warn("delete_folder_and_delete_children called with an incorrect item type", listItem);
+    return;
+  }
+  if (!confirm(`Are you sure you want to delete "${listItem.name}"?\nAll items within it will also be deleted`)) {
+    console.debug("delete_folder_and_delete_children was canceled by user", listItem);
+    return;
+  }
+
+  if (listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+    delete_mytokens_within_folder(listItem);
+    delete_mytokens_folder(listItem);
+    did_change_mytokens_items();
+    expand_all_folders_up_to(listItem.folderPath, tokensPanel.body);
+  } else if (listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+    delete_scenes_within_folder(listItem);
+    delete_scenes_folder(listItem);
+    did_update_scenes();
+    expand_all_folders_up_to(listItem.folderPath, scenesPanel.body);
+  } else {
+    console.warn("delete_folder_and_delete_children called with an incorrect item type", listItem);
+  }
+
+}
+
+/**
+ * deletes a folder and moves all items/folders within it to the given folder's parent. "items" refers to the mytokens, scenes, etc. that the item represents
+ * @param listItem {SidebarListItem} the item representing the folder you want to delete
+ */
+function delete_folder_and_move_children_up_one_level(listItem) {
+  if (!listItem.isTypeFolder()) {
+    console.warn("delete_folder_and_move_children_up_one_level called with an incorrect item type", listItem);
+    return;
+  }
+  if (!confirm(`Are you sure you want to delete "${listItem.name}"?\nAll items within it will be moved up one level.`)) {
+    console.debug("delete_folder_and_move_children_up_one_level was canceled by user", listItem);
+    return;
+  }
+
+  if (listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+    move_mytokens_to_parent_folder(listItem);
+    delete_mytokens_folder(listItem);
+    did_change_mytokens_items();
+    expand_all_folders_up_to(listItem.folderPath, tokensPanel.body);
+  } else if (listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+    move_scenes_to_parent_folder(listItem);
+    delete_scenes_folder(listItem);
+    did_update_scenes();
+    expand_all_folders_up_to(listItem.folderPath, scenesPanel.body);
+  } else {
+    console.warn("delete_folder_and_move_children_up_one_level called with an incorrect item type", listItem);
+  }
+}
+
+function sidebar_flyout(hoverEvent, buildFunction) {
+  if (hoverEvent.type === "mouseenter") {
+    $(`.sidebar-flyout`).remove(); // never duplicate
+    let flyout = $(`<div class='sidebar-flyout'></div>`);
+    $("body").append(flyout);
+    buildFunction(flyout);
+    let height = flyout.height();
+    let halfHeight = (height / 2);
+    let top = hoverEvent.clientY - halfHeight;
+    if (top < 30) { // make sure it's always below the main UI buttons
+      top = 30;
+    } else if (hoverEvent.clientY + halfHeight > window.innerHeight - 30) {
+      top = window.innerHeight - height - 30;
+    }
+    flyout.css({
+      "top": top
+    });
+  } else {
+    $(`.sidebar-flyout`).remove(); // never duplicate
+  }
+}
+
+function list_item_image_flyout(hoverEvent) {
+  console.log("list_item_image_flyout", hoverEvent);
+  $(`#list-item-image-flyout`).remove(); // never duplicate
+  if (hoverEvent.type === "mouseenter") {
+    let imgsrc = $(hoverEvent.currentTarget).find("img").attr("src");
+    let flyout = $(`<img id='list-item-image-flyout' src="${imgsrc}" alt="image preview" />`);
+    flyout.css({
+      "top": hoverEvent.clientY - 75,
+    });
+    $("body").append(flyout);
+  }
+}
+
+function disable_draggable_change_folder(listItemType) {
+  $(".token-row-drag-handle").remove();
+  switch (listItemType) {
+    case SidebarListItem.TypeMyToken:
+      tokensPanel.body.find(".token-row-button").show();
+      tokensPanel.body.find(".token-row-button.reorder-button").show();
+      tokensPanel.body.find(".reorder-button").removeClass("active");
+      tokensPanel.body.find(" > .custom-token-list > .folder").show();
+      tokensPanel.header.find("input[name='token-search']").show();
+      tokensPanel.updateHeader("Tokens");
+      try {
+        tokensPanel.body.find(".sidebar-list-item-row").draggable("destroy");
+      } catch (e) {} // don't care if it fails, just try
+      try {
+        tokensPanel.body.find(".sidebar-list-item-row").droppable("destroy");
+      } catch (e) {} // don't care if it fails, just try
+      break;
+    case SidebarListItem.TypeScene:
+      scenesPanel.body.find(".token-row-gear").show();
+      scenesPanel.body.find(".token-row-button").show();
+      scenesPanel.header.find(".token-row-gear").show();
+      scenesPanel.header.find(".token-row-button").show();
+      scenesPanel.header.find(".scenes-panel-add-buttons-wrapper input").show();
+      scenesPanel.header.find(".scenes-panel-add-buttons-wrapper")
+      scenesPanel.header.find(".reorder-button").removeClass("active");
+      scenesPanel.header.find(".scenes-panel-add-buttons-wrapper .reorder-explanation").hide();
+      try {
+        scenesPanel.body.find(".sidebar-list-item-row").draggable("destroy");
+      } catch (e) {} // don't care if it fails, just try
+      try {
+        scenesPanel.body.find(".sidebar-list-item-row").droppable("destroy");
+      } catch (e) {} // don't care if it fails, just try
+      break;
+  }
+}
+
+/**
+ * allows you to drag items from one folder to another
+ * @param listItemType {string} SidebarListItem.TypeMyTokens || SidebarListItem.TypeScene
+ */
+function enable_draggable_change_folder(listItemType) {
+
+  disable_draggable_change_folder(listItemType);
+
+  switch (listItemType) {
+    case SidebarListItem.TypeMyToken:
+
+      redraw_token_list("", false);
+
+      tokensPanel.body.find(".token-row-gear").hide();
+      tokensPanel.body.find(".token-row-button").hide();
+      tokensPanel.body.find(".folder").removeClass("collapsed");
+      tokensPanel.body.find(" > .custom-token-list > .folder").hide();
+      tokensPanel.body.find(".reorder-button").show();
+      tokensPanel.body.find(".reorder-button").addClass("active");
+      tokensPanel.header.find("input[name='token-search']").hide();
+      tokensPanel.updateHeader("Tokens", "", "Drag items to move them between folders");
+
+      let myTokensRootItem = tokens_rootfolders.find(i => i.name === SidebarListItem.NameMyTokens);
+      let myTokensRootFolder = find_html_row(myTokensRootItem, tokensPanel.body);
+      // make sure we expand all folders that can be dropped on
+      myTokensRootFolder.show();
+      myTokensRootFolder.removeClass("collapsed");
+      myTokensRootFolder.find(".folder").removeClass("collapsed");
+
+      // TODO: disable the draggable that was added here enable_draggable_token_creation
+      // tokensPanel.body.find(".sidebar-list-item-row").draggable("destroy");
+      tokensPanel.body.find(".sidebar-list-item-row").draggable({
+        container: tokensPanel.body,
+        opacity: 0.7,
+        revert: true,
+        scroll: false, // jQuery UI has a bug where scrolling changes the offset of the helper. If we can figure out how to work around that bug, then we can change this to true
+        // axis: "y",  // this helps if we set scroll: true
+        helper: function (event) {
+          let draggedRow = $(event.target).closest(".list-item-identifier");
+          let draggedItem = find_sidebar_list_item(draggedRow);
+          if (draggedItem.isTypeFolder()) {
+            draggedRow.addClass("collapsed");
+          }
+          draggedRow.addClass("draggable-sidebar-item-reorder");
+          return draggedRow;
+        },
+        stop: function (event, ui) {
+          let draggedRow = $(event.target).closest(".list-item-identifier");
+          draggedRow.removeClass("draggable-sidebar-item-reorder");
+          if (draggedRow.hasClass("drag-cancelled")) {
+            draggedRow.removeClass("drag-cancelled");
+            redraw_token_list("", false);
+            enable_draggable_change_folder(SidebarListItem.TypeMyToken);
+          }
+        }
+      });
+
+      const droppableOptions = {
+        greedy: true,
+        accept: ".draggable-sidebar-item-reorder:not(.drag-cancelled)",
+        drop: function (dropEvent, ui) {
+          let draggedRow = $(ui.helper);
+          let draggedItem = find_sidebar_list_item(draggedRow);
+          let droppedFolder = $(dropEvent.target);
+          let folderItem = find_sidebar_list_item(droppedFolder);
+          console.log("enable_draggable_change_folder dropped", draggedItem, folderItem);
+          move_item_into_folder(draggedItem, folderItem.fullPath());
+        }
+      };
+
+      myTokensRootFolder.droppable(droppableOptions); // allow dropping on root MyTokens folder
+      myTokensRootFolder.find(".folder").droppable(droppableOptions);  // allow dropping on folders within MyTokens folder
+
+      break;
+    case SidebarListItem.TypeScene:
+      scenesPanel.header.find(".token-row-button").hide();
+      scenesPanel.header.find(".scenes-panel-add-buttons-wrapper input").hide();
+      scenesPanel.header.find(".scenes-panel-add-buttons-wrapper .reorder-explanation").show();
+      scenesPanel.header.find(".reorder-button").show();
+      scenesPanel.header.find(".reorder-button").addClass("active");
+      scenesPanel.body.find(".token-row-gear").hide();
+      scenesPanel.body.find(".token-row-button").hide();
+      scenesPanel.body.find(".folder").removeClass("collapsed");
+
+      scenesPanel.body.find(".sidebar-list-item-row").draggable({
+        container: scenesPanel.body,
+        opacity: 0.7,
+        revert: true,
+        scroll: false, // jQuery UI has a bug where scrolling changes the offset of the helper. If we can figure out how to work around that bug, then we can change this to true
+        // axis: "y",  // this helps if we set scroll: true
+        helper: function (event) {
+          let draggedRow = $(event.target).closest(".list-item-identifier");
+          let draggedItem = find_sidebar_list_item(draggedRow);
+          if (draggedItem.isTypeFolder()) {
+            draggedRow.addClass("collapsed");
+          }
+          draggedRow.addClass("draggable-sidebar-item-reorder");
+          return draggedRow;
+        },
+        stop: function (event, ui) {
+          let draggedRow = $(event.target).closest(".list-item-identifier");
+          draggedRow.removeClass("draggable-sidebar-item-reorder");
+          if (draggedRow.hasClass("drag-cancelled")) {
+            draggedRow.removeClass("drag-cancelled");
+            redraw_scene_list("");
+            enable_draggable_change_folder(SidebarListItem.TypeScene);
+          }
+        }
+      });
+
+      scenesPanel.body.find(".folder").droppable({
+        greedy: true,
+        accept: ".draggable-sidebar-item-reorder:not(.drag-cancelled)",
+        drop: function (dropEvent, ui) {
+          let draggedRow = $(ui.helper);
+          let draggedItem = find_sidebar_list_item(draggedRow);
+          let droppedFolder = $(dropEvent.target);
+          let folderItem = find_sidebar_list_item(droppedFolder);
+          console.log("enable_draggable_change_folder dropped", draggedItem, folderItem);
+          move_item_into_folder(draggedItem, folderItem.fullPath());
+        }
+      });
+
+      break;
+    default:
+      console.warn("enable_draggable_change_folder was called with an invalid type");
+      return;
+  }
+
+}
+
+function move_item_into_folder(listItem, folderPath) {
+  if (listItem.isTypeMyToken()) {
+    move_mytoken_to_folder(listItem, folderPath);
+    persist_my_tokens();
+    rebuild_token_items_list();
+    enable_draggable_change_folder(SidebarListItem.TypeMyToken);
+  } else if (listItem.isTypeScene()) {
+    move_scene_to_folder(listItem, folderPath);
+    did_update_scenes();
+    enable_draggable_change_folder(SidebarListItem.TypeScene);
+  } else if (listItem.isTypeFolder() && listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+    move_mytokens_folder(listItem, folderPath);
+    persist_my_tokens();
+    rebuild_token_items_list();
+    enable_draggable_change_folder(SidebarListItem.TypeMyToken);
+  } else if (listItem.isTypeFolder() && listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+    move_scenes_folder(listItem, folderPath);
+    did_update_scenes();
+    enable_draggable_change_folder(SidebarListItem.TypeScene);
+  } else {
+    console.warn("move_item_into_folder was called with invalid item type", listItem)
+  }
 }

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -8,13 +8,13 @@ tokendata={
 function convert_path(path){
 	var pieces=path.split("/");
 	var current=tokendata;
-	
+
 	for(var i=0;i<pieces.length;i++){
-		if(pieces[i]=="")
+		if(!current || pieces[i]=="")
 			continue;
 		current=current.folders[pieces[i]];
 	}
-	return current;
+	return current || {};
 }
 
 // deprecated, but still needed for migrate_to_my_tokens() to work
@@ -29,12 +29,6 @@ function context_menu_flyout(id, hoverEvent, buildFunction) {
 	if (contextMenu.length === 0) {
 		console.warn("context_menu_flyout, but #tokenOptionsPopup could not be found");
 		return;
-	}
-
-	try {
-		clearTimeout(window.context_menu_flyout_timer);
-	} catch (e) {
-		console.debug("failed to clear window.context_menu_flyout_timer", window.context_menu_flyout_timer);
 	}
 
 	if (hoverEvent.type === "mouseenter") {

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -213,12 +213,36 @@ function find_builtin_token(fullPath) {
     return found;
 }
 
+function backfill_mytoken_folders() {
+    mytokens.forEach(myToken => {
+        if (myToken.folderPath !== SidebarListItem.PathRoot) {
+            // we split the path and backfill empty every folder along the way if needed. This is really important for folders that hold subfolders, but not items
+            let parts = myToken.folderPath.split("/");
+            let backfillPath = "";
+            parts.forEach(part => {
+                let fullBackfillPath = sanitize_folder_path(`${backfillPath}/${part}`);
+                if (fullBackfillPath !== SidebarListItem.PathRoot && !mytokensfolders.find(fi => sanitize_folder_path(`${fi.folderPath}/${fi.name}`) === fullBackfillPath)) {
+                    // we don't have this folder yet so add it
+                    let newFolder = { folderPath: sanitize_folder_path(backfillPath), name: part, collapsed: true };
+                    console.log("adding folder", newFolder);
+                    mytokensfolders.push(newFolder);
+                } else {
+                    console.log("not adding folder", fullBackfillPath);
+                }
+                backfillPath = fullBackfillPath;
+            });
+        }
+    });
+}
+
 /**
  * iterates over all the token sources and replaces window.tokenListItems with new objects.
  * token sources are window.pcs, mytokens, mytokensfolders, and builtInTokens
  */
 function rebuild_token_items_list() {
     console.groupCollapsed("rebuild_token_items_list");
+
+    backfill_mytoken_folders(); // just in case we're missing any folders
 
     // Players
     let tokenItems = window.pcs
@@ -290,7 +314,7 @@ function filter_token_list(searchTerm) {
                 // we always want the monsters folder to be open when searching
                 continue;
             }
-            let nonFolderDescendents = currentFolder.find(".tokens-panel-row:not(.folder)");
+            let nonFolderDescendents = currentFolder.find(".sidebar-list-item-row:not(.folder)");
             if (nonFolderDescendents.length === 0) {
                 // hide folders without results in them
                 currentFolder.hide();
@@ -336,7 +360,7 @@ function inject_monster_tokens(searchTerm, skip) {
                 let previousSkip = parseInt($(loadMoreClickEvent.currentTarget).attr("data-skip"));
                 inject_monster_tokens(searchTerm, previousSkip + 10);
             });
-            monsterFolder.find(`> .folder-token-list`).append(loadMoreButton);
+            monsterFolder.find(`> .folder-item-list`).append(loadMoreButton);
         }
     });
 }
@@ -347,7 +371,7 @@ function inject_monster_list_items(listItems) {
         console.warn("inject_monster_list_items failed to find the monsters folder");
         return;
     }
-    let list = monsterFolder.find(`> .folder-token-list`);
+    let list = monsterFolder.find(`> .folder-item-list`);
     for (let i = 0; i < listItems.length; i++) {
         let item = listItems[i];
         let row = build_sidebar_list_row(item);
@@ -385,6 +409,7 @@ function init_tokens_panel() {
 
     let header = tokensPanel.header;
     // TODO: remove this warning once tokens are saved in the cloud
+    tokensPanel.updateHeader("Tokens");
     header.append("<div class='panel-warning'>WARNING/WORKINPROGRESS. THIS TOKEN LIBRARY IS CURRENTLY STORED IN YOUR BROWSER STORAGE. IF YOU DELETE YOUR HISTORY YOU LOOSE YOUR LIBRARY</div>");
 
     let searchInput = $(`<input name="token-search" type="text" style="width:96%;margin:2%" placeholder="search tokens">`);
@@ -411,7 +436,7 @@ function init_tokens_panel() {
  * clears and redraws the list of tokens in the sidebar
  * @param searchTerm {string} the search term used to filter the list of tokens
  */
-function redraw_token_list(searchTerm) {
+function redraw_token_list(searchTerm, enableDraggable = true) {
     if (!window.tokenListItems) {
         // don't do anything on startup
         return;
@@ -423,7 +448,7 @@ function redraw_token_list(searchTerm) {
 
     let nameFilter = "";
     if (searchTerm !== undefined && typeof searchTerm === "string") {
-        nameFilter = searchTerm;
+        nameFilter = searchTerm.toLowerCase();
     }
 
     // first let's add our root folders
@@ -439,26 +464,23 @@ function redraw_token_list(searchTerm) {
         .forEach(item => {
             let row = build_sidebar_list_row(item);
             console.debug("appending item", item);
-            find_html_row_from_path(item.folderPath, list).find(` > .folder-token-list`).append(row);
+            find_html_row_from_path(item.folderPath, list).find(` > .folder-item-list`).append(row);
         });
 
     // now let's add all the other items
     window.tokenListItems
         .filter(item =>
             !item.isTypeFolder() // we already added all folders so don't include them in this loop
-            && (
-                item.name.toLowerCase().includes(nameFilter.toLowerCase()) // any item with a partially matching name
-                || item.containingFolderName().toLowerCase().includes(nameFilter.toLowerCase()) // all items within a folder with a partially matching name
-            )
+            && item.nameOrContainingFolderMatches(nameFilter)
         )
         .sort(SidebarListItem.sortComparator)
         .forEach(item => {
             let row = build_sidebar_list_row(item);
-            if (!item.isTypeEncounter()) {
+            if (enableDraggable === true && !item.isTypeEncounter()) {
                 enable_draggable_token_creation(row);
             }
             console.debug("appending item", item);
-            find_html_row_from_path(item.folderPath, list).find(` > .folder-token-list`).append(row);
+            find_html_row_from_path(item.folderPath, list).find(` > .folder-item-list`).append(row);
         });
 
     update_pc_token_rows();
@@ -477,7 +499,7 @@ function enable_draggable_token_creation(html, specificImage = undefined) {
         appendTo: "#VTTWRAPPER",
         zIndex: 100000,
         cursorAt: {top: 0, left: 0},
-        cancel: '.token-row-gear',
+        cancel: '.token-row-gear ',
         helper: function(event) {
             console.log("enable_draggable_token_creation helper");
             let draggedRow = $(event.target).closest(".list-item-identifier");
@@ -559,9 +581,9 @@ function update_pc_token_rows() {
             row.find(".tokens-panel-row-details-subtitle .pp-value").text(playerData.pp);
             row.find(".tokens-panel-row-details-subtitle .walking-value").text(playerData.walking);
             if (playerData.inspiration) {
-                row.find(".tokens-panel-row-details-subtitle .inspiration").show();
+                row.find(".sidebar-list-item-row-details-subtitle .inspiration").show();
             } else {
-                row.find(".tokens-panel-row-details-subtitle .inspiration").hide();
+                row.find(".sidebar-list-item-row-details-subtitle .inspiration").hide();
             }
         }
     });
@@ -598,9 +620,9 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
             let encounterMonsterItems = encounter_monster_items[encounterId];
             if (encounterMonsterItems === undefined || encounterMonsterItems.length === 0) {
                 let encounterRow = tokensPanel.body.find(`[data-encounter-id='${encounterId}']`);
-                encounterRow.find(".tokens-panel-row-item").addClass("button-loading");
+                encounterRow.find(".sidebar-list-item-row-item").addClass("button-loading");
                 refresh_encounter(encounterRow, listItem, function (response) {
-                    encounterRow.find(".tokens-panel-row-item").removeClass("button-loading");
+                    encounterRow.find(".sidebar-list-item-row-item").removeClass("button-loading");
                     if (response === true) {
                         create_and_place_token(listItem, hidden, specificImage, eventPageX, eventPageY);
                     }
@@ -834,7 +856,7 @@ function search_monsters(searchTerm, skip, callback) {
 function register_token_row_context_menu() {
 
     // don't allow the context menu when right clicking on the add button since that adds a hidden token
-    tokensPanel.body.find(".tokens-panel-row").on("contextmenu", ".token-row-add", function(event) {
+    tokensPanel.body.find(".sidebar-list-item-row").on("contextmenu", ".token-row-add", function(event) {
         event.preventDefault();
         event.stopPropagation();
         let clickedRow = $(event.target).closest(".list-item-identifier");
@@ -843,7 +865,7 @@ function register_token_row_context_menu() {
     });
 
     $.contextMenu({
-        selector: ".tokens-panel-row",
+        selector: "#tokens-panel .sidebar-list-item-row",
         build: function(element, e) {
 
             let menuItems = {};
@@ -891,7 +913,7 @@ function register_token_row_context_menu() {
                     name: "Edit",
                     callback: function(itemKey, opt, originalEvent) {
                         let itemToEdit = find_sidebar_list_item(opt.$trigger);
-                        display_token_item_configuration_modal(itemToEdit);
+                        display_sidebar_list_item_configuration_modal(itemToEdit);
                     }
                 };
             }
@@ -905,7 +927,7 @@ function register_token_row_context_menu() {
                 };
             }
 
-            if (rowItem.canDelete() ) {
+            if (rowItem.canDelete()) {
 
                 menuItems["border"] = "---";
 
@@ -932,38 +954,6 @@ function register_token_row_context_menu() {
 }
 
 /**
- * Displays a SidebarPanel as a modal that allows the user to configure the given listItem
- * @param listItem {SidebarListItem} the item to configure
- */
-function display_token_item_configuration_modal(listItem) {
-    switch (listItem.type) {
-        case SidebarListItem.TypeEncounter:
-            // TODO: support editing in an iframe on the page?
-            window.open(`https://www.dndbeyond.com/encounters/${listItem.encounterId}/edit`, '_blank');
-            break;
-        case SidebarListItem.TypeFolder:
-            if (listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
-                display_folder_configure_modal(listItem);
-            } else {
-                console.warn("Only allowed to folders within the My Tokens folder");
-                return;
-            }
-            break;
-        case SidebarListItem.TypeBuiltinToken:
-            display_builtin_token_details_modal(listItem);
-            break;
-        case SidebarListItem.TypeMyToken:
-        case SidebarListItem.TypePC:
-        case SidebarListItem.TypeMonster:
-            display_token_configuration_modal(listItem);
-            break;
-        default:
-            console.warn("display_token_item_configuration_modal not supported for listItem", listItem);
-    }
-}
-
-
-/**
  * determines if the given path exists or not.
  * @param folderPath {string} the path you are looking for
  * @returns {boolean} whether or not the path exists
@@ -976,9 +966,9 @@ function my_token_path_exists(folderPath) {
  * Creates a "My Tokens" folder within another "My Tokens" folder
  * @param listItem {SidebarListItem} The folder to create a new folder within
  */
-function create_folder_inside(listItem) {
+function create_mytoken_folder_inside(listItem) {
     if (!listItem.isTypeFolder() || !listItem.fullPath().startsWith(SidebarListItem.PathMyTokens)) {
-        console.warn("create_folder_inside called with an incorrect item type", listItem);
+        console.warn("create_mytoken_folder_inside called with an incorrect item type", listItem);
         return;
     }
 
@@ -993,7 +983,7 @@ function create_folder_inside(listItem) {
     mytokensfolders.push(newFolder);
     let newFolderFullPath = sanitize_folder_path(`${SidebarListItem.PathMyTokens}${newFolder.folderPath}/${newFolder.name}`);
     did_change_mytokens_items();
-    expand_all_folders_up_to(newFolderFullPath);
+    expand_all_folders_up_to(newFolderFullPath, tokensPanel.body);
     let newListItem = window.tokenListItems.find(i => i.fullPath() === newFolderFullPath);
     display_folder_configure_modal(newListItem);
 }
@@ -1005,7 +995,7 @@ function create_folder_inside(listItem) {
  * @param alertUser {boolean} whether or not to alert the user if an error occurs. The most common error is naming conflicts
  * @returns {string|undefined} the path of the newly created folder; undefined if the folder could not be created.
  */
-function rename_folder(item, newName, alertUser = true) {
+function rename_mytoken_folder(item, newName, alertUser = true) {
     if (!item.isTypeFolder() || !item.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
         console.warn("rename_folder called with an incorrect item type", item);
         if (alertUser !== false) {
@@ -1036,13 +1026,11 @@ function rename_folder(item, newName, alertUser = true) {
     }
 
     console.log(`updating tokens from ${fromFullPath} to ${toFullPath}`);
-    let didUpdateTokens = false;
     mytokens.forEach(token => {
         if (token.folderPath.startsWith(fromFullPath)) {
             let newFolderPath = sanitize_folder_path(token.folderPath.replace(fromFullPath, toFullPath));
             console.debug(`changing token ${token.name} folderpath from ${token.folderPath} to ${newFolderPath}`);
             token.folderPath = newFolderPath;
-            didUpdateTokens = true;
         } else {
             console.debug("not moving token", token);
         }
@@ -1069,60 +1057,28 @@ function rename_folder(item, newName, alertUser = true) {
     return toFullPath;
 }
 
-/**
- * deletes a folder and all tokens/folders within it
- * @param listItem {SidebarListItem} the item representing the folder you want to delete
- */
-function delete_folder_and_delete_children(listItem) {
-    if (!listItem.isTypeFolder() || !listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
-        console.warn("delete_folder_and_delete_children called with an incorrect item type", listItem);
-        return;
-    }
-    if (!confirm(`Are you sure you want to delete "${listItem.name}"?\nAll items within it will also be deleted`)) {
-        console.debug("delete_folder_and_delete_children was canceled by user", listItem);
-        return;
-    }
+function delete_mytokens_within_folder(listItem) {
+    console.groupCollapsed(`delete_mytokens_within_folder`);
+    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathMyTokens, ""));
 
-    console.groupCollapsed("delete_folder_and_delete_children");
-
-    let adjustedPath = listItem.fullPath().replace(SidebarListItem.PathMyTokens, "");
-    console.log("about to delete folder and everything in", adjustedPath);
-
+    console.log("about to delete all tokens within", adjustedPath);
     console.debug("before deleting from mytokens", mytokens);
     mytokens = mytokens.filter(token => !token.folderPath.startsWith(adjustedPath));
     console.debug("after deleting from mytokens", mytokens);
 
+    console.log("about to delete all folders within", adjustedPath);
     console.debug("before deleting from mytokensfolders", mytokensfolders);
-    mytokensfolders = mytokensfolders
-        .filter(folder => !folder.folderPath.startsWith(adjustedPath)) // remove everything under the folder
-        .filter(folder => sanitize_folder_path(`${folder.folderPath}/${folder.name}`) !== adjustedPath); // remove the folder itself
+    mytokensfolders = mytokensfolders.filter(folder => !folder.folderPath.startsWith(adjustedPath))
     console.debug("after deleting from mytokensfolders", mytokensfolders);
-
-    did_change_mytokens_items();
-    let oneLevelUp = sanitize_folder_path(listItem.folderPath);
-    expand_all_folders_up_to(oneLevelUp);
 
     console.groupEnd();
 }
 
-/**
- * deletes a folder and moves all tokens/folders within it to the given folder's parent
- * @param listItem {SidebarListItem} the item representing the folder you want to delete
- */
-function delete_folder_and_move_children_up_one_level(listItem) {
-    if (!listItem.isTypeFolder() || !listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
-        console.warn("delete_folder_and_move_children_up_one_level called with an incorrect item type", listItem);
-        return;
-    }
-    if (!confirm(`Are you sure you want to delete "${listItem.name}"?\nAll items within it will be moved up one level.`)) {
-        console.debug("delete_folder_and_move_children_up_one_level was canceled by user", listItem);
-        return;
-    }
-    console.groupCollapsed("delete_folder_and_move_children_up_one_level");
-
+function move_mytokens_to_parent_folder(listItem) {
+    // this is different from move_mytokens_folder in that it moved everything out of listItem
+    console.groupCollapsed(`move_mytokens_to_parent_folder`);
     let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathMyTokens, ""));
     let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(SidebarListItem.PathMyTokens, ""));
-    console.log(`about to delete folder ${adjustedPath} and move its children up one level to ${oneLevelUp}`);
 
     console.debug("before moving mytokens", mytokens);
     mytokens.forEach(token => {
@@ -1149,10 +1105,15 @@ function delete_folder_and_move_children_up_one_level(listItem) {
     });
     console.debug("after moving mytokensfolders", mytokensfolders);
 
-    did_change_mytokens_items();
-    expand_all_folders_up_to(oneLevelUp);
-
     console.groupEnd();
+}
+
+function delete_mytokens_folder(listItem) {
+    console.log("delete_mytokens_folder", listItem);
+    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathMyTokens, ""));
+    console.debug("before deleting from mytokensfolders", mytokensfolders);
+    mytokensfolders = mytokensfolders.filter(folder => sanitize_folder_path(`${folder.folderPath}/${folder.name}`) !== adjustedPath);
+    console.debug("after deleting from mytokensfolders", mytokensfolders);
 }
 
 /**
@@ -1615,7 +1576,7 @@ function update_token_folders_remembered_state() {
 }
 
 function fetch_encounter_monsters_if_necessary(clickedRow, clickedItem) {
-    if (clickedItem.isTypeEncounter() && clickedRow.find(".folder-token-list").is(":empty") && !clickedItem.activelyFetchingMonsters && clickedItem.encounterId !== undefined) {
+    if (clickedItem.isTypeEncounter() && clickedRow.find(".folder-item-list").is(":empty") && !clickedItem.activelyFetchingMonsters && clickedItem.encounterId !== undefined) {
         fetch_and_inject_encounter_monsters(clickedRow, clickedItem);
     }
 }
@@ -1632,8 +1593,8 @@ function refresh_encounter(clickedRow, clickedItem, callback) {
             fetch_and_inject_encounter_monsters(clickedRow, clickedItem);
             clickedItem.name = response.name;
             clickedItem.description = response.flavorText;
-            clickedRow.find(".tokens-panel-row-details-title").text(response.name);
-            clickedRow.find(".tokens-panel-row-details-subtitle").text(response.flavorText);
+            clickedRow.find(".sidebar-list-item-row-details-title").text(response.name);
+            clickedRow.find(".sidebar-list-item-row-details-subtitle").text(response.flavorText);
             callback(true);
         }
     });
@@ -1641,10 +1602,10 @@ function refresh_encounter(clickedRow, clickedItem, callback) {
 
 function fetch_and_inject_encounter_monsters(clickedRow, clickedItem) {
     clickedItem.activelyFetchingMonsters = true;
-    clickedRow.find(".tokens-panel-row-item").addClass("button-loading");
+    clickedRow.find(".sidebar-list-item-row-item").addClass("button-loading");
     window.EncounterHandler.fetch_encounter_monsters(clickedItem.encounterId, function (response, errorType) {
         clickedItem.activelyFetchingMonsters = true;
-        clickedRow.find(".tokens-panel-row-item").removeClass("button-loading");
+        clickedRow.find(".sidebar-list-item-row-item").removeClass("button-loading");
         if (response === false) {
             console.warn("Failed to fetch encounter monsters", errorType);
         } else {
@@ -1663,7 +1624,7 @@ function inject_encounter_monsters() {
         let monsterItems = encounter_monster_items[encounterId];
         let encounter = window.EncounterHandler.encounters[encounterId];
         let encounterRow = tokensPanel.body.find(`[data-encounter-id='${encounterId}']`);
-        let encounterMonsterList = encounterRow.find(`> .folder-token-list`);
+        let encounterMonsterList = encounterRow.find(`> .folder-item-list`);
         if (encounter?.groups === undefined || encounter.groups === null || encounterMonsterList.length === 0 || encounterRow.length === 0 || monsterItems === undefined) {
             continue;
         }
@@ -2226,4 +2187,63 @@ const fetch_and_cache_scene_monster_items = mydebounce( (clearCache = false) => 
 
 function update_monster_item_cache(newItems) {
     newItems.forEach(item => cached_monster_items[item.monsterData.id] = item);
+}
+
+function move_mytoken_to_folder(listItem, folderPath) {
+    if (!listItem.isTypeMyToken()) {
+        console.warn("move_mytoken_to_folder was called with the wrong item type", listItem);
+        return;
+    }
+    let myToken = find_my_token(listItem.fullPath());
+    if (!myToken) {
+        console.warn("move_mytoken_to_folder could not find myToken for listItem", listItem);
+        return;
+    }
+    myToken.folderPath = sanitize_folder_path(folderPath.replace(SidebarListItem.PathMyTokens, ""));
+}
+
+function move_mytokens_folder(listItem, folderPath) {
+    // this is different from move_mytokens_to_parent_folder in that it moves the listItem keeping everything within the folder intact
+    if (listItem.isTypeFolder() && listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+        console.groupCollapsed("move_mytokens_folder");
+
+        let fromPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathMyTokens, ""));
+
+        let folderObject = find_my_token_folder(listItem.fullPath());
+        let newFolderPath = sanitize_folder_path(folderPath.replace(SidebarListItem.PathMyTokens, ""));
+        if (folderObject) {
+            folderObject.folderPath = newFolderPath;
+        }
+        listItem.folderPath = newFolderPath;
+
+        let toPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathMyTokens, ""));
+
+        console.debug("before moving mytokens", mytokens);
+        mytokens.forEach(token => {
+            if (token.folderPath.startsWith(fromPath)) {
+                let newFolderPath = sanitize_folder_path(token.folderPath.replace(fromPath, toPath));
+                console.log(`moving ${token.name} up one level to ${newFolderPath}`, token);
+                token.folderPath = newFolderPath;
+            } else {
+                console.debug(`not moving token up one level`, token);
+            }
+        });
+        console.debug("after moving mytokens", mytokens);
+
+        console.debug("before moving mytokensfolders", mytokensfolders);
+        mytokensfolders.forEach(f => {
+            if (f.folderPath.startsWith(fromPath)) {
+                let newFolderPath = sanitize_folder_path(f.folderPath.replace(fromPath, toPath));
+                console.log("moving folder up to", newFolderPath, f);
+                f.folderPath = newFolderPath;
+            } else {
+                console.debug("not moving folder up", f);
+            }
+        });
+        console.debug("after moving mytokensfolders", mytokensfolders);
+
+        console.groupEnd();
+    } else {
+        console.warn("move_mytoken_to_folder was called with the wrong item type", listItem);
+    }
 }

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1273,7 +1273,8 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
 
         // token size
         let tokenSizeInput = build_token_size_input(tokenSize, function (newSize) {
-            console.log("do something with new token size", newSize)
+            myToken.tokenSize = newSize;
+            persist_my_tokens();
         });
         inputWrapper.append(tokenSizeInput);
         inputWrapper.append(`<div class="sidebar-panel-header-explanation" style="padding-bottom:6px;">The following will override global settings for this token. Global settings can be changed in the settings tab.</div>`)

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2126,13 +2126,14 @@ div.ct-sidebar__pane-content > div.selected-tab {
     width: 100%;
 }
 .sidebar-panel-header-title {
-    text-transform: uppercase;
-    font-size: 16px;
-    font-weight: 700;
     letter-spacing: .5px;
     display: flex;
     align-items: center;
     margin: 8px 0px 8px 8px;
+    font-family: "Roboto Condensed", "Arial Narrow", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 18px;
 }
 .sidebar-panel-header-title:empty{
     margin: 0px;
@@ -2147,6 +2148,7 @@ div.ct-sidebar__pane-content > div.selected-tab {
 .sidebar-panel-header-subtitle:empty{
     margin: 0px;
 }
+.reorder-explanation,
 .sidebar-panel-header-explanation {
     font-size: 14px;
     color: #979AA4;
@@ -2276,52 +2278,128 @@ h5.token-image-modal-footer-title:after {
     background: rgb(235, 241, 245);
     height: 100%;
 }
-.tokens-panel-row.encounter,
-.tokens-panel-row.folder {
+.sidebar-list-item-row.encounter,
+.sidebar-list-item-row.folder {
     background-color: rgb(235, 241, 245);
 }
-.tokens-panel-row.encounter.collapsed,
-.tokens-panel-row.folder.collapsed {
+.sidebar-list-item-row.encounter.collapsed,
+.sidebar-list-item-row.folder.collapsed {
     background-color: #fff;
 }
-.encounter .folder-token-list,
-.folder .folder-token-list {
-    padding-left: 1em;
+#scenes-panel .sidebar-list-item-row.scene-item .scene-bg {
+    background-size: cover;
+    background-repeat: no-repeat;
+    filter: blur(1px);
+    -webkit-filter: blur(1px);
+    max-width: 100%;
+    max-height: 100%;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 30px;
+}
+#scenes-panel .sidebar-list-item-row.scene-item:not(.folder) .sidebar-list-item-row-img {
+    background-color: gray;
+    margin: -4px 0;
+    border-radius: 0;
+}
+#scenes-panel .sidebar-list-item-row.scene-item:not(.folder) .sidebar-list-item-row-img img {
+    border-radius: 0;
+    max-height: none;
+}
+#scenes-panel .sidebar-list-item-row.scene-item .sidebar-list-item-row-item {
+    position: inherit;
+}
+#scenes-panel .sidebar-list-item-row.scene-item .sidebar-list-item-row-img img {
+    object-fit: cover;
+    height: 38px;
+}
+#scenes-panel .sidebar-list-item-row.scene-item .sidebar-list-item-row-img .scene-list-item-is-video {
+    font-size: 38px;
+    text-align: center;
+    color: lightgray;
+}
+.sidebar-flyout {
+    position: fixed;
+    right: 350px;
+    z-index: 1000;
+    border: 1px solid #d8e1e8;
+    box-shadow: 1px 1px 10px black, -1px -1px 10px black;
+    border-radius: 15px;
+    overflow: hidden;
+}
+.list-item-image-flyout {
+    width: 400px;
+    height: 400px;
+    object-fit: cover;
+    display: block;
+}
+#scenes-panel .sidebar-list-item-row.scene-item .scene-item-footer {
+    display: flex;
+    flex-direction: row;
+    margin: -4px -4px -4px -4px;
+}
+#scenes-panel .sidebar-list-item-row.scene-item {
+    cursor: default;
+}
+#scenes-panel .selected-scene {
+    background-color: #c53131;
+    background-position: center;
+}
+#scenes-panel .selected-scene svg path {
+    fill: #fff;
+}
+.scene-item-footer > button {
+    flex-grow: 1;
+    margin: 0;
+    padding: 0;
+    border-radius: 0;
+    border-width: 0;
+    overflow: hidden;
+}
+.encounter .folder-item-list,
+.folder .folder-item-list {
+    padding-left: 6px;
     padding-top: 0.3em;
     cursor: default;
 }
-.encounter .folder-token-list:empty:before,
-.folder .folder-token-list:empty:before {
+.encounter .folder-item-list:empty:before,
+.folder .folder-item-list:empty:before {
     content: "This folder is empty";
     color: #738694;
 }
-.encounter.collapsed .folder-token-list,
-.folder.collapsed .folder-token-list {
+.encounter.collapsed .folder-item-list,
+.folder.collapsed .folder-item-list {
     display: none;
 }
-.encounter > .tokens-panel-row-item > .token-row-button,
-.folder > .tokens-panel-row-item > .token-row-button {
+.encounter > .sidebar-list-item-row-item > .token-row-button,
+.folder > .sidebar-list-item-row-item > .token-row-button {
     background-color: rgb(235, 241, 245);
 }
-.encounter.collapsed > .tokens-panel-row-item > .token-row-button,
-.folder.collapsed > .tokens-panel-row-item > .token-row-button {
+.encounter.collapsed > .sidebar-list-item-row-item > .token-row-button,
+.folder.collapsed > .sidebar-list-item-row-item > .token-row-button {
     background-color: #fff;
 }
-.tokens-panel-row {
+.sidebar-list-item-row {
     position: relative;
-    padding: 4px;
+    padding: 4px 0px;
     width: 100%;
-    margin: 2px 0px 2px 0px;
+    margin: 2px 0px;
     border: 1px solid #d8e1e8;
     border-radius: 3px;
     background-color: #fff;
     cursor: pointer;
 }
-.tokens-panel-row-item {
+.sidebar-list-item-row:not(.folder) {
+    overflow: hidden;
+}
+.sidebar-list-item-row-item {
     display: flex;
     width: 100%;
+    padding-right: 4px;
 }
-.tokens-panel-row-img {
+.sidebar-list-item-row-img {
     display: flex;
     flex-basis: 38px;
     width: 38px;
@@ -2331,14 +2409,14 @@ h5.token-image-modal-footer-title:after {
     border-radius: 3px;
     object-fit: cover;
 }
-.tokens-panel-row-img img {
+.sidebar-list-item-row-img img {
     object-fit: contain;
     width: 38px;
     max-width: 38px;
     height: 100%;
     max-height: 38px;
 }
-.tokens-panel-row-details {
+.sidebar-list-item-row-details {
     text-overflow: ellipsis;
     overflow: hidden;
     display: flex;
@@ -2352,19 +2430,33 @@ h5.token-image-modal-footer-title:after {
     text-align: left;
     white-space: nowrap;
 }
-.tokens-panel-row-details div {
+.sidebar-list-item-row-details div {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
     justify-content: center;
 }
-.tokens-panel-row-details-title {
+.sidebar-list-item-row-details-title {
     font-size: 13px;
     font-weight: 700;
 }
-.tokens-panel-row-details-subtitle {
+.sidebar-list-item-row-details-subtitle {
     color: #738694;
     font-size: 10px;
+}
+.sidebar-list-item-row-item div.sidebar-list-item-row-details-subtitle .legacy-monster {
+    color: rgb(18, 24, 28);
+    background-color: rgba(18, 24, 28, 0.12);
+    border-radius: 4px;
+    flex-grow: 0;
+}
+.sidebar-list-item-row-item div.sidebar-list-item-row-details-subtitle .legacy-monster span {
+    font-family: Roboto;
+    font-weight: 500;
+    line-height: 20px;
+    font-size: 12px;
+    letter-spacing: 0px;
+    padding: 0px 6px;
 }
 .token-row-button {
     display: block;
@@ -2377,10 +2469,10 @@ h5.token-image-modal-footer-title:after {
     margin: 0 2px;
     min-width: 30px;
 }
-.tokens-panel-row.player-row {
+.sidebar-list-item-row.player-row {
     height: 68px;
 }
-.tokens-panel-row.player-row .player-expansion-button {
+.sidebar-list-item-row.player-row .player-expansion-button {
     height: 16px;
     margin: 0px 0px -8px 0px;
     bottom: 8px;
@@ -2394,23 +2486,26 @@ h5.token-image-modal-footer-title:after {
     text-transform: uppercase;
     background-color: #f2f2f2;
 }
-.tokens-panel-row .tokens-panel-row-details-subtitle {
+.sidebar-list-item-row .sidebar-list-item-row-details-subtitle {
     flex-direction: row;
     justify-content: start;
 }
-.tokens-panel-row .tokens-panel-row-details-subtitle .subtitle-attibute {
+.sidebar-list-item-row .sidebar-list-item-row-details-subtitle .subtitle-attibute {
     flex-direction: row;
-    margin-right: 4px;
+    min-width: 40px;
+    margin-right: 8px;
     flex-grow: 0;
+    justify-content: start;
+    font-size: 12px;
 }
-.tokens-panel-row .tokens-panel-row-details-subtitle .subtitle-attibute img {
+.sidebar-list-item-row .sidebar-list-item-row-details-subtitle .subtitle-attibute img {
     width: 24px;
     height: 24px;
 }
-.tokens-panel-row .tokens-panel-row-details-subtitle .subtitle-attibute .material-icons {
+.sidebar-list-item-row .sidebar-list-item-row-details-subtitle .subtitle-attibute .material-icons {
     font-size: 18px;
 }
-.tokens-panel-row .tokens-panel-row-details-subtitle .subtitle-attibute .plain-text {
+.sidebar-list-item-row .sidebar-list-item-row-details-subtitle .subtitle-attibute .plain-text {
     font-size: 18px;
     margin-top: -2px;
     font-family: 'Material Icons', serif;
@@ -2424,44 +2519,44 @@ h5.token-image-modal-footer-title:after {
     word-wrap: normal;
     direction: ltr;
 }
-.tokens-panel-row.player-row .player-expansion-button .material-icons {
+.sidebar-list-item-row.player-row .player-expansion-button .material-icons {
     width: 100%;
     height: 100%;
     text-align: center;
     font-size: 18px;
     font-weight: 700;
 }
-.tokens-panel-row.player-row.expanded {
+.sidebar-list-item-row.player-row.expanded {
     height: 142px;
 }
-.tokens-panel-row.player-row .player-card-footer {
+.sidebar-list-item-row.player-row .player-card-footer {
     max-height: 0px;
     height: 0px;
 }
-.tokens-panel-row.player-row.expanded .player-card-footer {
+.sidebar-list-item-row.player-row.expanded .player-card-footer {
     max-height: 76px;
     height: 76px;
 }
-.tokens-panel-row.player-row .ability_value {
+.sidebar-list-item-row.player-row .ability_value {
     margin: 8px 0;
 }
-.tokens-panel-row.player-row .token-row-add > .material-icons {
+.sidebar-list-item-row.player-row .token-row-add > .material-icons {
     display: none;
 }
-.tokens-panel-row.player-row.on-scene .token-row-add > .material-icons {
+.sidebar-list-item-row.player-row.on-scene .token-row-add > .material-icons {
     display: inline-block;
     color: #1b9af0;
 }
-.tokens-panel-row.player-row.on-scene .token-row-add > svg {
+.sidebar-list-item-row.player-row.on-scene .token-row-add > svg {
     display: none;
 }
-.tokens-panel-row.player-row .token-row-gear {
+.sidebar-list-item-row.player-row .token-row-gear {
     border-bottom-right-radius: 0;
 }
-.tokens-panel-row.player-row.button-loading .tokens-panel-row-details-subtitle {
+.sidebar-list-item-row.player-row.button-loading .sidebar-list-item-row-details-subtitle {
     content: "loading character sheet yo!";
 }
-.tokens-panel-row.player-row.expanded .token-row-gear {
+.sidebar-list-item-row.player-row.expanded .token-row-gear {
     border-bottom: 1px solid #d8e1e8;
 }
 .token-row-button .material-icons {
@@ -2490,20 +2585,16 @@ h5.token-image-modal-footer-title:after {
     height: 100%;
     fill: #738694;
 }
-.tokens-panel-row.encounter .tokens-panel-row-item,
-.tokens-panel-row.folder .tokens-panel-row-item {
-    height: 38px;
-}
-.tokens-panel-row.encounter .player-row > .tokens-panel-row-item,
-.tokens-panel-row.folder .player-row > .tokens-panel-row-item {
+.sidebar-list-item-row.encounter .player-row > .sidebar-list-item-row-item,
+.sidebar-list-item-row.folder .player-row > .sidebar-list-item-row-item {
     height: 42px; /* players are taller than everything else */
 }
-.tokens-panel-row.encounter > .tokens-panel-row-item,
-.tokens-panel-row.folder > .tokens-panel-row-item {
+.sidebar-list-item-row.encounter > .sidebar-list-item-row-item,
+.sidebar-list-item-row.folder > .sidebar-list-item-row-item {
     height: 30px; /* folders are shorter than everything else */
 }
-.tokens-panel-row.encounter > .folder-token-list > .encounter-monster-group.grouped,
-.tokens-panel-row.folder > .folder-token-list > .encounter-monster-group.grouped {
+.sidebar-list-item-row.encounter > .folder-item-list > .encounter-monster-group.grouped,
+.sidebar-list-item-row.folder > .folder-item-list > .encounter-monster-group.grouped {
     border: 2px dashed #1b9af0;
     border-radius: 3px;
     padding: 0px 2px;
@@ -3711,4 +3802,50 @@ button.avtt-roll-button {
 @keyframes spin {
     0%  {-webkit-transform: rotate(0deg);}
     100% {-webkit-transform: rotate(360deg);}
+}
+
+.scenes-panel-add-buttons-wrapper {
+    display: flex;
+    flex-direction: row;
+    position: relative;
+    padding-right: 6px;
+    padding-left: 4px;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.folder.ui-droppable-hover {
+    border: 2px solid black;
+    background-color: white;
+}
+.reorder-button {
+    background-color: #f2f6f8;
+}
+.reorder-button.active {
+    background-color: #fff;
+}
+
+.token-row-drag-handle {
+    display: block;
+    width: 30px;
+    height: 30px;
+    padding: 3px;
+    border-top-right-radius: 3px;
+    border-bottom: 1px solid #d8e1e8;
+    background-color: #f2f6f8;
+    border-left: 1px solid #d8e1e8;
+    margin: -4px -4px;
+    cursor: move;
+    min-width: 30px;
+
+    position: relative;
+}
+
+#scenes-panel .sidebar-list-item-row.scene-item.ui-draggable,
+.sidebar-list-item-row.ui-draggable {
+    cursor: move;
+}
+
+.sidebar-list-item-row.ui-draggable-dragging {
+    z-index: 100000;
 }


### PR DESCRIPTION
Closes #508 
Closes #503
Closes #509


# What

1. Move the list of Scenes into a new Scenes tab in sidebar utilizing the `SidebarListItem` framework that was added during the the Tokens Panel unification. 
2. Allow Scenes to be added to folders. (cannot be moved yet)
3. Allow Searching of Scenes
4. Refactored some of the `SidebarListItem` framework to be more generic and reusable.
5. This is only available if `window.CLOUD` is true. Non-migrated users will continue to use the old window at the top of the screen.


# Other Considerations

We discussed not showing images in the sidebar to reduce the initial download and memory impact. I chose to leave it in for now so we could all play with it before making a final decision on it.


# Demos
### Folder and scene creation
![avtt-scenes-panel-demo-1](https://user-images.githubusercontent.com/584771/169044585-af4205b9-8c9b-4ea3-aed6-2e2296e65e19.gif)

### Display larger image on hover
![avtt-flyout-styling](https://user-images.githubusercontent.com/584771/169056811-f2be9a71-acfc-4099-b1f9-7ae91aa635cf.gif)


### Scene and folder deletion
![avtt-scenes-panel-deletion](https://user-images.githubusercontent.com/584771/169046345-dffec206-a4b3-4b34-b564-e218df81c053.gif)

### Scene search
![avtt-scenes-panel-search](https://user-images.githubusercontent.com/584771/169070544-2ae2b4f0-1b99-438f-9a5e-19e1d398ea5f.gif)

### Moving Scenes between folders
https://user-images.githubusercontent.com/584771/169146013-16312f54-9bee-48ac-bcc4-e15684a925b2.mov


