### PR TITLE
Fixes: Close context menu when opening character sheets as DM. If a frame is open the context menu should now close properly when clicking on the frame.

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -149,7 +149,7 @@ function init_combat_tracker(){
 				next=$("#combat_area tr").first()
 			}
 			next.attr('data-current','1');
-			if($(".iframe-encounter-combat-tracker").css("z-index")>9999) {
+			if($("#resizeDragMon:not(.hideMon)").length>0) {
 				$("[data-current][data-monster] button.openSheetCombatButton").click();
 			}
 		}

--- a/Main.js
+++ b/Main.js
@@ -564,11 +564,13 @@ function load_monster_stat(monsterid, token_id) {
 	});
 	
 	/*Set draggable and resizeable on monster sheets for players. Allow dragging and resizing through iFrames by covering them to avoid mouse interaction*/
-	const monster_close_title_button=$('<div id="monster_close_title_button"><svg class="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><g transform="rotate(-45 50 50)"><rect></rect></g><g transform="rotate(45 50 50)"><rect></rect></g></svg></div>')
-	$("#resizeDragMon").append(monster_close_title_button);
-	monster_close_title_button.click(function() {
-		close_player_monster_stat_block()
-	});
+	if($("#monster_close_title_button").length==0){
+		const monster_close_title_button=$('<div id="monster_close_title_button"><svg class="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><g transform="rotate(-45 50 50)"><rect></rect></g><g transform="rotate(45 50 50)"><rect></rect></g></svg></div>')
+		$("#resizeDragMon").append(monster_close_title_button);
+		monster_close_title_button.click(function() {
+			close_player_monster_stat_block()
+		});
+	}
 	$("#resizeDragMon").addClass("moveableWindow");
 	if(!$("#resizeDragMon").hasClass("minimized")){
 		$("#resizeDragMon").addClass("restored");

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -126,6 +126,7 @@ function token_context_menu_expanded(tokenIds, e) {
 			let button = $(`<button>Open Character Sheet<span class="material-icons icon-view"></span></button>`);
 			button.on("click", function() {
 				open_player_sheet(token.options.id);
+				$("#tokenOptionsClickCloseDiv").click();
 			});
 			body.append(button);
 		} else if (token.isMonster()) {
@@ -331,9 +332,6 @@ function token_context_menu_expanded(tokenIds, e) {
 			}
 		});
 	
-	$("#tokenOptionsPopup").mousedown(function() {
-		frame_z_index_when_click($(this));
-	});
 
 	moveableTokenOptions.css("left", Math.max(e.clientX - 230, 0) + 'px');
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -158,6 +158,7 @@ function token_context_menu_expanded(tokenIds, e) {
 			let button = $(`<button>Open Character Sheet<span class="material-icons icon-view"></span></button>`);
 			button.on("click", function() {
 				open_player_sheet(token.options.id);
+				$("#tokenOptionsClickCloseDiv").click();
 			});
 			body.append(button);
 		} else if (token.isMonster()) {
@@ -329,10 +330,6 @@ function token_context_menu_expanded(tokenIds, e) {
 
 			}
 		});
