### PR TITLE
Fix so borders still show up on "My Tokens" if borders and HP aura are both enabled

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -390,7 +390,7 @@ class Token {
 		let tokenWidth = this.options.size;
 		let tokenHeight = this.options.size;
 			
-		if(tokenData.disableaura) {
+		if(tokenData.disableaura || !tokenData.hp) {
 			token.css('--token-hp-aura-color', 'transparent');
 			token.css('--token-temp-hp', "transparent");
 		} 


### PR DESCRIPTION
Currently when a token from "My Tokens" is spawned in with hp aura's and borders enabled borders don't show due to no hp existing and a non-existent variable.