### PR TITLE
Fix dice streaming

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2698,7 +2698,7 @@ function init_buttons() {
 
 	window.STREAMPEERS={};
 	window.MYSTREAMID=uuid();
-	window.JOINTHEDICESTREAM=true;
+	window.JOINTHEDICESTREAM=false;
 
 
 

--- a/Main.js
+++ b/Main.js
@@ -2698,7 +2698,7 @@ function init_buttons() {
 
 	window.STREAMPEERS={};
 	window.MYSTREAMID=uuid();
-	window.JOINTHEDICESTREAM=false;
+	window.JOINTHEDICESTREAM=true;
 
 
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -679,24 +679,7 @@ class MessageBroker {
 				if( (!window.MYSTREAMID))
 					return;
 				const configuration = {
-    				iceServers:  [ {
-					     	urls: "stun:openrelay.metered.ca:80",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:80",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443?transport=tcp",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    }]
+    				iceServers:  [ {urls: "stun:stun.l.google.com:19302"}]
   				};
 				var peer= new RTCPeerConnection(configuration);
 
@@ -755,24 +738,7 @@ class MessageBroker {
 				if( (!window.MYSTREAMID)  || (msg.data.to!= window.MYSTREAMID) )
 					return;
 				const configuration = {
-    				iceServers:  [ {
-					     	urls: "stun:openrelay.metered.ca:80",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:80",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443?transport=tcp",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    }]
+    				iceServers:  [ {urls: "stun:stun.l.google.com:19302"}]
   				};
 				var peer= new RTCPeerConnection(configuration);
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -710,19 +710,8 @@ class MessageBroker {
 						from: window.MYSTREAMID,
 						ice: e.candidate
 					})
-				};
-
-				
-				window.STREAMPEERS[msg.data.from]=peer;
-				peer.onconnectionstatechange=() => {
-					if((peer.connectionState=="closed") || (peer.connectionState=="failed")){
-						console.log("DELETING PEER "+msg.data.from);
-						delete window.STREAMPEERS[msg.data.from];
-						$("#streamer-canvas-"+msg.data.from).remove();
-					}
-				};
-
-					
+				};				
+				window.STREAMPEERS[msg.data.from]=peer;				
 			}
 			if(msg.eventType == "custom/myVTT/okletmeseeyourdice"){
 				if( !window.JOINTHEDICESTREAM)
@@ -761,16 +750,6 @@ class MessageBroker {
 					})
 				};
 
-				
-				window.STREAMPEERS[msg.data.from]=peer;
-				peer.onconnectionstatechange=() => {
-					if((peer.connectionState=="closed") || (peer.connectionState=="failed")){
-						console.log("DELETING PEER "+msg.data.from);
-						delete window.STREAMPEERS[msg.data.from];
-						$("#streamer-canvas-"+msg.data.from).remove();
-					}
-				};
-				
 				window.STREAMPEERS[msg.data.from]= await peer;
 
 				if(window.MYMEDIASTREAM){

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -48,7 +48,8 @@ function addVideo(stream,streamerid) {
 	dicecanvas.css("z-index",60000);
 	dicecanvas.css("touch-action","none");
 	dicecanvas.css("pointer-events","none");
-	dicecanvas.css("filter", "drop-shadow(-16px 18px 15px black)")
+	dicecanvas.css("filter", "drop-shadow(-16px 18px 15px black)");
+	dicecanvas.css("clip-path", "inset(2px 2px 2px 2px)");
 	$("#site").append(dicecanvas);
 	
 	

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -669,16 +669,6 @@ class MessageBroker {
 					      urls: "turn:openrelay.metered.ca:80",
 					      username: "openrelayproject",
 					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443?transport=tcp",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
 					    }]
   				};
 				var peer= new RTCPeerConnection(configuration);
@@ -690,9 +680,6 @@ class MessageBroker {
 
 				peer.addEventListener('track', (event) => {
 					console.log("aggiungo video!!!!");
-					    if ($("#streamer-video-"+msg.data.from).srcObject) {
-      					return;
-   						}
 				     addVideo(event.streams[0],msg.data.from);
 				});
 				window.makingOffer = [];
@@ -712,6 +699,31 @@ class MessageBroker {
 								offer: desc
 							})}, staggerRandom
 						)
