### PR TITLE
Fix - Enable the DM setting toggle in firefox for dice streams and add a chat message prompting to attempt reconnect if connection fails between a peer.

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -761,7 +761,7 @@ class MessageBroker {
 				window.makingOffer = [];
 				window.makingOffer[msg.data.from] = false;
 				peer.onconnectionstatechange=() => {
-					if(peer.connectionState=="connected"{
+					if(peer.connectionState=="connected"){
 						window.MB.inject_chat({
                 player: window.PLAYER_NAME,
                 img: window.PLAYER_IMG,
@@ -769,6 +769,7 @@ class MessageBroker {
                 whisper: window.PLAYER_NAME,
 	          });
 					}
+
 					if(peer.connectionState=="closed" || peer.connectionState=="failed" || peer.connectionState == "disconnected"){
 						restartIce();
 						window.MB.inject_chat({
@@ -855,7 +856,7 @@ class MessageBroker {
 					}	
 				};
 				peer.onconnectionstatechange=() => {
-					if(peer.connectionState=="connected"{
+					if(peer.connectionState=="connected"){
 						window.MB.inject_chat({
                 player: window.PLAYER_NAME,
                 img: window.PLAYER_IMG,

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -704,7 +704,13 @@ class MessageBroker {
 				}	
 					$("[id^='streamer-"+msg.data.from+"']").remove();
 					window.STREAMPEERS[msg.data.from].close();
-					delete window.STREAMPEERS[msg.data.from]
+					delete window.STREAMPEERS[msg.data.from];
+					window.MB.inject_chat({
+              player: window.PLAYER_NAME,
+              img: window.PLAYER_IMG,
+              text: `<span class="flex-wrap-center-chat-message">One of your dice stream connections has failed/disconnected. Try reconnecting to the dice stream if this was not intentional.<br/><br/></div>`,
+              whisper: window.PLAYER_NAME
+          });
 			}
 			if(msg.eventType == "custom/myVTT/disabledicestream"){
 				enable_dice_streaming_feature(false);
@@ -752,7 +758,7 @@ class MessageBroker {
 				window.makingOffer = [];
 				window.makingOffer[msg.data.from] = false;
 				peer.onconnectionstatechange=() => {
-					if((peer.connectionState=="closed") || (peer.connectionState=="failed")){
+					if(peer.connectionState=="closed" || peer.connectionState=="failed" || peer.connectionState == "disconnected"){
 						console.log("DELETING PEER "+msg.data.from);
 						delete window.STREAMPEERS[msg.data.from];
 						$("#streamer-canvas-"+msg.data.from).remove();
@@ -760,6 +766,12 @@ class MessageBroker {
 							to: msg.data.from,
 							from: window.MYSTREAMID
 						})
+						window.MB.inject_chat({
+                player: window.PLAYER_NAME,
+                img: window.PLAYER_IMG,
+                text: `<span class="flex-wrap-center-chat-message">One of your dice stream connections has failed/disconnected. Try disconnecting and reconnecting to the dice stream if this was not intentional.<br/><br/></div>`,
+                whisper: window.PLAYER_NAME
+	          });
 					}
 				};
 			  try {
@@ -822,7 +834,13 @@ class MessageBroker {
 						window.MB.sendMessage("custom/myVTT/turnoffsingledicestream", {
 							to: msg.data.from,
 							from: window.MYSTREAMID
-						})
+						});
+						window.MB.inject_chat({
+                player: window.PLAYER_NAME,
+                img: window.PLAYER_IMG,
+                text: `<span class="flex-wrap-center-chat-message">One of your dice stream connections has failed/disconnected. Try disconnecting and reconnecting to the dice stream if this was not intentional.<br/><br/></div>`,
+                whisper: window.PLAYER_NAME
+	          });
 					}
 				};
 		

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -761,6 +761,14 @@ class MessageBroker {
 				window.makingOffer = [];
 				window.makingOffer[msg.data.from] = false;
 				peer.onconnectionstatechange=() => {
+					if(peer.connectionState=="connected"{
+						window.MB.inject_chat({
+                player: window.PLAYER_NAME,
+                img: window.PLAYER_IMG,
+                text: `<span class="flex-wrap-center-chat-message"><p>A dice stream peer has ${peer.connectionState}. <br/><br/></div>`,
+                whisper: window.PLAYER_NAME,
+	          });
+					}
 					if(peer.connectionState=="closed" || peer.connectionState=="failed" || peer.connectionState == "disconnected"){
 						restartIce();
 						window.MB.inject_chat({
@@ -847,6 +855,14 @@ class MessageBroker {
 					}	
 				};
 				peer.onconnectionstatechange=() => {
+					if(peer.connectionState=="connected"{
+						window.MB.inject_chat({
+                player: window.PLAYER_NAME,
+                img: window.PLAYER_IMG,
+                text: `<span class="flex-wrap-center-chat-message"><p>A dice stream peer has ${peer.connectionState}. <br/><br/></div>`,
+                whisper: window.PLAYER_NAME,
+	          });
+					}
 					if((peer.connectionState=="closed") || (peer.connectionState=="failed" || peer.connectionState == "disconnected")){
 						restartIce();
 						window.MB.inject_chat({

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -771,7 +771,7 @@ class MessageBroker {
 					}
 
 					if(peer.connectionState=="closed" || peer.connectionState=="failed" || peer.connectionState == "disconnected"){
-						restartIce();
+						peer.restartIce();
 						window.MB.inject_chat({
                 player: window.PLAYER_NAME,
                 img: window.PLAYER_IMG,
@@ -865,7 +865,7 @@ class MessageBroker {
 	          });
 					}
 					if((peer.connectionState=="closed") || (peer.connectionState=="failed" || peer.connectionState == "disconnected")){
-						restartIce();
+						peer.restartIce();
 						window.MB.inject_chat({
                 player: window.PLAYER_NAME,
                 img: window.PLAYER_IMG,

--- a/Settings.js
+++ b/Settings.js
@@ -307,14 +307,13 @@ function init_settings(){
 			dmOnly: true
 		}
 	];
-	if (get_browser().chrome) {
-		experimental_features.push({
-			name: 'streamDiceRolls',
-			label: 'Stream Dice Rolls',
-			enabledDescription: `You and your players can find the button to join the dice stream in the game log in the top right corner. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`,
-			disabledDescription: `This will enable the dice stream feature for everyone. You will all still have to join the dice stream. You and your players can find the button to do this in the game log in the top right corner once this feature is enabled. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`
-		});
-	}
+	
+	experimental_features.push({
+		name: 'streamDiceRolls',
+		label: 'Stream Dice Rolls',
+		enabledDescription: `You and your players can find the button to join the dice stream in the game log in the top right corner. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`,
+		disabledDescription: `This will enable the dice stream feature for everyone. You will all still have to join the dice stream. You and your players can find the button to do this in the game log in the top right corner once this feature is enabled. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`
+	});
 	body.append(`
 		<br />
 		<h5 class="token-image-modal-footer-title">Experimental Features</h5>


### PR DESCRIPTION
This allows the setting to be turned on in firefox.

It also will prompt a user to try and reconnect if there is an unintentional failed peer connection.