### PR TITLE
Fix when placing tokens feeling like a performance issue 

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1132,7 +1132,7 @@ class Token {
 			$("#tokens").append(tok);
 			tok.animate({
 				opacity: newopacity
-			}, { duration: 3000, queue: false });
+			}, { duration: 500, queue: false });
 
 
 			let click = {


### PR DESCRIPTION
I feel 500ms is a better feel than 3000 for the fade timer. It feels like a performance issue at 3000 as mentioned by a few people.