### PR TITLE
Fix: darkness preview only if adjusting current map settings

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -287,8 +287,10 @@ function edit_scene_dialog(scene_id) {
 		let darknessFilterRangeValue = parseInt(darknessFilterRange.val());
    	 	let darknessPercent = 100 - darknessFilterRangeValue;
    	 	let lightnessPercent = 100+(darknessFilterRangeValue/5);
-   	 	$('#VTT').css('--darkness-filter', darknessPercent + "%");
-   	 	$('#VTT').css('--light-filter', lightnessPercent + "%");
+   	 	if(window.CURRENT_SCENE_DATA.id == window.ScenesHandler.scenes[scene_id].id) {
+	   	 	$('#VTT').css('--darkness-filter', darknessPercent + "%");
+	   	 	$('#VTT').css('--light-filter', lightnessPercent + "%");
+   		}
 	});
 	darknessFilterRange.on(' mouseup', function(){
    	 	let darknessFilterRangeValue = parseInt(darknessFilterRange.val());


### PR DESCRIPTION
Fixes the darkness preview. It should now only show the preview when on the current map. 