### PR TITLE
Close context menu on token delete

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -309,7 +309,8 @@ function token_context_menu_expanded(tokenIds, e) {
 	 		tokens.forEach(token => {
 	 			token.selected = true;
 	 		});
-			delete_selected_tokens()
+			delete_selected_tokens();
+			$("#tokenOptionsClickCloseDiv").click();
 	 	});
 	 }
 


### PR DESCRIPTION
This was  mentioned a couple times in discord. It was an oversight on my part - if there's no tokens to edit when keep the menu open.

Are there any other buttons that we think should close it? I didn't want it to close for everything because I often find myself changing more than one setting.