### PR TITLE
update error message when map fails to load

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -240,8 +240,21 @@ function getPlayerIDFromSheet(sheet_url)
 
 window.YTTIMEOUT = null;
 
-function map_load_error_cb() {
-	alert("Map could not be loaded - if you're using Drive or similar, ensure sharing is enabled");
+function map_load_error_cb(e) {
+	console.log(e);
+	let src = e.currentTarget.getAttribute("src");
+	console.error("map_load_error_cb src", src, e);
+	if (typeof src === "string") {
+		let specificMessage = `Please make sure the image is accessible to anyone on the internet.`;
+		if (src.includes("drive.google")) {
+			specificMessage = `It looks like you're using a Google Drive image. Please make sure the "Get link" modal says "Anyone on the internet with this link can view".`;
+		}
+		if (confirm(`Map could not be loaded!\n${specificMessage}\nYou may also need to disable ad blockers.\nWould you like to try loading the image in a separate tab to verify that it's accessible? If you are currently logged in to google, you will need to log out or open the image in a different browser or an incognito window to truly test it.`)) {
+			if (window.DM || confirm(`SPOILER ALERT!!!\nIf you click OK, you might see the entire map without fog of war. However, the map isn't loading at all so you will probably see a broken link. Are you sure you want to test this image?`)) {
+				window.open(src, '_blank');
+			}
+		}
+	}
 }
 
 /// the first time we load, an overlay is shown to mask all the window modifications we do. This removes it. See `Load.js` for the injection of the overlay.


### PR DESCRIPTION
This updates the error message with more debugging messaging, as well as allows the user to open the image in a new tab. If the user is not the DM, it prompts again with a "SPOILER ALERT!" message since they might open the image without any fog of war. However, the map won't load so it's unlikely to load in a new tab either.

Here's a non-public gdrive link to test with `https://drive.google.com/file/d/1rboAWxZpr0SUlRp2MR5pd_EHAISgR-0z/view?usp=sharing`

<img width="456" alt="Screen Shot 2022-05-24 at 9 17 50 PM" src="https://user-images.githubusercontent.com/584771/170165750-6b1ec057-bc76-4d69-bc91-8ffe5825b4ba.png">
<img width="381" alt="Screen Shot 2022-05-24 at 9 18 18 PM" src="https://user-images.githubusercontent.com/584771/170165758-01501767-7309-407b-b8ac-85abc28abcd6.png">

