### PR TITLE
Measuring appears when dragging tokens, drop and pick back up before the ruler vanishes to place waypoints

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -54,7 +54,7 @@ class WaypointManagerClass {
 			lineWidth: Math.max(25 * Math.max((1 - window.ZOOM), 0), 5),
 			color: "#f2f2f2",
 			outlineColor: "black",
-			textColor: "#838383",
+			textColor: "black",
 			backgroundColor: "#f2f2f2"
 		}
 	}
@@ -115,7 +115,7 @@ class WaypointManagerClass {
 
 		this.ctx.beginPath();
 		this.ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
-		this.ctx.lineWidth = this.lineWidth
+		this.ctx.lineWidth = this.drawStyle.lineWidth
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.stroke();
 		this.ctx.fillStyle =  this.drawStyle.color
@@ -311,7 +311,7 @@ class WaypointManagerClass {
 		this.ctx.fillText(text, textX, textY);
 		
 		this.drawBobble(snapPointXStart, snapPointYStart);
-		this.drawBobble(snapPointXEnd, snapPointYEnd, Math.max(15 * Math.max((1 - window.ZOOM), 0), 3));
+		this.drawBobble(snapPointXEnd, snapPointYEnd);
 	}
 
 	/**
@@ -858,7 +858,7 @@ function drawing_mousemove(e) {
 	if (window.MOUSEMOVEWAIT) {
 		return;
 	}
-	clear_temp_canvas()
+	
 	var mousex = Math.round(((e.pageX - 200) * (1.0 / window.ZOOM)));
 	var mousey = Math.round(((e.pageY - 200) * (1.0 / window.ZOOM)));
 
@@ -876,6 +876,7 @@ function drawing_mousemove(e) {
 	}, mouseMoveFps);
 
 	if (window.MOUSEDOWN) {
+		clear_temp_canvas()
 		var width = mousex - window.BEGIN_MOUSEX;
 		var height = mousey - window.BEGIN_MOUSEY;
 
@@ -1137,15 +1138,7 @@ function drawing_mouseup(e) {
 		console.log("READY");
 	}
 	if (window.DRAWSHAPE == "measure") {
-
-		setTimeout(function () {
-			// We do not clear if we are still measuring, added this as it somehow appeared multiple
-			// timers could be set, may be a race condition or something still here...
-			if (!WaypointManager.isMeasuring()) {
-				redraw_canvas();
-			}
-		}, 2000);
-		WaypointManager.clearWaypoints();
+		WaypointManager.fadeoutMeasuring()
 	}
 }
 

--- a/Fog.js
+++ b/Fog.js
@@ -55,7 +55,7 @@ class WaypointManagerClass {
 			color: "#f2f2f2",
 			outlineColor: "black",
 			textColor: "black",
-			backgroundColor: "#f2f2f2"
+			backgroundColor: "rgba(255, 255, 255, 0.7)"
 		}
 	}
 	/**
@@ -70,7 +70,7 @@ class WaypointManagerClass {
 			color: "#f2f2f2",
 			outlineColor: "black",
 			textColor: "black",
-			backgroundColor: "#f2f2f2"
+			backgroundColor: "rgba(255, 255, 255, 0.7)"
 		}
 	}
 
@@ -299,9 +299,7 @@ class WaypointManagerClass {
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.fillStyle = this.drawStyle.backgroundColor
 		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0), 3));
-		this.ctx.globalAlpha = 0.6
 		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, true);
-		this.ctx.globalAlpha = 1
 		// draw the outline of the text box
 		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, false, true);
 
@@ -335,6 +333,7 @@ class WaypointManagerClass {
 			self.draw(false)
 			alpha = alpha - 0.2;
 			if (alpha <= 0.0){
+				self.cancelFadeout()
 				self.clearWaypoints();
 				clear_temp_canvas()
 			}
@@ -342,7 +341,7 @@ class WaypointManagerClass {
 	}
 
 	/**
-	 * clears the interval if available and sets opacity back to 100%
+	 * 
 	 */
 	cancelFadeout(){
 		if (this.timerId !== undefined){
@@ -760,10 +759,13 @@ function stop_drawing() {
 }
 
 function drawing_mousedown(e) {
+	// perform some cleanup of the canvas/objects
 	clear_temp_canvas()
-	if (!e.buttons === 2){
+	WaypointManager.cancelFadeout()
+	if(e.button !== 2){
 		WaypointManager.clearWaypoints()
 	}
+
 	WaypointManager.resetDefaultDrawStyle()
 	window.LINEWIDTH = $("#draw_line_width").val();
 	window.DRAWTYPE = $(".drawTypeSelected ").attr('data-value');

--- a/Fog.js
+++ b/Fog.js
@@ -281,6 +281,45 @@ class WaypointManagerClass {
 		this.drawBobble(snapPointXStart, snapPointYStart);
 		this.drawBobble(snapPointXEnd, snapPointYEnd, Math.max(15 * Math.max((1 - window.ZOOM), 0), 3));
 	}
+
+	/**
+	 * redraws the waypoints using various levels of opacity until completely clear
+	 * then removes all waypoints and resets canvas opacity
+	 */
+	 fadeoutMeasuring(){
+		let alpha = 1.0
+		const self = this
+		// only ever allow a single fadeout to occur
+		// this stops weird flashing behaviour with interacting
+		// interval function calls
+		if (this.timerId){
+			return
+		}
+		this.timerId = setInterval(function(){ fadeout() }, 100);
+
+		function fadeout(){
+			self.ctx.clearRect(0,0, self.canvas.width, self.canvas.height);
+			self.ctx.globalAlpha = alpha;
+			self.draw(false)
+			alpha = alpha - 0.2;
+			if (alpha <= 0.0){
+				self.cancelFadeout()
+				self.clearWaypoints();
+			}
+		}
+	}
+
+	/**
+	 * 
+	 */
+	cancelFadeout(){
+		if (this.timerId !== undefined){
+			clearInterval(this.timerId);
+			this.ctx.globalAlpha = 1.0
+			this.timerId = undefined
+
+		}	
+	}
 };
 
 
@@ -481,6 +520,9 @@ function draw_wizarding_box() {
 }
 
 function reset_canvas() {
+	$('#temp_overlay').get(0).width =($("#scene_map").width());
+	$('#temp_overlay').get(0).height =($("#scene_map").width());
+
 	$('#fog_overlay').width($("#scene_map").width());
 	$('#fog_overlay').height($("#scene_map").height());
 
@@ -686,7 +728,8 @@ function stop_drawing() {
 }
 
 function drawing_mousedown(e) {
-
+	clear_temp_canvas()
+	WaypointManager.cancelFadeout()
 	window.LINEWIDTH = $("#draw_line_width").val();
 	window.DRAWTYPE = $(".drawTypeSelected ").attr('data-value');
 	window.DRAWCOLOR = $(".colorselected").css('background-color');
@@ -1457,6 +1500,12 @@ function drawPolygon (
 	{
 		ctx.fill();
 	}
+}
+
+function clear_temp_canvas(){
+	const canvas = document.getElementById("temp_overlay");
+	const context = canvas.getContext("2d");
+	context.clearRect(0, 0, canvas.width, canvas.height);
 }
 
 function savePolygon(e) {

--- a/Main.js
+++ b/Main.js
@@ -2191,6 +2191,12 @@ function init_ui() {
 	fog.css("position", "absolute");
 	fog.css("z-index", "20");
 
+	temp_overlay = $("<canvas id='temp_overlay'></canvas>");
+	temp_overlay.css("position", "absolute");
+	temp_overlay.css("top", "0");
+	temp_overlay.css("left", "0");
+	temp_overlay.css("z-index", "25");
+
 
 	fog.dblclick(function(e) {
 		e.preventDefault();
@@ -2247,6 +2253,7 @@ function init_ui() {
 	VTT.append(fog);
 	VTT.append(grid);
 	VTT.append(draw_overlay);
+	VTT.append(temp_overlay);
 
 	wrapper = $("<div id='VTTWRAPPER'/>");
 	wrapper.css("margin-left", "200px");

--- a/Token.js
+++ b/Token.js
@@ -1238,11 +1238,7 @@ class Token {
 						// finish measuring
 						// drop the temp overlay back down so selection works correctly
 						$("#temp_overlay").css("z-index", "25")
-						const canvas = document.getElementById("temp_overlay");
-						const context = canvas.getContext("2d");
-						WaypointManager.setCanvas(canvas);
 						WaypointManager.fadeoutMeasuring()
-						
 					},
 
 				start: function (event) {

--- a/Token.js
+++ b/Token.js
@@ -1301,23 +1301,9 @@ class Token {
 					window.BEGIN_MOUSEX = mousex
 					window.BEGIN_MOUSEY = mousey
 					if (!self.options.disableborder){
-						// strip out alpha and cap dark desaturated colours
-						let color = $(tok).css("--token-border-color")
-						const valueRegex = /(\d+\.\d+|\d+)/g
-						const match = color.match(valueRegex)
-						let [r,g,b] = match
-						if (r < 50 && g < 50 && b < 50 && !color.includes("#")){
-							r = 50
-							g = 50
-							b = 50
-							color = `rgb(${r}, ${g}, ${b})`
-						}else if (match && !color.includes("#")){
-							color = `rgb(${r}, ${g}, ${b})`
-						}
-						
-						WaypointManager.drawStyle.color = color
+						WaypointManager.drawStyle.color = $(tok).css("--token-border-color")
 					}else{
-						WaypointManager.resetDrawStyle()
+						WaypointManager.resetDefaultDrawStyle()
 					}
 					
 
@@ -1346,8 +1332,8 @@ class Token {
 					// incase we click while on select, remove any line dashes
 					context.setLineDash([])
 					// list the temp overlay so we can see the ruler
-					$("#temp_overlay").css("z-index", "50")
 					clear_temp_canvas()
+					$("#temp_overlay").css("z-index", "50")
 					WaypointManager.setCanvas(canvas);
 					WaypointManager.registerMouseMove(mousex, mousey);
 					WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey);

--- a/Token.js
+++ b/Token.js
@@ -1234,6 +1234,14 @@ class Token {
 
 						draw_selected_token_bounding_box();
 						window.toggleSnap=false;
+
+						// finish measuring
+						// drop the temp overlay back down so selection works correctly
+						$("#temp_overlay").css("z-index", "25")
+						const canvas = document.getElementById("temp_overlay");
+						const context = canvas.getContext("2d");
+						WaypointManager.setCanvas(canvas);
+						WaypointManager.fadeoutMeasuring()
 					},
 
 				start: function (event) {
@@ -1281,10 +1289,15 @@ class Token {
 					}
 
 					// Setup waypoint manager
+					const mousex = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM)));
+					const mousey = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM)));
 
-
-					window.BEGIN_MOUSEX = (event.pageX - 200) * (1.0 / window.ZOOM);
-					window.BEGIN_MOUSEY = (event.pageY - 200) * (1.0 / window.ZOOM);
+					WaypointManager.cancelFadeout()
+					if(WaypointManager.numWaypoints > 0){
+						WaypointManager.checkNewWaypoint(mousex, mousey)
+					}
+					window.BEGIN_MOUSEX = mousex
+					window.BEGIN_MOUSEY = mousey
 
 					remove_selected_token_bounding_box();
 				},
@@ -1297,6 +1310,24 @@ class Token {
 						left: Math.round((event.clientX - click.x + original.left) / zoom),
 						top: Math.round((event.clientY - click.y + original.top) / zoom)
 					};
+
+
+					const mousex = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM)));
+					const mousey = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM)));
+
+					const canvas = document.getElementById("temp_overlay");
+					const context = canvas.getContext("2d");
+					// incase we click while on select, remove any line dashes
+					context.setLineDash([])
+					// list the temp overlay so we can see the ruler
+					$("#temp_overlay").css("z-index", "50")
+					clear_temp_canvas()
+					WaypointManager.setCanvas(canvas);
+					WaypointManager.registerMouseMove(mousex, mousey);
+					WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mousex, mousey);
+					WaypointManager.draw(false);
+					console.log(WaypointManager)
+					context.fillStyle = '#f50';
 					//console.log("Changing to " +ui.position.left+ " "+ui.position.top);
 					// HACK TEST 
 					/*$(event.target).css("left",ui.position.left);

--- a/Token.js
+++ b/Token.js
@@ -1242,6 +1242,7 @@ class Token {
 						const context = canvas.getContext("2d");
 						WaypointManager.setCanvas(canvas);
 						WaypointManager.fadeoutMeasuring()
+						
 					},
 
 				start: function (event) {
@@ -1299,6 +1300,26 @@ class Token {
 					}
 					window.BEGIN_MOUSEX = mousex
 					window.BEGIN_MOUSEY = mousey
+					if (!self.options.disableborder){
+						// strip out alpha and cap dark desaturated colours
+						let color = $(tok).css("--token-border-color")
+						const valueRegex = /(\d+\.\d+|\d+)/g
+						const match = color.match(valueRegex)
+						let [r,g,b] = match
+						if (r < 50 && g < 50 && b < 50 && !color.includes("#")){
+							r = 50
+							g = 50
+							b = 50
+							color = `rgb(${r}, ${g}, ${b})`
+						}else if (match && !color.includes("#")){
+							color = `rgb(${r}, ${g}, ${b})`
+						}
+						
+						WaypointManager.drawStyle.color = color
+					}else{
+						WaypointManager.resetDrawStyle()
+					}
+					
 
 					remove_selected_token_bounding_box();
 				},


### PR DESCRIPTION
- Moving a token automatically applies a ruler
- Waypoints can be created by dropping and picking it back up within the fadeout time of the ruler
- Ruler styling is applied based on token border color
- Measuring normally also uses the same fadeout, but the waypoints are created in the previous way of using RMB
- Tokens and their ruler snap to grid as you move if snapping is enabled, or if CTRL isn't pressed (ty @vlaminck)

 