### PR TITLE
Draw selection box around non square token or scaled images.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1901,10 +1901,14 @@ function draw_selected_token_bounding_box() {
 	for (let i = 0; i < window.CURRENTLY_SELECTED_TOKENS.length; i++) {
 		let id = window.CURRENTLY_SELECTED_TOKENS[i];
 		let token = window.TOKEN_OBJECTS[id];
-		let tokenTop = parseFloat(token.options.top);
-		let tokenBottom = tokenTop + parseFloat(token.options.size);
-		let tokenLeft = parseFloat(token.options.left);
-		let tokenRight = tokenLeft + parseFloat(token.options.size);
+		let tokenImageClientPosition = $(`div.token[data-id='${id}']>.token-image`)[0].getBoundingClientRect();
+		let tokenImagePosition = $(`div.token[data-id='${id}']>.token-image`).position();
+		let tokenImageWidth = tokenImageClientPosition.right - tokenImageClientPosition.left;
+		let tokenImageHeight = tokenImageClientPosition.bottom - tokenImageClientPosition.top;
+		let tokenTop = parseFloat(token.options.top) + tokenImagePosition.top;
+		let tokenBottom = tokenTop + tokenImageHeight;
+		let tokenLeft = parseFloat(token.options.left)  + tokenImagePosition.left;
+		let tokenRight = tokenLeft + tokenImageWidth;
 		if (top == undefined) {
 			top = tokenTop;
 		} else {

--- a/Token.js
+++ b/Token.js
@@ -1898,16 +1898,17 @@ function draw_selected_token_bounding_box() {
 	var bottom = undefined;
 	var right = undefined;
 	var left = undefined;
+
 	for (let i = 0; i < window.CURRENTLY_SELECTED_TOKENS.length; i++) {
 		let id = window.CURRENTLY_SELECTED_TOKENS[i];
 		let token = window.TOKEN_OBJECTS[id];
 		let tokenImageClientPosition = $(`div.token[data-id='${id}']>.token-image`)[0].getBoundingClientRect();
 		let tokenImagePosition = $(`div.token[data-id='${id}']>.token-image`).position();
-		let tokenImageWidth = tokenImageClientPosition.right - tokenImageClientPosition.left;
-		let tokenImageHeight = tokenImageClientPosition.bottom - tokenImageClientPosition.top;
-		let tokenTop = parseFloat(token.options.top) + tokenImagePosition.top;
+		let tokenImageWidth = (tokenImageClientPosition.width) / (window.ZOOM);
+		let tokenImageHeight = (tokenImageClientPosition.height) / (window.ZOOM);
+		let tokenTop = ($(`div.token[data-id='${id}']`).position().top + tokenImagePosition.top) / (window.ZOOM);
 		let tokenBottom = tokenTop + tokenImageHeight;
-		let tokenLeft = parseFloat(token.options.left)  + tokenImagePosition.left;
+		let tokenLeft = ($(`div.token[data-id='${id}']`).position().left  + tokenImagePosition.left) / (window.ZOOM);
 		let tokenRight = tokenLeft + tokenImageWidth;
 		if (top == undefined) {
 			top = tokenTop;
@@ -1933,10 +1934,10 @@ function draw_selected_token_bounding_box() {
 
 	// add 10px to each side of out bounding box to give the tokens a little space
 	let borderOffset = 10;
-	top = top - borderOffset;
-	left = left - borderOffset;
-	right = right + borderOffset;
-	bottom = bottom + borderOffset;
+	top = (top - borderOffset);
+	left = (left - borderOffset);
+	bottom = (bottom + borderOffset);
+	right = (right + borderOffset);
 	let width = right - left;
 	let height = bottom - top;
 	let centerHorizontal = left + Math.ceil(width / 2);

--- a/Token.js
+++ b/Token.js
@@ -1898,7 +1898,6 @@ function draw_selected_token_bounding_box() {
 	var bottom = undefined;
 	var right = undefined;
 	var left = undefined;
-
 	for (let i = 0; i < window.CURRENTLY_SELECTED_TOKENS.length; i++) {
 		let id = window.CURRENTLY_SELECTED_TOKENS[i];
 		let token = window.TOKEN_OBJECTS[id];
@@ -1936,8 +1935,8 @@ function draw_selected_token_bounding_box() {
 	let borderOffset = 10;
 	top = (top - borderOffset);
 	left = (left - borderOffset);
-	bottom = (bottom + borderOffset);
-	right = (right + borderOffset);
+	right = right + borderOffset;
+	bottom = bottom + borderOffset;
 	let width = right - left;
 	let height = bottom - top;
 	let centerHorizontal = left + Math.ceil(width / 2);


### PR DESCRIPTION
Selection border fit's the token image boundaries. Below are examples of tokens that are not square or are scaled up.

![image](https://user-images.githubusercontent.com/65363489/171355003-9907ced7-a088-441e-ba6d-314140f2fcae.png)
![image](https://user-images.githubusercontent.com/65363489/171355012-e93a40af-eed1-432b-98dc-39a5b975c9f5.png)
![image](https://user-images.githubusercontent.com/65363489/171355026-e7faec8c-7e7a-4510-8ff1-0b4537800e77.png)
![image](https://user-images.githubusercontent.com/65363489/171355041-23671caf-d14c-4ad3-b6f8-aae589334cda.png)
