### PR TITLE
Disabled token measuring

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1242,7 +1242,9 @@ class Token {
 						// finish measuring
 						// drop the temp overlay back down so selection works correctly
 						$("#temp_overlay").css("z-index", "25")
-						WaypointManager.fadeoutMeasuring()
+						if (window.ALLOWTOKENMEASURING){
+							WaypointManager.fadeoutMeasuring()
+						}
 					},
 
 				start: function (event) {
@@ -1292,21 +1294,29 @@ class Token {
 						el.attr("data-top", el.css("top").replace("px", ""));
 					}
 
-					// Setup waypoint manager
-					const tokenMidX = parseInt(self.orig_left) + Math.round(self.options.size / 2);
-					const tokenMidY = parseInt(self.orig_top) + Math.round(self.options.size / 2);
-					WaypointManager.cancelFadeout()
-					if(WaypointManager.numWaypoints > 0){
-						WaypointManager.checkNewWaypoint(tokenMidX, tokenMidY)
+					if (window.ALLOWTOKENMEASURING){
+						// Setup waypoint manager
+						// reset measuring when a new token is picked up
+						if(window.previous_measured_token != self.options.id){
+							window.previous_measured_token = self.options.id
+							WaypointManager.cancelFadeout()
+							WaypointManager.clearWaypoints()
+						}
+						const tokenMidX = parseInt(self.orig_left) + Math.round(self.options.size / 2);
+						const tokenMidY = parseInt(self.orig_top) + Math.round(self.options.size / 2);
+						
+						if(WaypointManager.numWaypoints > 0){
+							WaypointManager.checkNewWaypoint(tokenMidX, tokenMidY)
+							WaypointManager.cancelFadeout()
+						}
+						window.BEGIN_MOUSEX = tokenMidX;
+						window.BEGIN_MOUSEY = tokenMidY;
+						if (!self.options.disableborder){
+							WaypointManager.drawStyle.color = $(tok).css("--token-border-color")
+						}else{
+							WaypointManager.resetDefaultDrawStyle()
+						}
 					}
-					window.BEGIN_MOUSEX = tokenMidX;
-					window.BEGIN_MOUSEY = tokenMidY;
-					if (!self.options.disableborder){
-						WaypointManager.drawStyle.color = $(tok).css("--token-border-color")
-					}else{
-						WaypointManager.resetDefaultDrawStyle()
-					}
-					
 
 					remove_selected_token_bounding_box();
 				},
@@ -1329,18 +1339,20 @@ class Token {
 					const tokenMidX = tokenPosition.x + Math.round(self.options.size / 2);
 					const tokenMidY = tokenPosition.y + Math.round(self.options.size / 2);
 
-					const canvas = document.getElementById("temp_overlay");
-					const context = canvas.getContext("2d");
-					// incase we click while on select, remove any line dashes
-					context.setLineDash([])
-					// list the temp overlay so we can see the ruler
-					clear_temp_canvas()
-					$("#temp_overlay").css("z-index", "50")
-					WaypointManager.setCanvas(canvas);
-					WaypointManager.registerMouseMove(tokenMidX, tokenMidY);
-					WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, tokenMidX, tokenMidY);
-					WaypointManager.draw(false, Math.round(tokenPosition.x + (self.options.size / 2)), Math.round(tokenPosition.y + self.options.size + 10));
-					context.fillStyle = '#f50';
+					if (window.ALLOWTOKENMEASURING){
+						const canvas = document.getElementById("temp_overlay");
+						const context = canvas.getContext("2d");
+						// incase we click while on select, remove any line dashes
+						context.setLineDash([])
+						// list the temp overlay so we can see the ruler
+						clear_temp_canvas()
+						$("#temp_overlay").css("z-index", "50")
+						WaypointManager.setCanvas(canvas);
+						WaypointManager.registerMouseMove(tokenMidX, tokenMidY);
+						WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, tokenMidX, tokenMidY);
+						WaypointManager.draw(false, Math.round(tokenPosition.x + (self.options.size / 2)), Math.round(tokenPosition.y + self.options.size + 10));
+						context.fillStyle = '#f50';
+					}
 					//console.log("Changing to " +ui.position.left+ " "+ui.position.top);
 					// HACK TEST 
 					/*$(event.target).css("left",ui.position.left);

--- a/Token.js
+++ b/Token.js
@@ -1161,6 +1161,7 @@ class Token {
 				y: 0
 			};
 			tok.draggable({
+				scroll: false,
 				stop:
 					function (event) {
 						//remove cover for smooth drag


### PR DESCRIPTION
- Disabled token measuring unless `window.ALLOWTOKENMEASURING` is true
- removed scroll as it messes up the cursor position while dragging tokens
- fixed issue in which a tokens waypoint would start from anothers if quickly changing tokens