-	
-	$("#tokenOptionsPopup").mousedown(function() {
-		frame_z_index_when_click($(this));
-	});
 
 	moveableTokenOptions.css("left", Math.max(e.clientX - 245, 0) + 'px');
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -118,39 +118,7 @@ function token_context_menu_expanded(tokenIds, e) {
 	$('body').append(tokenOptionsClickCloseDiv);
 
 	// stat block / character sheet
-	let toTopMenuButton = $("<button class='material-icons to-top'>Move to Top</button>");
-	let toBottomMenuButton = $("<button class='material-icons to-bottom'>Move to Bottom</button>")
 
-	if(window.DM || (tokens.length == 1 && (tokens[0].isPlayer() || (tokens[0].options.player_owned && !tokens[0].isPlayer())))) {
-		body.append(toTopMenuButton);
-		body.append(toBottomMenuButton);
-
-		toTopMenuButton.off().on("click", function(tokenIds){
-			tokens.forEach(token => {
-				$(".token").each(function(){	
-					let tokenId = $(this).attr('data-id');	
-					let tokenzindexdiff = window.TOKEN_OBJECTS[tokenId].options.zindexdiff;
-					if (tokenzindexdiff >= window.TOKEN_OBJECTS[token.options.id].options.zindexdiff && tokenId != token.options.id) {
-						window.TOKEN_OBJECTS[token.options.id].options.zindexdiff = tokenzindexdiff + 1;
-					}		
-				});
-				token.place_sync_persist();
-			});
-		});
-
-		toBottomMenuButton.off().on("click", function(tokenIds){
-			tokens.forEach(token => {			
-				$(".token").each(function(){	
-					let tokenId = $(this).attr('data-id');	
-					let tokenzindexdiff = window.TOKEN_OBJECTS[tokenId].options.zindexdiff;
-					if (tokenzindexdiff <= window.TOKEN_OBJECTS[token.options.id].options.zindexdiff && tokenId != token.options.id) {
-						window.TOKEN_OBJECTS[token.options.id].options.zindexdiff = Math.max(tokenzindexdiff - 1, -5000);
-					}		
-				});
-				token.place_sync_persist();
-			});
-		});
-	}
 
 	if (tokens.length === 1) {
 		let token = tokens[0];
@@ -158,7 +126,6 @@ function token_context_menu_expanded(tokenIds, e) {
 			let button = $(`<button>Open Character Sheet<span class="material-icons icon-view"></span></button>`);
 			button.on("click", function() {
 				open_player_sheet(token.options.id);
-				$("#tokenOptionsClickCloseDiv").click();
 			});
 			body.append(button);
 		} else if (token.isMonster()) {
@@ -221,7 +188,40 @@ function token_context_menu_expanded(tokenIds, e) {
 		});
 		body.append(hiddenMenuButton);
 	}
-	
+
+	let toTopMenuButton = $("<button class='material-icons to-top'>Move to Top</button>");
+	let toBottomMenuButton = $("<button class='material-icons to-bottom'>Move to Bottom</button>")
+
+	if(window.DM || (tokens.length == 1 && (tokens[0].isPlayer() || (tokens[0].options.player_owned && !tokens[0].isPlayer())))) {
+		body.append(toTopMenuButton);
+		body.append(toBottomMenuButton);
+
+		toTopMenuButton.off().on("click", function(tokenIds){
+			tokens.forEach(token => {
+				$(".token").each(function(){	
+					let tokenId = $(this).attr('data-id');	
+					let tokenzindexdiff = window.TOKEN_OBJECTS[tokenId].options.zindexdiff;
+					if (tokenzindexdiff >= window.TOKEN_OBJECTS[token.options.id].options.zindexdiff && tokenId != token.options.id) {
+						window.TOKEN_OBJECTS[token.options.id].options.zindexdiff = tokenzindexdiff + 1;
+					}		
+				});
+				token.place_sync_persist();
+			});
+		});
+
+		toBottomMenuButton.off().on("click", function(tokenIds){
+			tokens.forEach(token => {			
+				$(".token").each(function(){	
+					let tokenId = $(this).attr('data-id');	
+					let tokenzindexdiff = window.TOKEN_OBJECTS[tokenId].options.zindexdiff;
+					if (tokenzindexdiff <= window.TOKEN_OBJECTS[token.options.id].options.zindexdiff && tokenId != token.options.id) {
+						window.TOKEN_OBJECTS[token.options.id].options.zindexdiff = Math.max(tokenzindexdiff - 1, -5000);
+					}		
+				});
+				token.place_sync_persist();
+			});
+		});
+	}
 
 	if (tokens.length === 1) {
 		body.append(build_menu_stat_inputs(tokenIds));
@@ -330,14 +330,18 @@ function token_context_menu_expanded(tokenIds, e) {
 
 			}
 		});
+	
+	$("#tokenOptionsPopup").mousedown(function() {
+		frame_z_index_when_click($(this));
+	});
 
-	moveableTokenOptions.css("left", Math.max(e.clientX - 245, 0) + 'px');
+	moveableTokenOptions.css("left", Math.max(e.clientX - 230, 0) + 'px');
 
 	if($(moveableTokenOptions).height() + e.clientY > window.innerHeight - 20) {
 		moveableTokenOptions.css("top", (window.innerHeight - $(moveableTokenOptions).height() - 20 + 'px'));
 	}
 	else {
-		moveableTokenOptions.css("top", e.clientY + 'px');
+		moveableTokenOptions.css("top", e.clientY - 10 + 'px');
 	}	
 }
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -393,7 +393,7 @@ ul.context-menu-list.context-menu-root{
     height:  100vh;
     width:  100vw;
     display:  block !important;
-    z-index: 1000;
+    z-index: 58000;
     position:  fixed;
     top: 0;
     right: 0;


### PR DESCRIPTION
Closes context menu when opening character sheets as DM.
 If a frame is open the context menu should now close properly when clicking on/over the frame.
 
 I removed the zindex change as we want the context menu always on top. Copy paste carry over. 
 
 Moved the close div above frames.
 
Fix clicking next opening next monster stat block

Fix multiple title close buttons for monster 

Context menu order and positioning adjustments

Example for the last 3 changes discussed in discord today

https://user-images.githubusercontent.com/65363489/170583359-ae2bd971-3ae3-405c-9bb1-a9f39de96aeb.mp4


