### PR TITLE
folder improvements

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1471,6 +1471,7 @@ function init_scenes_panel() {
 	console.log("init_scenes_panel");
 
 	scenesPanel.updateHeader("Scenes");
+	add_expand_collapse_buttons_to_header(scenesPanel);
 
 	let searchInput = $(`<input name="scene-search" type="text" style="width:96%;margin:2%" placeholder="search scenes">`);
 	searchInput.off("input").on("input", mydebounce(() => {
@@ -1573,7 +1574,7 @@ function redraw_scene_list(searchTerm) {
 	// this is similar to the structure of a SidebarListItem.Folder row.
 	// since we don't have root folders like the tokensPanel does, we want to treat the entire list like a subfolder
 	// this will allow us to reuse all the folder traversing functions that the tokensPanel uses
-	let list = $(`<div class="folder"><div class="folder-item-list" style="padding: 0;"></div></div>`);
+	let list = $(`<div class="folder not-collapsible"><div class="folder-item-list" style="padding: 0;"></div></div>`);
 	scenesPanel.body.empty();
 	scenesPanel.body.append(list);
 	set_full_path(list, SidebarListItem.PathScenes);

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1512,7 +1512,6 @@ function disable_draggable_change_folder(listItemType) {
 function add_expand_collapse_buttons_to_header(sidebarPanel) {
   let expandAll = $(`<button class="token-row-button expand-collapse-button" title="Expand All Folders" style=""><span class="material-icons">expand</span></button>`);
   expandAll.on("click", function (clickEvent) {
-    console.log("ugh")
     $(clickEvent.target).closest(".sidebar-panel-content").find(".sidebar-panel-body .folder:not(.not-collapsible)").removeClass("collapsed");
   });
   let collapseAll = $(`<button class="token-row-button expand-collapse-button" title="Collapse All Folders" style=""><span class="material-icons">vertical_align_center</span></button>`);

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1477,9 +1477,10 @@ function disable_draggable_change_folder(listItemType) {
       tokensPanel.body.find(".token-row-button.reorder-button").show();
       tokensPanel.body.find(".reorder-button").removeClass("active");
       tokensPanel.body.find(" > .custom-token-list > .folder").show();
+      tokensPanel.body.removeClass("folder");
       tokensPanel.header.find("input[name='token-search']").show();
       tokensPanel.updateHeader("Tokens");
-      tokensPanel.body.removeClass("folder");
+      add_expand_collapse_buttons_to_header(tokensPanel);
       try {
         tokensPanel.body.find(".sidebar-list-item-row").draggable("destroy");
       } catch (e) {} // don't care if it fails, just try
@@ -1506,6 +1507,22 @@ function disable_draggable_change_folder(listItemType) {
       } catch (e) {} // don't care if it fails, just try
       break;
   }
+}
+
+function add_expand_collapse_buttons_to_header(sidebarPanel) {
+  let expandAll = $(`<button class="token-row-button expand-collapse-button" title="Expand All Folders" style=""><span class="material-icons">expand</span></button>`);
+  expandAll.on("click", function (clickEvent) {
+    console.log("ugh")
+    $(clickEvent.target).closest(".sidebar-panel-content").find(".sidebar-panel-body .folder:not(.not-collapsible)").removeClass("collapsed");
+  });
+  let collapseAll = $(`<button class="token-row-button expand-collapse-button" title="Collapse All Folders" style=""><span class="material-icons">vertical_align_center</span></button>`);
+  collapseAll.on("click", function (clickEvent) {
+    $(clickEvent.target).closest(".sidebar-panel-content").find(".sidebar-panel-body .folder:not(.not-collapsible)").addClass("collapsed");
+  });
+  let buttonWrapper = $("<div class='expand-collapse-wrapper'></div>");
+  sidebarPanel.header.find(".sidebar-panel-header-title").append(buttonWrapper);
+  buttonWrapper.append(expandAll);
+  buttonWrapper.append(collapseAll);
 }
 
 /**
@@ -1554,6 +1571,7 @@ function enable_draggable_change_folder(listItemType) {
       tokensPanel.body.find(".reorder-button").addClass("active");
       tokensPanel.header.find("input[name='token-search']").hide();
       tokensPanel.updateHeader("Tokens", "", "Drag items to move them between folders");
+      add_expand_collapse_buttons_to_header(tokensPanel);
 
       let myTokensRootItem = tokens_rootfolders.find(i => i.name === SidebarListItem.NameMyTokens);
       let myTokensRootFolder = find_html_row(myTokensRootItem, tokensPanel.body);
@@ -1592,7 +1610,7 @@ function enable_draggable_change_folder(listItemType) {
 
       myTokensRootFolder.droppable(droppableOptions); // allow dropping on root MyTokens folder
       myTokensRootFolder.find(".folder").droppable(droppableOptions);  // allow dropping on folders within MyTokens folder
-      tokensPanel.body.addClass("folder");  // allow dropping on folders within MyTokens folder
+      tokensPanel.body.addClass("folder").addClass("not-collapsible");  // allow dropping on folders within MyTokens folder
       tokensPanel.body.droppable(droppableOptions);  // allow dropping on folders within MyTokens folder
 
       break;
@@ -1604,7 +1622,7 @@ function enable_draggable_change_folder(listItemType) {
       scenesPanel.header.find(".reorder-button").addClass("active");
       scenesPanel.body.find(".token-row-gear").hide();
       scenesPanel.body.find(".token-row-button").hide();
-      scenesPanel.body.addClass("folder");
+      scenesPanel.body.addClass("folder").addClass("not-collapsible"); // we want the root to act like a folder, but we don't want to allow it to collapse
 
       scenesPanel.body.find(".sidebar-list-item-row").draggable({
         container: scenesPanel.body,

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -410,6 +410,7 @@ function init_tokens_panel() {
     let header = tokensPanel.header;
     // TODO: remove this warning once tokens are saved in the cloud
     tokensPanel.updateHeader("Tokens");
+    add_expand_collapse_buttons_to_header(tokensPanel);
     header.append("<div class='panel-warning'>WARNING/WORKINPROGRESS. THIS TOKEN LIBRARY IS CURRENTLY STORED IN YOUR BROWSER STORAGE. IF YOU DELETE YOUR HISTORY YOU LOOSE YOUR LIBRARY</div>");
 
     let searchInput = $(`<input name="token-search" type="text" style="width:96%;margin:2%" placeholder="search tokens">`);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2144,9 +2144,15 @@ div.ct-sidebar__pane-content > div.selected-tab {
     font-style: normal;
     font-weight: bold;
     font-size: 18px;
+    justify-content: space-between;
 }
 .sidebar-panel-header-title:empty{
     margin: 0px;
+}
+.sidebar-panel-header-title .expand-collapse-wrapper {
+    display: flex;
+    flex-direction: row;
+    margin-right: 6px;
 }
 .sidebar-panel-header-subtitle {
     font-size: 12px;

--- a/built-in-tokens.js
+++ b/built-in-tokens.js
@@ -57,7 +57,7 @@ const builtInTokens = [
   },
   {
     "name": "Commoner",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://drive.google.com/file/d/1H-5cCt03oIB43CnhmdaHM6P2Aw8T2n60/view?usp=sharing",
     "alternativeImages": [
       "https://drive.google.com/file/d/1H-5cCt03oIB43CnhmdaHM6P2Aw8T2n60/view?usp=sharing",
@@ -79,7 +79,7 @@ const builtInTokens = [
   },
   {
     "name": "Dragonborn [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/92aaNuq.png",
     "alternativeImages": [
       "https://i.imgur.com/92aaNuq.png",
@@ -90,7 +90,7 @@ const builtInTokens = [
   },
   {
     "name": "Dragonborn [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/0qQpdH6.png",
     "alternativeImages": [
       "https://i.imgur.com/0qQpdH6.png",
@@ -112,7 +112,7 @@ const builtInTokens = [
   },
   {
     "name": "Drow [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/lwPqseX.png",
     "alternativeImages": [
       "https://i.imgur.com/lwPqseX.png",
@@ -138,7 +138,7 @@ const builtInTokens = [
   },
   {
     "name": "Drow [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/RgY5TkF.png",
     "alternativeImages": [
       "https://i.imgur.com/RgY5TkF.png",
@@ -159,7 +159,7 @@ const builtInTokens = [
   },
   {
     "name": "Dwarf [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/4Xuzbp6.png",
     "alternativeImages": [
       "https://i.imgur.com/4Xuzbp6.png",
@@ -172,7 +172,7 @@ const builtInTokens = [
   },
   {
     "name": "Dwarf [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/T6K1v8s.png",
     "alternativeImages": [
       "https://i.imgur.com/T6K1v8s.png",
@@ -198,7 +198,7 @@ const builtInTokens = [
   },
   {
     "name": "Elf [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/5brExHK.png",
     "alternativeImages": [
       "https://i.imgur.com/5brExHK.png",
@@ -223,7 +223,7 @@ const builtInTokens = [
   },
   {
     "name": "Elf [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/KhyErAR.png",
     "alternativeImages": [
       "https://i.imgur.com/KhyErAR.png",
@@ -274,7 +274,7 @@ const builtInTokens = [
   },
   {
     "name": "Genasi",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/YnlG0US.png",
     "alternativeImages": [
       "https://i.imgur.com/YnlG0US.png",
@@ -287,7 +287,7 @@ const builtInTokens = [
   },
   {
     "name": "Guard [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://drive.google.com/file/d/1C9ghQrfHckKPOMEHdmStaN47y0OXUPZ9/view?usp=sharing",
     "alternativeImages": [
       "https://drive.google.com/file/d/1C9ghQrfHckKPOMEHdmStaN47y0OXUPZ9/view?usp=sharing"
@@ -295,7 +295,7 @@ const builtInTokens = [
   },
   {
     "name": "Human [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/NjP2sGL.png",
     "alternativeImages": [
       "https://i.imgur.com/NjP2sGL.png",
@@ -328,7 +328,7 @@ const builtInTokens = [
   },
   {
     "name": "Human [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/vyeBFvg.png",
     "alternativeImages": [
       "https://i.imgur.com/vyeBFvg.png",
@@ -435,7 +435,7 @@ const builtInTokens = [
   },
   {
     "name": "Maid [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://drive.google.com/file/d/1wB5yKNKQ5dqkLhvWA5UZybLBBTDu-57c/view?usp=sharing",
     "alternativeImages": [
       "https://drive.google.com/file/d/1wB5yKNKQ5dqkLhvWA5UZybLBBTDu-57c/view?usp=sharing"
@@ -443,7 +443,7 @@ const builtInTokens = [
   },
   {
     "name": "Orc [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/gmUUKun.png",
     "alternativeImages": [
       "https://i.imgur.com/gmUUKun.png",
@@ -454,7 +454,7 @@ const builtInTokens = [
   },
   {
     "name": "Orc [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/4pWxSUn.png",
     "alternativeImages": [
       "https://i.imgur.com/4pWxSUn.png",
@@ -472,7 +472,7 @@ const builtInTokens = [
   },
   {
     "name": "Tiefling [F]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/r6fKPlI.png",
     "alternativeImages": [
       "https://i.imgur.com/r6fKPlI.png",
@@ -497,7 +497,7 @@ const builtInTokens = [
   },
   {
     "name": "Tiefling [M]",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/iLKRQF5.png",
     "alternativeImages": [
       "https://i.imgur.com/iLKRQF5.png",
@@ -515,7 +515,7 @@ const builtInTokens = [
   },
   {
     "name": "Warforged",
-    "folderPath": "/",
+    "folderPath": "/NPCs",
     "image": "https://i.imgur.com/N5Nvgkw.png",
     "alternativeImages": [
       "https://i.imgur.com/N5Nvgkw.png",


### PR DESCRIPTION
1. Don't expand folders all the damn time... Any collapsed/expanded folders should now stay that way when you reorder things
2. Allow dropping anywhere on the sidebar body to move things to the root folder. (not the header, though, just the body)
3. Add Expand All and Collapse All buttons
4. Move built in tokens to a dedicated NPCs folder