+
+						peer.oniceconnectionstatechange = () => {
+						  if (peer.iceConnectionState === "failed" || peer.iceConnectionState === "disconnected" ) {
+						  	console.log("Dice Stream Connection failed Retrying");
+						    self.sendMessage("custom/myVTT/okletmeseeyourdice",{
+										to: msg.data.from,
+										from: window.MYSTREAMID,
+										offer: desc
+									})
+						    peer.restartIce();
+						  }
+					    else if (peer.iceConnectionState === "checking"  ) {
+						   	console.log("Dice Stream Connection failed Retrying")
+						  	setTimeout(function(){
+						  		if(peer.connectionState == "connecting"  || peer.connectionState == "failed" || peer.iceConnectionState === "disconnected") {
+							  		self.sendMessage("custom/myVTT/okletmeseeyourdice",{
+											to: msg.data.from,
+											from: window.MYSTREAMID,
+											offer: desc
+										})
+										peer.restartIce();
+									}
+						  	}, 20000);		    
+						  }	  
+						}
 					});
 
 			  } catch(err) {
@@ -723,28 +735,7 @@ class MessageBroker {
 			    
 			  }
 
-				peer.oniceconnectionstatechange = () => {
-				  if (peer.iceConnectionState === "failed" || peer.iceConnectionState === "disconnected" ) {
-				  	console.log("Dice Stream Connection failed Retrying");
-				    self.sendMessage("custom/myVTT/okletmeseeyourdice",{
-								to: msg.data.from,
-								from: window.MYSTREAMID,
-								offer: msg.data.offer
-							})
-				  }
-			    if (peer.iceConnectionState === "checking"  ) {
-				   	console.log("Dice Stream Connection failed Retrying")
-				  	setTimeout(function(){
-				  		if(peer.connectionState == "connecting") {
-					  		self.sendMessage("custom/myVTT/okletmeseeyourdice",{
-									to: msg.data.from,
-									from: window.MYSTREAMID,
-									offer: msg.data.offer
-								})
-							}
-				  	}, 20000);		    
-				  }	  
-				}
+				
 				peer.onicecandidate = e => {
 					window.MB.sendMessage("custom/myVTT/iceforyourgintonic",{
 						to: msg.data.from,
@@ -776,47 +767,13 @@ class MessageBroker {
 					      urls: "turn:openrelay.metered.ca:80",
 					      username: "openrelayproject",
 					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
-					    },
-					    {
-					      urls: "turn:openrelay.metered.ca:443?transport=tcp",
-					      username: "openrelayproject",
-					      credential: "openrelayproject",
 					    }]
   				};
 				var peer= new RTCPeerConnection(configuration);
 				peer.addEventListener('track', (event) => {
-					if ($("#streamer-video-"+msg.data.from).srcObject) {
-      			return;
-   				}
 					addVideo(event.streams[0],msg.data.from);
 				});
-				peer.oniceconnectionstatechange = () => {
-				  if (peer.iceConnectionState === "failed" || peer.iceConnectionState === "disconnected" ){
-				  	console.log("Dice Stream Connection failed Retrying")
-				    self.sendMessage("custom/myVTT/okletmeseeyourdice",{
-								to: msg.data.from,
-								from: window.MYSTREAMID,
-								offer: msg.data.offer
-							})
-				  }
-				  if (peer.iceConnectionState === "checking"  ) {
-				   	console.log("Dice Stream Connection failed Retrying")
-				  	setTimeout(function(){
-				  		if(peer.connectionState == "connecting") {
-					  			self.sendMessage("custom/myVTT/okletmeseeyourdice",{
-									to: msg.data.from,
-									from: window.MYSTREAMID,
-									offer: msg.data.offer
-								})
-							}
-				  	}, 10000);
-					}
-				}
+				
 				peer.onicecandidate = e => {
 					window.MB.sendMessage("custom/myVTT/iceforyourgintonic",{
 						to: msg.data.from,
@@ -842,6 +799,30 @@ class MessageBroker {
 						to: msg.data.from,
 						answer: desc
 					});
+					peer.oniceconnectionstatechange = () => {
+					  if (peer.iceConnectionState === "failed" || peer.iceConnectionState === "disconnected" ){
+					  	console.log("Dice Stream Connection failed Retrying")
+					    self.sendMessage("custom/myVTT/okseethem",{
+								from: window.MYSTREAMID,
+								to: msg.data.from,
+								answer: desc
+							})
+							peer.restartIce();
+					  }
+					  else if(peer.connectionState == "connecting") {
+					   	console.log("Dice Stream Connection failed Retrying")
+					  	setTimeout(function(){
+					  		if(peer.connectionState == "connecting" || peer.connectionState == "failed" || peer.iceConnectionState === "disconnected") {
+						  			self.sendMessage("custom/myVTT/okseethem",{
+										from: window.MYSTREAMID,
+										to: msg.data.from,
+										answer: desc
+									})
+						  		peer.restartIce();
+								}
+					  	}, 20000);
+						}
+					}
 				})			
 			}
 			if(msg.eventType == "custom/myVTT/okseethem"){

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -334,7 +334,7 @@ class MessageBroker {
 		this.lastAlertTS = 0;
 		this.latestVersionSeen = abovevtt_version;
 
-		this.onmessage =  function(event,tries=0) {
+		this.onmessage = function(event,tries=0) {
 			if (event.data == "pong")
 				return;
 			if (event.data == "ping")
@@ -648,12 +648,11 @@ class MessageBroker {
 					return;
 				if( (!window.MYSTREAMID)  || (msg.data.to!= window.MYSTREAMID) )
 					return;
-	
-					setTimeout( () => {
-					var peer= window.STREAMPEERS[msg.data.from];
-					if(peer.remoteDescription!= null)
-						peer.addIceCandidate(msg.data.ice);
-					 },500); // ritardalo un po'
+				setTimeout( () => {
+				var peer= window.STREAMPEERS[msg.data.from];
+				if(peer.remoteDescription!= null)
+					peer.addIceCandidate(msg.data.ice);
+				},500); // ritardalo un po'
 			}
 			if(msg.eventType == "custom/myVTT/whatsyourdicerolldefault"){
 				if( !window.JOINTHEDICESTREAM)
@@ -716,12 +715,12 @@ class MessageBroker {
 				if( (!window.MYSTREAMID))
 					return;
 				const configuration = {
-    				iceServers:  [ {urls: "stun:stun.l.google.com:19302"}]
+    				iceServers:  [{urls: "stun:stun.l.google.com:19302"}]
   				};
 				var peer= new RTCPeerConnection(configuration);
 
 				if(window.MYMEDIASTREAM){
-					var stream=  window.MYMEDIASTREAM;
+					var stream = window.MYMEDIASTREAM;
 					stream.getTracks().forEach(track => peer.addTrack(track, stream));
 				}
 
@@ -779,7 +778,7 @@ class MessageBroker {
 				if( (!window.MYSTREAMID)  || (msg.data.to!= window.MYSTREAMID) )
 					return;
 				const configuration = {
-    				iceServers:  [ {urls: "stun:stun.l.google.com:19302"}]
+    				iceServers:  [{urls: "stun:stun.l.google.com:19302"}]
   				};
 				var peer= new RTCPeerConnection(configuration);
 
@@ -790,7 +789,7 @@ class MessageBroker {
 
 				peer.addEventListener('track', (event) => {
 					console.log("aggiungo video!!!!");
-				     addVideo(event.streams[0],msg.data.from);
+				  addVideo(event.streams[0],msg.data.from);
 				});
 				window.makingOffer = [];
 				window.makingOffer[msg.data.from] = false;
@@ -856,8 +855,6 @@ class MessageBroker {
 				peer.setRemoteDescription(msg.data.answer);
 				console.log("fatto setRemoteDescription");
 			}
-
-
 			
 			if (msg.eventType == "dice/roll/fulfilled") {
 				notify_gamelog();
@@ -1355,12 +1352,12 @@ class MessageBroker {
 			message.sceneId=window.CURRENT_SCENE_DATA.id;
 		if(window.PLAYER_SCENE_ID)
 			message.playersSceneId = window.PLAYER_SCENE_ID;
+
 		const jsmessage=JSON.stringify(message);
 		if(jsmessage.length > (128000)){
 			alert("YOU REACHED THE MAXIMUM MESSAGE SIZE. PROBABLY SOMETHING IS WRONG WITH YOUR SCENE. You may have some tokens with embedded images that takes up too much space. Please delete them and refresh the scene");
 			return;
 		}
-
 
 		if (this.abovews.readyState == this.ws.OPEN) {
 			this.abovews.send(JSON.stringify(message));

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -686,11 +686,11 @@ class MessageBroker {
 		   		peer.createOffer({offerToReceiveVideo: 1}).then( async (desc) => {
 						console.log("fatto setLocalDescription");
 						await peer.setLocalDescription(desc);
-						self.sendMessage("custom/myVTT/okletmeseeyourdice",{
+						setTimeout(function(){self.sendMessage("custom/myVTT/okletmeseeyourdice",{
 							to: msg.data.from,
 							from: window.MYSTREAMID,
 							offer: desc
-						})
+						})}, Math.floor(Math.random() * 10000))		
 					});
 
 			  } catch(err) {
@@ -723,7 +723,7 @@ class MessageBroker {
 					return;
 				let ignoreOffer = false;
 				if(msg.data.offer){
-					const offerCollision = (msg.data.offer.type == "offer") && (window.makingOffer[msg.data.from] || window.STREAMPEERS[msg.data.from].signalingState == "stable");
+					const offerCollision = (msg.data.offer.type == "offer") && (window.makingOffer[msg.data.from] || window.STREAMPEERS[msg.data.from].signalingState == "stable")
 				  ignoreOffer = offerCollision;
 				  if (ignoreOffer) {
 				    return;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -716,7 +716,9 @@ class MessageBroker {
 				window.STREAMPEERS[msg.data.from]=peer;
 				peer.onconnectionstatechange=() => {
 					if((peer.connectionState=="closed") || (peer.connectionState=="failed")){
-
+						console.log("DELETING PEER "+msg.data.from);
+						delete window.STREAMPEERS[msg.data.from];
+						$("#streamer-canvas-"+msg.data.from).remove();
 					}
 				};
 
@@ -763,7 +765,9 @@ class MessageBroker {
 				window.STREAMPEERS[msg.data.from]=peer;
 				peer.onconnectionstatechange=() => {
 					if((peer.connectionState=="closed") || (peer.connectionState=="failed")){
-
+						console.log("DELETING PEER "+msg.data.from);
+						delete window.STREAMPEERS[msg.data.from];
+						$("#streamer-canvas-"+msg.data.from).remove();
 					}
 				};
 				

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -638,6 +638,16 @@ class MessageBroker {
 				peer.addIceCandidate(msg.data.ice);
 				 },500); // ritardalo un po'
 			}
+			if(msg.eventType == "custom/myVTT/turnoffdicestream"){
+				consloe.log("custom/myVTT/turnoffdicestream")
+					window.JOINTHEDICESTREAM = false;
+					for (let i in window.STREAMPEERS) {
+						window.STREAMPEERS[i].close();
+						delete window.STREAMPEERS[i];
+					}
+					$(".streamer-canvas").remove();
+			}
+
 			if(msg.eventType == "custom/myVTT/hidemydicestream"){
 					console.log("custom/myVTT/hidemydicestream");
 					hideVideo(msg.data.streamid);

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -686,11 +686,13 @@ class MessageBroker {
 		   		peer.createOffer({offerToReceiveVideo: 1}).then( async (desc) => {
 						console.log("fatto setLocalDescription");
 						await peer.setLocalDescription(desc);
-						setTimeout(function(){self.sendMessage("custom/myVTT/okletmeseeyourdice",{
-							to: msg.data.from,
-							from: window.MYSTREAMID,
-							offer: desc
-						})}, Math.floor(Math.random() * 10000))		
+						setTimeout(function(){
+							self.sendMessage("custom/myVTT/okletmeseeyourdice",{
+								to: msg.data.from,
+								from: window.MYSTREAMID,
+								offer: desc
+							})}, Math.floor(Math.random() * (6000 - 3000) + 3000)
+						)
 					});
 
 			  } catch(err) {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -69,7 +69,7 @@ function addVideo(stream,streamerid) {
 		dicecanvas.css("height",tmpcanvas.height);
 		dicecanvas.css("width",tmpcanvas.width );
 		window.requestAnimationFrame(updateCanvas);
-		tmpctx.drawImage(video, 0, 0);
+		tmpctx.drawImage(video, 0, 0, tmpcanvas.width, tmpcanvas.height);
 		if(tmpcanvas.width>0)
 		{
 			const frame = tmpctx.getImageData(0, 0, tmpcanvas.width, tmpcanvas.height);
@@ -639,13 +639,7 @@ class MessageBroker {
 				 },500); // ritardalo un po'
 			}
 			if(msg.eventType == "custom/myVTT/turnoffdicestream"){
-				consloe.log("custom/myVTT/turnoffdicestream")
-					window.JOINTHEDICESTREAM = false;
-					for (let i in window.STREAMPEERS) {
-						window.STREAMPEERS[i].close();
-						delete window.STREAMPEERS[i];
-					}
-					$(".streamer-canvas").remove();
+				$("[id^='streamer-']").remove();
 			}
 
 			if(msg.eventType == "custom/myVTT/hidemydicestream"){

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -639,12 +639,24 @@ class MessageBroker {
 						peer.addIceCandidate(msg.data.ice);
 					 },500); // ritardalo un po'
 			}
-			if(msg.eventType == "custom/myVTT/turnoffdicestream"){
+			if(msg.eventType == "custom/myVTT/turnoffsingledicestream"){
 				$("[id^='streamer-"+msg.data.from+"']").remove();
 				window.STREAMPEERS[msg.data.from].close();
 				delete window.STREAMPEERS[msg.data.from]
 			}
+			if(msg.eventType == "custom/myVTT/disabledicestream"){
+				enable_dice_streaming_feature(false);
+			}
 
+			if(msg.eventType == "custom/myVTT/showonlytodmdicestream"){
+					console.log("custom/myVTT/showonlytodmdicestream");
+				if(!window.DM){		
+					hideVideo(msg.data.streamid);
+				}		
+				else{
+					revealVideo(msg.data.streamid);
+				}
+			}
 			if(msg.eventType == "custom/myVTT/hidemydicestream"){
 					console.log("custom/myVTT/hidemydicestream");
 					hideVideo(msg.data.streamid);

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -677,15 +677,15 @@ class MessageBroker {
    						}
 				     addVideo(event.streams[0],msg.data.from);
 				});
-
-				window.makingOffer = false;
+				window.makingOfferTo = [];
+				window.makingOfferTo[msg.data.from] = false;
 
 		
 			  try {
-			    window.makingOffer = true;
 		   		peer.createOffer({offerToReceiveVideo: 1}).then( async (desc) => {
 						console.log("fatto setLocalDescription");
 						await peer.setLocalDescription(desc);
+						window.makingOfferTo[msg.data.from] = true;
 						self.sendMessage("custom/myVTT/okletmeseeyourdice",{
 							to: msg.data.from,
 							from: window.MYSTREAMID,
@@ -696,7 +696,7 @@ class MessageBroker {
 			  } catch(err) {
 			    console.error(err);
 			  } finally {
-			    window.makingOffer = false;
+			    window.makingOfferTo[msg.data.from] = false;
 			  }
 
 				peer.oniceconnectionstatechange = () => {
@@ -718,14 +718,8 @@ class MessageBroker {
 					return;
 				if( (!window.MYSTREAMID)  || (msg.data.to!= window.MYSTREAMID) )
 					return;
-				let ignoreOffer = false;
-				if(msg.data.offer){
-					const offerCollision = (msg.data.offer.type == "offer") && (window.makingOffer === undefined || window.makingOffer || window.STREAMPEERS[msg.data.from].signalingState == "stable");
-				  ignoreOffer = offerCollision;
-				  if (ignoreOffer) {
-				    return;
-				  }
-				}
+				if(window.makingOfferTo[msg.data.from] )
+					return;
 
 				const configuration = {
     				iceServers: [{urls: "turn:turn.abovevtt.net:3478",username:"abovevtt",credential:"pleasedontfuckitupthisisanopenproject"}]
@@ -737,7 +731,7 @@ class MessageBroker {
    				}
 					addVideo(event.streams[0],msg.data.from);
 				});
-				pc.oniceconnectionstatechange = () => {
+				peer.oniceconnectionstatechange = () => {
 				  if (peer.iceConnectionState === "failed") {
 				    peer.restartIce();
 				  }
@@ -775,14 +769,6 @@ class MessageBroker {
 				if( (!window.MYSTREAMID)  || (msg.data.to!= window.MYSTREAMID) )
 					return;
 
-				let ignoreOffer = false;
-				if(msg.data.offer){
-					const offerCollision = (msg.data.offer.type == "offer") && (makingOffer || window.STREAMPEERS[msg.data.from].signalingState != "stable");
-				  ignoreOffer = offerCollision;
-				  if (ignoreOffer) {
-				    return;
-				  }
-				}
 				var peer=window.STREAMPEERS[msg.data.from];
 				peer.setRemoteDescription(msg.data.answer);
 				console.log("fatto setRemoteDescription");

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -591,7 +591,9 @@ class MessageBroker {
 							}
 						}
 					}
-
+					if($("[name='streamDiceRolls'].rc-switch-checked").length > 0) {
+						window.MB.sendMessage("custom/myVTT/enabledicestreamingfeature")
+					}
 					window.JOURNAL.sync();
 				}	
 			}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -63,8 +63,17 @@ function addVideo(stream,streamerid) {
 		delayedClear();
 		
 		let tmpcanvas = document.createElement("canvas");
-		tmpcanvas.width = Math.min(video.videoWidth, window.innerWidth);
-		tmpcanvas.height = Math.min(video.videoHeight, window.innerHeight);
+		let videoAspectRatio = video.videoWidth / video.videoHeight
+		if (video.videoWidth > video.videoHeight)
+		{
+			tmpcanvas.width = Math.min(video.videoWidth, window.innerWidth);
+			tmpcanvas.height = Math.min(video.videoHeight, window.innerWidth / videoAspectRatio);		
+		}
+		else {
+			tmpcanvas.width = Math.min(video.videoWidth, window.innerHeight / (1 / videoAspectRatio));
+			tmpcanvas.height = Math.min(video.videoHeight, window.innerHeight);		
+		}
+		
 		video.setAttribute("width", tmpcanvas.width)
 		video.setAttribute("height", tmpcanvas.height)
 		let tmpctx = tmpcanvas.getContext("2d");

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -653,8 +653,8 @@ class MessageBroker {
 					console.log("custom/myVTT/revealmydicestream");
 					revealVideo(msg.data.streamid);
 			}
-			if(msg.eventType == "custom/myVTT/updatedicestreamingfeature"){
-					update_dice_streaming_feature(true);				
+			if(msg.eventType == "custom/myVTT/enabledicestreamingfeature"){
+					enable_dice_streaming_feature(true);				
 			}
 					
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -635,6 +635,7 @@ class MessageBroker {
 	
 					setTimeout( async () => {
 					var peer= window.STREAMPEERS[msg.data.from];
+					if(peer.remoteDescription!= null)
 					await peer.addIceCandidate(msg.data.ice);
 					 },500); // ritardalo un po'
 			}
@@ -661,7 +662,24 @@ class MessageBroker {
 				if( (!window.MYSTREAMID))
 					return;
 				const configuration = {
-    				iceServers: [{urls: "turn:turn.abovevtt.net:3478",username:"abovevtt",credential:"pleasedontfuckitupthisisanopenproject"}]
+    				iceServers: [ {
+					     	urls: "stun:openrelay.metered.ca:80",
+					    },
+					    {
+					      urls: "turn:openrelay.metered.ca:80",
+					      username: "openrelayproject",
+					      credential: "openrelayproject",
+					    },
+					    {
+					      urls: "turn:openrelay.metered.ca:443",
+					      username: "openrelayproject",
+					      credential: "openrelayproject",
+					    },
+					    {
+					      urls: "turn:openrelay.metered.ca:443?transport=tcp",
+					      username: "openrelayproject",
+					      credential: "openrelayproject",
+					    }
   				};
 				var peer=await new RTCPeerConnection(configuration);
 
@@ -680,6 +698,7 @@ class MessageBroker {
 				window.makingOffer = [];
 				window.makingOffer[msg.data.from] = false;
 
+				let staggerRandom = Math.floor(Math.random() * (5000 - 500) + 500); //Looking for a better way to do this or cause only one of the clients to answer the offer
 		
 			  try {
 			    	window.makingOffer[msg.data.from] = true;
@@ -691,7 +710,7 @@ class MessageBroker {
 								to: msg.data.from,
 								from: window.MYSTREAMID,
 								offer: desc
-							})}, Math.floor(Math.random() * (6000 - 3000) + 3000)
+							})}, staggerRandom
 						)
 					});
 
@@ -700,7 +719,7 @@ class MessageBroker {
 			  } finally {
 			  	setTimeout(function(){
 			  			window.makingOffer[msg.data.from] = false;
-			  	}, 2000)
+			  	}, staggerRandom)
 			    
 			  }
 
@@ -733,7 +752,24 @@ class MessageBroker {
 				}
 
 				const configuration = {
-    				iceServers: [{urls: "turn:turn.abovevtt.net:3478",username:"abovevtt",credential:"pleasedontfuckitupthisisanopenproject"}]
+    				iceServers: [ {
+					     	urls: "stun:openrelay.metered.ca:80",
+					    },
+					    {
+					      urls: "turn:openrelay.metered.ca:80",
+					      username: "openrelayproject",
+					      credential: "openrelayproject",
+					    },
+					    {
+					      urls: "turn:openrelay.metered.ca:443",
+					      username: "openrelayproject",
+					      credential: "openrelayproject",
+					    },
+					    {
+					      urls: "turn:openrelay.metered.ca:443?transport=tcp",
+					      username: "openrelayproject",
+					      credential: "openrelayproject",
+					    }
   				};
 				var peer= await new RTCPeerConnection(configuration);
 				peer.addEventListener('track', async (event) => {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -659,7 +659,7 @@ class MessageBroker {
 					return;
 
 				const configuration = {
-    				iceServers: [{urls: "turn:openrelay.metered.ca:443",username:"openrelayproject",credential:"openrelayproject"}]
+    				iceServers: [{urls: "turn:turn.abovevtt.net:3478",username:"abovevtt",credential:"pleasedontfuckitupthisisanopenproject"}]
   				};
 				var peer=new RTCPeerConnection(configuration);
 				peer.addEventListener('track', async (event) => {
@@ -706,7 +706,7 @@ class MessageBroker {
 					return;
 
 				const configuration = {
-    				iceServers: [{urls: "turn:openrelay.metered.ca:443",username:"openrelayproject",credential:"openrelayproject"}]
+    				iceServers: [{urls: "turn:turn.abovevtt.net:3478",username:"abovevtt",credential:"pleasedontfuckitupthisisanopenproject"}]
   				};
 				var peer=new RTCPeerConnection(configuration);
 				peer.addEventListener('track', async (event) => {

--- a/Settings.js
+++ b/Settings.js
@@ -326,6 +326,8 @@ function init_settings(){
 				enable_dice_streaming_feature(newValue);
 				if(newValue == true) {
 					window.MB.sendMessage("custom/myVTT/enabledicestreamingfeature");
+				} else {
+					window.MB.sendMessage("custom/myVTT/disabledicestream");
 				}
 			} else {
 				window.EXPERIMENTAL_SETTINGS[setting.name] = newValue;
@@ -433,7 +435,9 @@ function redraw_settings_panel_token_examples() {
 	}
 }
 
-function enable_dice_streaming_feature(){
+function enable_dice_streaming_feature(enabled){
+	if(enabled)
+	{
 		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
 		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
 		$(".stream-dice-button").remove();
@@ -446,6 +450,16 @@ function enable_dice_streaming_feature(){
 				update_dice_streaming_feature(true);
 			}
 		})
+	}
+	else{
+		$(".stream-dice-button").remove();
+		window.JOINTHEDICESTREAM = false;
+		$("[id^='streamer-']").remove();
+		for (let peer in window.STREAMPEERS) {
+			window.STREAMPEERS[peer].close();
+			delete window.STREAMPEERS[peer]
+		}
+	}
 }
 
 function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text()) {
@@ -453,19 +467,24 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 		
 
 	if (enabled == true) {
-	
+		$(`.stream-dice-button`).html("Leave Dice Stream");
 		// STREAMING STUFF
 		window.JOINTHEDICESTREAM = true;
 		$('.stream-dice-button').html("Leave Dice Stream");
 		$("[role='presentation'] [role='menuitem']").each(function(){
 			$(this).off().on("click", function(){
-				if($(this).text() != "Everyone") {
-					window.MB.sendMessage("custom/myVTT/hidemydicestream",{
+				if($(this).text() == "Everyone") {
+					window.MB.sendMessage("custom/myVTT/revealmydicestream",{
+						streamid: window.MYSTREAMID
+					});		
+				}
+				else if($(this).text() == "Dungeon Master"){
+					window.MB.sendMessage("custom/myVTT/showonlytodmdicestream",{
 						streamid: window.MYSTREAMID
 					});
 				}
 				else{
-					window.MB.sendMessage("custom/myVTT/revealmydicestream",{
+					window.MB.sendMessage("custom/myVTT/hidemydicestream",{
 						streamid: window.MYSTREAMID
 					});
 				}
@@ -499,9 +518,10 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 		} 
 	}
 	else {
+		$(`.stream-dice-button`).html("Join Dice Stream");
 		window.JOINTHEDICESTREAM = false;
 		$("[id^='streamer-']").remove();
-		window.MB.sendMessage("custom/myVTT/turnoffdicestream", {
+		window.MB.sendMessage("custom/myVTT/turnoffsingledicestream", {
 			from: window.MYSTREAMID
 		})
 		for (let peer in window.STREAMPEERS) {

--- a/Settings.js
+++ b/Settings.js
@@ -438,10 +438,9 @@ function redraw_settings_panel_token_examples() {
 function enable_dice_streaming_feature(enabled){
 	if(enabled)
 	{
-		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
-		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
+
 		$(".stream-dice-button").remove();
-		$(".dice-toolbar__dropdown-top").prepend($(`<div class='dice-die-button stream-dice-button' style='color:#ddd;font-weight:700;'>Join Dice Stream</div>`));
+		$(".glc-game-log>[class*='Container-Flex']").append($(`<div  id="stream_dice"><div class='stream-dice-button'>Dice Stream Disabled</div></div>`));
 		$(".stream-dice-button").off().on("click", function(){
 			if(window.JOINTHEDICESTREAM){
 				update_dice_streaming_feature(false);
@@ -467,10 +466,10 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 		
 
 	if (enabled == true) {
-		$(`.stream-dice-button`).html("Leave Dice Stream");
 		// STREAMING STUFF
 		window.JOINTHEDICESTREAM = true;
-		$('.stream-dice-button').html("Leave Dice Stream");
+		$('.stream-dice-button').html("Dice Stream Enabled");
+		$('.stream-dice-button').toggleClass("enabled", true);
 		$("[role='presentation'] [role='menuitem']").each(function(){
 			$(this).off().on("click", function(){
 				if($(this).text() == "Everyone") {
@@ -518,8 +517,9 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 		} 
 	}
 	else {
-		$(`.stream-dice-button`).html("Join Dice Stream");
+		$(`.stream-dice-button`).html("Dice Stream Disabled");
 		window.JOINTHEDICESTREAM = false;
+		$('.stream-dice-button').toggleClass("enabled", false);
 		$("[id^='streamer-']").remove();
 		window.MB.sendMessage("custom/myVTT/turnoffsingledicestream", {
 			from: window.MYSTREAMID

--- a/Settings.js
+++ b/Settings.js
@@ -323,7 +323,10 @@ function init_settings(){
 		let inputWrapper = build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
 			console.log(`experimental setting ${name} is now ${newValue}`);
 			if (name === "streamDiceRolls") {
-				update_dice_streaming_feature(newValue)
+				update_dice_streaming_feature(newValue);
+				if(newValue == true) {
+					window.MB.sendMessage("custom/myVTT/updatedicestreamingfeature");
+				}
 			} else {
 				window.EXPERIMENTAL_SETTINGS[setting.name] = newValue;
 				persist_experimental_settings(window.EXPERIMENTAL_SETTINGS);
@@ -450,8 +453,8 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 			});
 		});
 
-		window.MB.sendMessage("custom/myVTT/updatedicestreamingfeature")
-				// DICE STREAMING ?!?!
+
+		// DICE STREAMING ?!?!
 		let diceRollPanel = $(".dice-rolling-panel__container");
 		if (diceRollPanel.length > 0) {
 			window.MYMEDIASTREAM = diceRollPanel[0].captureStream(30);
@@ -469,7 +472,9 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 					});
 				}		
 			}, 1500)
-				
+			window.MB.sendMessage("custom/myVTT/wannaseemydicecollection", {
+				from: window.MYSTREAMID
+			})	
 		} 
 	}
 	else {

--- a/Settings.js
+++ b/Settings.js
@@ -467,26 +467,16 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 					window.MB.sendMessage("custom/myVTT/hidemydicestream",{
 						streamid: window.MYSTREAMID
 					});
-				}
-				else{
-					window.MB.sendMessage("custom/myVTT/revealmydicestream",{
-						streamid: window.MYSTREAMID
-					});
 				}		
 			}, 1500)
 				
-		}
-
+		} 
 	}
 	else {
-		window.JOINTHEDICESTREAM = false;
-		for (let i in window.STREAMPEERS) {
-			window.STREAMPEERS[i].close();
-			delete window.STREAMPEERS[i];
-		}
-	$(".streamer-canvas").remove();
-	window.MB.sendMessage("custom/myVTT/turnoffdicestream")
+		$("[id^='streamer-']").remove();
+		window.MB.sendMessage("custom/myVTT/turnoffdicestream")
 	}
+
 }
 
 function persist_token_settings(settings){

--- a/Settings.js
+++ b/Settings.js
@@ -320,6 +320,7 @@ function init_settings(){
 		if (currentValue === undefined && setting.defaultValue !== undefined) {
 			currentValue = setting.defaultValue;
 		}
+
 		let inputWrapper = build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
 			console.log(`experimental setting ${name} is now ${newValue}`);
 			if (name === "streamDiceRolls") {
@@ -438,8 +439,8 @@ function redraw_settings_panel_token_examples() {
 function enable_dice_streaming_feature(enabled){
 	if(enabled)
 	{
-
-		$(".stream-dice-button").remove();
+		if($(".stream-dice-button").length>0)
+			return;
 		$(".glc-game-log>[class*='Container-Flex']").append($(`<div  id="stream_dice"><div class='stream-dice-button'>Dice Stream Disabled</div></div>`));
 		$(".stream-dice-button").off().on("click", function(){
 			if(window.JOINTHEDICESTREAM){
@@ -503,7 +504,12 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 				window.STREAMPEERS[i].getSenders()[0].replaceTrack(window.MYMEDIASTREAM.getVideoTracks()[0]);
 			}
 			setTimeout(function(){
-				if(sendToText != "Everyone") {
+				if(sendToText == "Dungeon Master"){
+					window.MB.sendMessage("custom/myVTT/showonlytodmdicestream",{
+						streamid: window.MYSTREAMID
+					});
+				}
+				else{
 					window.MB.sendMessage("custom/myVTT/hidemydicestream",{
 						streamid: window.MYSTREAMID
 					});
@@ -522,6 +528,7 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 		$('.stream-dice-button').toggleClass("enabled", false);
 		$("[id^='streamer-']").remove();
 		window.MB.sendMessage("custom/myVTT/turnoffsingledicestream", {
+			to: "everyone",
 			from: window.MYSTREAMID
 		})
 		for (let peer in window.STREAMPEERS) {

--- a/Settings.js
+++ b/Settings.js
@@ -430,12 +430,27 @@ function redraw_settings_panel_token_examples() {
 	}
 }
 
-function update_dice_streaming_feature(enabled) {
+function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text()) {
 	// this essentially does what the button used to do, but I could never get it to work before and I still can't. Hopefully someone that understands it will fix it.
 	if (enabled == true) {
 		// STREAMING STUFF
 		window.JOINTHEDICESTREAM = true;
-		window.MB.sendMessage("custom/myVTT/updatedicestreamingfeature");
+		$("[role='presentation'] [role='menuitem']").each(function(){
+			$(this).off().on("click", function(){
+				if($(this).text() != "Everyone") {
+					window.MB.sendMessage("custom/myVTT/hidemydicestream",{
+						streamid: window.MYSTREAMID
+					});
+				}
+				else{
+					window.MB.sendMessage("custom/myVTT/revealmydicestream",{
+						streamid: window.MYSTREAMID
+					});
+				}
+			});
+		});
+
+		window.MB.sendMessage("custom/myVTT/updatedicestreamingfeature")
 				// DICE STREAMING ?!?!
 		let diceRollPanel = $(".dice-rolling-panel__container");
 		if (diceRollPanel.length > 0) {
@@ -447,14 +462,27 @@ function update_dice_streaming_feature(enabled) {
 				console.log("replacing the track")
 				window.STREAMPEERS[i].getSenders()[0].replaceTrack(window.MYMEDIASTREAM.getVideoTracks()[0]);
 			}
-		}
-	} else {
-		window.JOINTHEDICESTREAM = false;
-		for (let i in window.STREAMPEERS) {
-			window.STREAMPEERS[i].close();
-			delete window.STREAMPEERS[i];
-		}
+			setTimeout(function(){
+				if(sendToText != "Everyone") {
+					window.MB.sendMessage("custom/myVTT/hidemydicestream",{
+						streamid: window.MYSTREAMID
+					});
+				}
+				else{
+					window.MB.sendMessage("custom/myVTT/revealmydicestream",{
+						streamid: window.MYSTREAMID
+					});
+				}		
+			}, 1500)
+				
+		} else {
+			window.JOINTHEDICESTREAM = false;
+			for (let i in window.STREAMPEERS) {
+				window.STREAMPEERS[i].close();
+				delete window.STREAMPEERS[i];
+			}
 		$(".streamer-canvas").remove();
+		}
 	}
 
 }

--- a/Settings.js
+++ b/Settings.js
@@ -471,10 +471,12 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 						streamid: window.MYSTREAMID
 					});
 				}		
-			}, 1500)
-			window.MB.sendMessage("custom/myVTT/wannaseemydicecollection", {
-				from: window.MYSTREAMID
-			})	
+			}, 12000)
+			setTimeout(function(){
+				window.MB.sendMessage("custom/myVTT/wannaseemydicecollection", {
+					from: window.MYSTREAMID
+				})
+			}, 7000);
 		} 
 	}
 	else {

--- a/Settings.js
+++ b/Settings.js
@@ -436,6 +436,20 @@ function redraw_settings_panel_token_examples() {
 function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text()) {
 	// this essentially does what the button used to do, but I could never get it to work before and I still can't. Hopefully someone that understands it will fix it.
 	if (enabled == true) {
+		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
+		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
+		$(".stream-dice-button").remove();
+		$(".dice-toolbar__dropdown-top").prepend($(`<div class='dice-die-button stream-dice-button' style='color:#ddd;font-weight:700;'>Leave Dice Stream</div>`));
+		$(".stream-dice-button").off().on("click", function(){
+			if(window.JOINTHEDICESTREAM){
+				update_dice_streaming_feature(false);
+				$('.stream-dice-button').html("Join Dice Stream");
+			}
+			else {
+				update_dice_streaming_feature(true);
+				$('.stream-dice-button').html("Leave Dice Stream");
+			}
+		})
 		// STREAMING STUFF
 		window.JOINTHEDICESTREAM = true;
 		$("[role='presentation'] [role='menuitem']").each(function(){
@@ -480,8 +494,15 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 		} 
 	}
 	else {
+		window.JOINTHEDICESTREAM = false;
 		$("[id^='streamer-']").remove();
-		window.MB.sendMessage("custom/myVTT/turnoffdicestream")
+		window.MB.sendMessage("custom/myVTT/turnoffdicestream", {
+			from: window.MYSTREAMID
+		})
+		for (let peer in window.STREAMPEERS) {
+			window.STREAMPEERS[peer].close();
+			delete window.STREAMPEERS[peer]
+		}
 	}
 
 }

--- a/Settings.js
+++ b/Settings.js
@@ -323,9 +323,9 @@ function init_settings(){
 		let inputWrapper = build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
 			console.log(`experimental setting ${name} is now ${newValue}`);
 			if (name === "streamDiceRolls") {
-				update_dice_streaming_feature(newValue);
+				enable_dice_streaming_feature(newValue);
 				if(newValue == true) {
-					window.MB.sendMessage("custom/myVTT/updatedicestreamingfeature");
+					window.MB.sendMessage("custom/myVTT/enabledicestreamingfeature");
 				}
 			} else {
 				window.EXPERIMENTAL_SETTINGS[setting.name] = newValue;
@@ -433,25 +433,30 @@ function redraw_settings_panel_token_examples() {
 	}
 }
 
-function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text()) {
-	// this essentially does what the button used to do, but I could never get it to work before and I still can't. Hopefully someone that understands it will fix it.
-	if (enabled == true) {
+function enable_dice_streaming_feature(){
 		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
 		$(".dice-rolling-panel>.dice-toolbar .dice-toolbar__dropdown-die").click();
 		$(".stream-dice-button").remove();
-		$(".dice-toolbar__dropdown-top").prepend($(`<div class='dice-die-button stream-dice-button' style='color:#ddd;font-weight:700;'>Leave Dice Stream</div>`));
+		$(".dice-toolbar__dropdown-top").prepend($(`<div class='dice-die-button stream-dice-button' style='color:#ddd;font-weight:700;'>Join Dice Stream</div>`));
 		$(".stream-dice-button").off().on("click", function(){
 			if(window.JOINTHEDICESTREAM){
 				update_dice_streaming_feature(false);
-				$('.stream-dice-button').html("Join Dice Stream");
 			}
 			else {
 				update_dice_streaming_feature(true);
-				$('.stream-dice-button').html("Leave Dice Stream");
 			}
 		})
+}
+
+function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text()) {
+	// this essentially does what the button used to do, but I could never get it to work before and I still can't. Hopefully someone that understands it will fix it.
+		
+
+	if (enabled == true) {
+	
 		// STREAMING STUFF
 		window.JOINTHEDICESTREAM = true;
+		$('.stream-dice-button').html("Leave Dice Stream");
 		$("[role='presentation'] [role='menuitem']").each(function(){
 			$(this).off().on("click", function(){
 				if($(this).text() != "Everyone") {
@@ -485,12 +490,12 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 						streamid: window.MYSTREAMID
 					});
 				}		
-			}, 12000)
+			}, 1000)
 			setTimeout(function(){
 				window.MB.sendMessage("custom/myVTT/wannaseemydicecollection", {
 					from: window.MYSTREAMID
 				})
-			}, 7000);
+			}, 500);
 		} 
 	}
 	else {

--- a/Settings.js
+++ b/Settings.js
@@ -433,22 +433,30 @@ function redraw_settings_panel_token_examples() {
 function update_dice_streaming_feature(enabled) {
 	// this essentially does what the button used to do, but I could never get it to work before and I still can't. Hopefully someone that understands it will fix it.
 	if (enabled == true) {
+		// STREAMING STUFF
 		window.JOINTHEDICESTREAM = true;
+		window.MB.sendMessage("custom/myVTT/updatedicestreamingfeature");
+				// DICE STREAMING ?!?!
+		let diceRollPanel = $(".dice-rolling-panel__container");
+		if (diceRollPanel.length > 0) {
+			window.MYMEDIASTREAM = diceRollPanel[0].captureStream(30);
+		}
+		if (window.JOINTHEDICESTREAM) {
+			// we should tear down and reconnect
+			for (let i in window.STREAMPEERS) {
+				console.log("replacing the track")
+				window.STREAMPEERS[i].getSenders()[0].replaceTrack(window.MYMEDIASTREAM.getVideoTracks()[0]);
+			}
+		}
 	} else {
-		window.JOINTHEDICESTREAM = false;
-	}
-
-	if (window.JOINTHEDICESTREAM) {
 		window.JOINTHEDICESTREAM = false;
 		for (let i in window.STREAMPEERS) {
 			window.STREAMPEERS[i].close();
 			delete window.STREAMPEERS[i];
 		}
 		$(".streamer-canvas").remove();
-	} else {
-		window.JOINTHEDICESTREAM = true;
-		window.MB.sendMessage("custom/myVTT/wannaseemydicecollection", { from: window.MYSTREAMID });
 	}
+
 }
 
 function persist_token_settings(settings){

--- a/Settings.js
+++ b/Settings.js
@@ -475,16 +475,18 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 				}		
 			}, 1500)
 				
-		} else {
-			window.JOINTHEDICESTREAM = false;
-			for (let i in window.STREAMPEERS) {
-				window.STREAMPEERS[i].close();
-				delete window.STREAMPEERS[i];
-			}
-		$(".streamer-canvas").remove();
 		}
-	}
 
+	}
+	else {
+		window.JOINTHEDICESTREAM = false;
+		for (let i in window.STREAMPEERS) {
+			window.STREAMPEERS[i].close();
+			delete window.STREAMPEERS[i];
+		}
+	$(".streamer-canvas").remove();
+	window.MB.sendMessage("custom/myVTT/turnoffdicestream")
+	}
 }
 
 function persist_token_settings(settings){

--- a/Settings.js
+++ b/Settings.js
@@ -302,8 +302,8 @@ function init_settings(){
 		experimental_features.push({
 			name: 'streamDiceRolls',
 			label: 'Stream Dice Rolls',
-			enabledDescription: `You can currently see player's DDB dice rolling visuals. Disclaimer: currently shows dice in low resolution in the first few rolls, then it gets better.`,
-			disabledDescription: `SHARE/SEE player's DDB dice rolling visuals. Disclaimer: currently shows dice in low resolution in the first few rolls, then it gets better.`
+			enabledDescription: `You and your players can find the button to join the dice stream in the game log in the top right corner. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`,
+			disabledDescription: `This will enable the dice stream feature for everyone. You will all still have to join the dice stream. You and your players can find the button to do this in the game log in the top right corner once this feature is enabled. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`
 		});
 	}
 	body.append(`

--- a/Settings.js
+++ b/Settings.js
@@ -320,7 +320,6 @@ function init_settings(){
 		if (currentValue === undefined && setting.defaultValue !== undefined) {
 			currentValue = setting.defaultValue;
 		}
-
 		let inputWrapper = build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
 			console.log(`experimental setting ${name} is now ${newValue}`);
 			if (name === "streamDiceRolls") {
@@ -462,9 +461,7 @@ function enable_dice_streaming_feature(enabled){
 	}
 }
 
-function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text()) {
-	// this essentially does what the button used to do, but I could never get it to work before and I still can't. Hopefully someone that understands it will fix it.
-		
+function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text()) {		
 
 	if (enabled == true) {
 		// STREAMING STUFF
@@ -498,7 +495,7 @@ function update_dice_streaming_feature(enabled, sendToText=gamelog_send_to_text(
 			window.MYMEDIASTREAM = diceRollPanel[0].captureStream(30);
 		}
 		if (window.JOINTHEDICESTREAM) {
-			// we should tear down and reconnect
+			
 			for (let i in window.STREAMPEERS) {
 				console.log("replacing the track")
 				window.STREAMPEERS[i].getSenders()[0].replaceTrack(window.MYMEDIASTREAM.getVideoTracks()[0]);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3626,13 +3626,40 @@ button.avtt-roll-button {
 }
 
 .stream-dice-button {
-    text-shadow: 1px 0px #000, 0px 1px #000, -1px 0px #000, 0px -1px #000;
-    text-align: center;
-    font-size: 10px;
-    font-weight: 500;
-    color: #ddd;
+        display: flex;
+    border: 1px solid transparent;
+    box-sizing: border-box;
+    border-radius: 2px;
+    text-align: right;
+    position: absolute;
+    width: 88px;
+    top: 11px;
+    left: 250px;
+    height: fit-content;
+    font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 11px;
+    line-height: 13px;
+    -webkit-box-align: center;
+    align-items: center;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: rgb(111, 116, 120);
+    padding: 0px 2px;
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    color: #9c2727;
+    opacity: 0.8;
+}
+.stream-dice-button:hover {
+    cursor: pointer;
+    background: rgb(245, 248, 250);
+    border: 1px solid rgb(206, 217, 224);
 }
 
+.stream-dice-button.enabled{
+    color: #138306;
+}
 .icon-concentration-reminder:before,
 .icon-inspiration:before,
 .icon-flying:before,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3626,7 +3626,7 @@ button.avtt-roll-button {
 }
 
 .stream-dice-button {
-        display: flex;
+    display: flex;
     border: 1px solid transparent;
     box-sizing: border-box;
     border-radius: 2px;
@@ -3658,7 +3658,7 @@ button.avtt-roll-button {
 }
 
 .stream-dice-button.enabled{
-    color: #138306;
+    color: rgb(111, 116, 120);
 }
 .icon-concentration-reminder:before,
 .icon-inspiration:before,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3625,6 +3625,14 @@ button.avtt-roll-button {
     z-index: 40;
 }
 
+.stream-dice-button {
+    text-shadow: 1px 0px #000, 0px 1px #000, -1px 0px #000, 0px -1px #000;
+    text-align: center;
+    font-size: 10px;
+    font-weight: 500;
+    color: #ddd;
+}
+
 .icon-concentration-reminder:before,
 .icon-inspiration:before,
 .icon-flying:before,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3712,3 +3712,7 @@ button.avtt-roll-button {
     0%  {-webkit-transform: rotate(0deg);}
     100% {-webkit-transform: rotate(360deg);}
 }
+
+[id^="streamer-"].hidden {
+    display: none;
+}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3652,6 +3652,9 @@ button.avtt-roll-button {
     color: #9c2727;
     opacity: 0.8;
 }
+.glc-game-log>div>div[class*="-Title"] {
+    margin-bottom: 7px;
+}
 .stream-dice-button:hover {
     cursor: pointer;
     background: rgb(245, 248, 250);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3627,6 +3627,7 @@ button.avtt-roll-button {
 
 .stream-dice-button {
     display: flex;
+    box-shadow: 1px 1px 1px 1px #0003, 1px 2px 0px -2px #0003;
     border: 1px solid transparent;
     box-sizing: border-box;
     border-radius: 2px;
@@ -3647,7 +3648,7 @@ button.avtt-roll-button {
     text-transform: uppercase;
     color: rgb(111, 116, 120);
     padding: 0px 2px;
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     color: #9c2727;
     opacity: 0.8;
 }
@@ -3657,8 +3658,55 @@ button.avtt-roll-button {
     border: 1px solid rgb(206, 217, 224);
 }
 
+.stream-dice-button:hover:after {
+    width: fit-content;
+    height: fit-content;
+    cursor: pointer;
+    background: rgb(245, 248, 250);
+    border: 1px solid rgb(206, 217, 224);
+    visibility: visible;
+}
+
+.stream-dice-button:active {
+  background-color: rgb(245, 248, 250);
+  box-shadow: none;
+  transform: translate(1px, 2px);
+}
+
 .stream-dice-button.enabled{
     color: rgb(111, 116, 120);
+}
+.stream-dice-button:hover:after { 
+    opacity:1;
+    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 500ms, background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;  
+}
+
+.stream-dice-button:after{
+    content: 'Click to join the dice stream';
+    position:fixed;
+    width: fit-content;
+    height: fit-content;
+    background: rgb(245, 248, 250);
+    border: 1px solid rgb(206, 217, 224);
+    top:80px;
+    right:0px;
+    z-index:80000;
+    opacity:0;
+    color: rgb(0 0 0);
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.stream-dice-button.enabled:hover:after {
+    opacity:1;
+    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 500ms, background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;   
+}
+
+.stream-dice-button.enabled:after {
+    content: 'Click to leave the dice stream';
+}
+.stream-dice-button:active:after{
+    display:none;
 }
 .icon-concentration-reminder:before,
 .icon-inspiration:before,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3675,6 +3675,7 @@ button.avtt-roll-button {
 
 .stream-dice-button.enabled{
     color: rgb(111, 116, 120);
+    box-shadow: 1px 1px 1px -1px #0003, 1px 2px 0px -2px #0003;
 }
 .stream-dice-button:hover:after { 
     opacity:1;


### PR DESCRIPTION
There's still a lot wrong with this but thought others could look at it and some wanted to see it. 

This works with firefox now. 

Some of the issues if anyone wants to tackle them - this will probably be pretty slow going for me:

- [x] Add the join button to player view if the DM enabled it before they launched AboveVTT

- [x] Destroying/removing the elements when it's turned off for players. <s>Partially complete. Need to close RTC connections</s>

- [x] Have players join after it's been enabled (? Do we want to leave a way for people not to stream. It'd probably be better to build a disable button on the player side but currently if they join after it's been enabled they won't stream their dice unless it's reset)

- [x] It starts off low resolution but small getting bigger until it's the size of the original roll window. This can result in some dice going off screen if the original window is larger. Not sure there's much we can do about it starting low res as I think this is a WebRTC buffering thing. Dice from firefox clients start larger. I guess it's how the browsers process the video before sending it. Marking this as done unless someone knows a way to do something about this
- [x] Create join/leave stream button once enabled

- [x] <s>Local connections now work for me. Need to check if external connections are a server problem or code adjustments are needed. </s> I think this was a networking issue on my end. I connected to my modem directly and could then connect to my friend. Maybe a fluke not sure.

- [x] <s>The video connection offers sometimes clash. A better way to stagger the calls would be better or a way to determine which should answer the offer. I think this causes the need to toggle it off and back on to force a reconnect currently.  </s>I added politeness logic to determine which client should answer.

<s>Addressing this somewhat I added new servers. They are free to use, can be used in I think all software but also open source projects. The connections seem to be more consistent and I no longer get errors requesting a STUN server (I added on from the same) More info here:

https://www.metered.ca/tools/openrelay/
https://www.metered.ca/tools/openrelay/terms-and-conditions</s>

I switched this to a google server as the aboveVTT turn and the one I found weren't working today externally.

- [x] Contain the dice to screen despite coming from a larger window area

- [x] There's some duplicate elements. 

- [x] The DM rolls to self show. We can either try to find a way to only stream rolls to `everyone` or disable DM stream rolls all together. 

- [x] I'm having some issues getting all the clients to connect to each other. The DM seems to be able to connect to all of them without issue most of the time however the player view seems sporadic with other players. I could use some help with this. I don't know if it's a race condition or the codes in the wrong spot. I've melted my brain on this too much today. Edit: There may be other issues as I tested with someone else and was only able to get this to work locally. Still with some clients getting stuck connecting to each other. I tried a different server that is free just to test and that also didn't work. It's possible the answer is out pacing the offer or ice stuff as well. Or something to do with them both making requests around the same time. NOTE: This might need more tweaking but I got the players connecting to each other now 🥳

I think there's probably more to fix but these are the main ones




