### PR TITLE
Contain large images in journal window - adjust menu

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -355,9 +355,7 @@ class JournalManager{
 			selector: '#' + tmp,
 			menubar: false,
 			plugins: 'save,hr,image,link,lists,media,paste,tabfocus,textcolor,colorpicker,autoresize',
-			toolbar1: 'undo,|,paste,|,bold,|,italic,|,underline,|,strikethrough,|,blockquote,|,alignleft,|,aligncenter,|,alignright,|,outdent,|,indent,|,bullist,|,numlist',
-			toolbar2: 'forecolor,|,backcolor,|,fontselect,|,fontsizeselect,|,formatselect,|,removeformat,|,hr',
-			toolbar3: 'link,|,unlink,|,image,|,media',
+			toolbar1: 'undo,|,paste,|,bold,|,italic,|,underline,|,strikethrough,|,blockquote,|,alignleft,|,aligncenter,|,alignright,|,outdent,|,indent,|,bullist,|,numlist,|,forecolor,|,backcolor,|,fontselect,|,fontsizeselect,|,formatselect,|,removeformat,|,hr,link,|,unlink,|,image,|,media',
 			image_class_list: [
 				{title: 'None', value: ''},
 				{title: 'Magnify', value: 'magnify'},

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3712,3 +3712,29 @@ button.avtt-roll-button {
     0%  {-webkit-transform: rotate(0deg);}
     100% {-webkit-transform: rotate(360deg);}
 }
+
+div.note[id^="ui-id"] {
+    width: 100% !important;
+    padding: 0px !important;
+    max-height: calc(100% - 33px) !important;
+    overflow: auto;
+}
+
+div.note[id^="ui-id"] .mce-listbox button{
+    padding: 0px;
+}
+
+div.note[id^="ui-id"] .mce-btn button {
+    padding: 1px 4px;
+}
+
+.ui-dialog .ui-dialog-titlebar .ui-dialog-title {
+    line-height: 18px;
+}
+.ui-dialog .ui-dialog-titlebar{
+    height: 32px;
+}
+.ui-widget.ui-widget-content {
+    max-height: calc(100vh - 20px);
+    overflow: hidden;
+}


### PR DESCRIPTION
Ensures for both Player and DM view that the note displayed doesn't leave it's window. 

Also adjusted the mce menu a bit to allow better resizing. The editor should also fill the window.

A small step towards the journal update in #391