### PR TITLE
Fix selection hit box for tall or wide image tokens when scaled

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -431,21 +431,24 @@ class Token {
 		}
 		token.attr("data-border-color", this.options.color);
 		if(!this.options.legacyaspectratio) {
-			debugger;
 			if($(`div.token[data-id='${this.options.id}'] .token-image`)[0] !== undefined){
 				let imageWidth = $(`div.token[data-id='${this.options.id}'] .token-image`)[0].naturalWidth;
 				let imageHeight = $(`div.token[data-id='${this.options.id}'] .token-image`)[0].naturalHeight;
-				if( imageWidth == imageHeight ){
-					token.children('.token-image').css("min-width", tokenWidth + 'px');
-					token.children('.token-image').css("min-height", tokenHeight + 'px');
-				}
-				else if(imageWidth > imageHeight) {
-					token.children('.token-image').css("min-width", tokenWidth + 'px');
-					token.children('img').css("min-height", '');
-				}
-				else {
-					token.children('.token-image').css("min-height", tokenHeight + 'px');
-					token.children('.token-image').css("min-width", '');
+				if(imageWidth != 0 && imageHeight != 0){
+
+					if( imageWidth == imageHeight ){
+						token.children('.token-image').css("min-width", tokenWidth + 'px');
+						token.children('.token-image').css("min-height", tokenHeight + 'px');
+					}
+					else if(imageWidth > imageHeight) {
+						token.children('.token-image').css("min-width", tokenWidth + 'px');
+						token.children('img').css("min-height", '');
+					}
+					else {
+						token.children('.token-image').css("min-height", tokenHeight + 'px');
+						token.children('.token-image').css("min-width", '');
+					}
+									
 				}
 			}
 		}

--- a/Token.js
+++ b/Token.js
@@ -431,15 +431,19 @@ class Token {
 		}
 		token.attr("data-border-color", this.options.color);
 		if(!this.options.legacyaspectratio) {
+			debugger;
 			if(token.children('img').width() == token.children('img').height()){
 				token.children('img').css("min-width", tokenWidth + 'px');
 				token.children('img').css("min-height", tokenHeight + 'px');
+				debugger;
 			}
 			else if(token.children('img').width() > token.children('img').height()) {
 				token.children('img').css("min-width", tokenWidth + 'px');
+				token.children('img').css("min-height", '');
 			}
 			else {
 				token.children('img').css("min-height", tokenHeight + 'px');
+				token.children('img').css("min-width", '');
 			}
 		}
 		else {

--- a/Token.js
+++ b/Token.js
@@ -432,26 +432,29 @@ class Token {
 		token.attr("data-border-color", this.options.color);
 		if(!this.options.legacyaspectratio) {
 			debugger;
-			if(token.children('img').width() == token.children('img').height()){
-				token.children('img').css("min-width", tokenWidth + 'px');
-				token.children('img').css("min-height", tokenHeight + 'px');
-				debugger;
-			}
-			else if(token.children('img').width() > token.children('img').height()) {
-				token.children('img').css("min-width", tokenWidth + 'px');
-				token.children('img').css("min-height", '');
-			}
-			else {
-				token.children('img').css("min-height", tokenHeight + 'px');
-				token.children('img').css("min-width", '');
+			if($(`div.token[data-id='${this.options.id}'] .token-image`)[0] !== undefined){
+				let imageWidth = $(`div.token[data-id='${this.options.id}'] .token-image`)[0].naturalWidth;
+				let imageHeight = $(`div.token[data-id='${this.options.id}'] .token-image`)[0].naturalHeight;
+				if( imageWidth == imageHeight ){
+					token.children('.token-image').css("min-width", tokenWidth + 'px');
+					token.children('.token-image').css("min-height", tokenHeight + 'px');
+				}
+				else if(imageWidth > imageHeight) {
+					token.children('.token-image').css("min-width", tokenWidth + 'px');
+					token.children('img').css("min-height", '');
+				}
+				else {
+					token.children('.token-image').css("min-height", tokenHeight + 'px');
+					token.children('.token-image').css("min-width", '');
+				}
 			}
 		}
 		else {
-			token.children('img').css("min-width", "");
-			token.children('img').css("min-height", "");
+			token.children('.token-image').css("min-width", "");
+			token.children('.token-image').css("min-height", "");
 		}
 		
-		token.children('img').css({		
+		token.children('.token-image').css({		
 		    'max-width': tokenWidth + 'px',
 			'max-height': tokenHeight + 'px',
 		});


### PR DESCRIPTION
This fixes the selections boxes for wide or tall images when scaled outside their token. This was working at some point but I probably broke it in a recent fix for something else. This is a QoL fix since clicking dead air and having a token get selected isn't great. This minimizes that as much as possible again. Fixes #525

![image](https://user-images.githubusercontent.com/65363489/171061856-a15b70df-c0a8-47df-92c7-c3b75758e941.png)

VS

![image](https://user-images.githubusercontent.com/65363489/171061984-8cca7d4d-2ff3-4d6c-947c-4bd8784cfe20.png)
