### PR TITLE
move hover-text to flyouts instead of over the top

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1986,15 +1986,15 @@ function inject_chat_buttons() {
 	}
 	// AGGIUNGI CHAT
 	// the text has to be up against the left for it to style correctly
-	$(".glc-game-log").append($(`<div class='chat-text-wrapper sidebar-hovertext' data-hover="Dice Rolling Format: /cmd diceNotation action  &#xa;\
-'/r 1d20'&#xa;\
-'/roll 1d4 punch:damage'&#xa;\
-'/hit 2d20kh1+2 longsword ADV'&#xa;\
-'/dmg 1d8-2 longsword'&#xa;\
-'/save 2d20kl1 DEX DISADV'&#xa;\
-'/skill 1d20+1d4 Theives' Tools + Guidance'&#xa;\
-Advantage: 2d20kh1 (keep highest)&#xa;\
-Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;\
+	$(".glc-game-log").append($(`<div class='chat-text-wrapper sidebar-hover-text' data-hover="Dice Rolling Format: /cmd diceNotation action  &#xa;<br/>
+'/r 1d20'&#xa;<br/>
+'/roll 1d4 punch:damage'&#xa;<br/>
+'/hit 2d20kh1+2 longsword ADV'&#xa;<br/>
+'/dmg 1d8-2 longsword'&#xa;<br/>
+'/save 2d20kl1 DEX DISADV'&#xa;<br/>
+'/skill 1d20+1d4 Theives' Tools + Guidance'&#xa;<br/>
+Advantage: 2d20kh1 (keep highest)&#xa;<br/>
+Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 '/w [playername] a whisper to playername'"><input id='chat-text' autocomplete="off" placeholder='Chat, /r 1d20+4..'></div>`));
 
 	$(".glc-game-log").append($(`

--- a/Settings.js
+++ b/Settings.js
@@ -132,7 +132,7 @@ function init_settings(){
 		<h5 class="token-image-modal-footer-title">MIGRATE YOUR SCENES TO THE CLOUD</h5>
 		<div class="sidebar-panel-header-explanation">
 			<p>Your data is currently stored on your browser's cache. Press migrate to move your data into the AboveVTT cloud (<b>WARNING. YOU RISK LOOSING YOU DATA</b>) </p>
-			<button onclick='cloud_migration();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="This will migrate your data to the cloud. Be careful or you may loose your scenes">MIGRATE</button>
+			<button onclick='cloud_migration();' class="sidebar-panel-footer-button sidebar-hover-text" data-hover="This will migrate your data to the cloud. Be careful or you may loose your scenes">MIGRATE</button>
 		</div>
 		`)
 	}
@@ -147,8 +147,8 @@ function init_settings(){
 			<p>Export will download a file containing all of your scenes, custom tokens, and soundpads. 
 			Import will allow you to upload an exported file. Scenes from that file will be added to the scenes in this campaign.</p>
 			<div class="sidebar-panel-footer-horizontal-wrapper">
-			<button onclick='import_openfile();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="Upload a file containing scenes, custom tokens, and soundpads. This will not overwrite your existing scenes. Any scenes found in the uploaded file will be added to your current list scenes">IMPORT</button>
-			<button onclick='export_file();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="Download a file containing all of your scenes, custom tokens, and soundpads">EXPORT</button>
+			<button onclick='import_openfile();' class="sidebar-panel-footer-button sidebar-hover-text" data-hover="Upload a file containing scenes, custom tokens, and soundpads. This will not overwrite your existing scenes. Any scenes found in the uploaded file will be added to your current list scenes">IMPORT</button>
+			<button onclick='export_file();' class="sidebar-panel-footer-button sidebar-hover-text" data-hover="Download a file containing all of your scenes, custom tokens, and soundpads">EXPORT</button>
 				<input accept='.abovevtt' id='input_file' type='file' style='display: none' />
 		</div>
 	`);

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -29,7 +29,7 @@ function init_sidebar_tabs() {
   $("#sounds-panel").remove();
   soundsPanel = new SidebarPanel("sounds-panel", false);
   sidebarContent.append(soundsPanel.build());
-	init_audio();
+  init_audio();
 
   $("#journal-panel").remove();
   journalPanel = new SidebarPanel("journal-panel", false);
@@ -46,6 +46,8 @@ function init_sidebar_tabs() {
     sidebarContent.append(settingsPanel.build());
     init_settings();
   }
+
+  observe_hover_text($(".sidebar__inner"));
 }
 
 function sidebar_modal_is_open() {
@@ -60,6 +62,19 @@ function close_sidebar_modal() {
 function display_sidebar_modal(sidebarPanel) {
   $("#VTTWRAPPER").append(sidebarPanel.build());
   window.current_sidebar_modal = sidebarPanel;
+  observe_hover_text(sidebarPanel.container);
+}
+
+function observe_hover_text(sidebarPanelContent) {
+  sidebarPanelContent.off("mouseenter mouseleave").on("mouseenter mouseleave", ".sidebar-hover-text", function(hoverEvent) {
+    const displayText = $(hoverEvent.currentTarget).attr("data-hover");
+    if (typeof displayText === "string" && displayText.length > 0) {
+      sidebar_flyout(hoverEvent, function (flyout) {
+        flyout.append(`<div class="sidebar-hover-text-flyout">${displayText}</div>`);
+        flyout.css("left", sidebarPanelContent[0].getBoundingClientRect().left - flyout.width());
+      });
+    }
+  });
 }
 
 class SidebarPanel {
@@ -293,10 +308,11 @@ function build_toggle_input(name, labelText, enabled, enabledHoverText, disabled
   let input = $(`<button name="${name}" type="button" role="switch" class="rc-switch"><span class="rc-switch-inner"></span></button>`);
   const updateHoverText = function(hoverElement, hoverText) {
     if (hoverText !== undefined && hoverText.length > 0) {
-      hoverElement.addClass("sidebar-hovertext");
+      hoverElement.addClass("sidebar-hover-text");
       hoverElement.attr("data-hover", hoverText);
+      $(".sidebar-flyout .sidebar-hover-text-flyout").text(hoverText);
     } else {
-      hoverElement.removeClass("sidebar-hovertext");
+      hoverElement.removeClass("sidebar-hover-text");
       hoverElement.removeAttr("data-hover");
     }
   }

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -37,6 +37,7 @@ function context_menu_flyout(id, hoverEvent, buildFunction) {
 
 		buildFunction(flyout);
 		$("#tokenOptionsContainer").append(flyout);
+		observe_hover_text(flyout);
 
 		let contextMenuCenter = (contextMenu.height() / 2);
 		let flyoutHeight = flyout.height();

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2188,6 +2188,13 @@ div.token-image-modal-footer-title {
     font-size: 13px;
     /*width: 100%;*/
 }
+h1.token-image-modal-footer-title,
+h2.token-image-modal-footer-title,
+h3.token-image-modal-footer-title,
+h4.token-image-modal-footer-title,
+h5.token-image-modal-footer-title {
+    display: block;
+}
 h1.token-image-modal-footer-title:after,
 h2.token-image-modal-footer-title:after,
 h3.token-image-modal-footer-title:after,
@@ -2349,11 +2356,9 @@ h5.token-image-modal-footer-title:after {
 }
 .sidebar-flyout {
     position: fixed;
-    right: 350px;
-    z-index: 1000;
-    border: 1px solid #d8e1e8;
+    z-index: 100000;
     box-shadow: 1px 1px 10px black, -1px -1px 10px black;
-    border-radius: 15px;
+    border-radius: 5px;
     overflow: hidden;
 }
 .list-item-image-flyout {
@@ -2772,6 +2777,17 @@ h5.token-image-modal-footer-title:after {
     outline: 2px solid #000;
 }
 
+.sidebar-hover-text-flyout {
+    display: block;
+    max-width: 400px;
+    padding: 0px 10px;
+    background-color: rgba(28,29,30,0.8);
+    color: #fff;
+    font-family: 'Roboto', sans-serif;
+    font-weight: 300;
+    font-size: 14px;
+    text-transform: none;
+}
 .sidebar-hovertext:before {
     content: attr(data-hover);
     font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
Instead of showing the hover text over the top of the sidebar, this displays it in a flyout to the left.

### Settings Panel

In this gif, the hover text is still displayed above the sidebar, but I only left that in there to show the difference. The old hover has been removed.
![avtt-sidebar-hovertext-flyout](https://user-images.githubusercontent.com/584771/172059447-d3446955-3ed6-4140-8cf9-98bae9e0b134.gif)

### Chat Input

<img width="726" alt="Screen_Shot_2022-06-05_at_9 55 41_AM" src="https://user-images.githubusercontent.com/584771/172059479-fb2a5fcd-06e4-41fc-a5df-0f537a5544e6.png">

### Token Context Menu Options
<img width="788" alt="Screen_Shot_2022-06-05_at_10 58 10_AM" src="https://user-images.githubusercontent.com/584771/172059495-27d08ab9-ab7e-4055-8453-fabfa992a895.png">



## Before
This is what it used to look like 

<img width="411" alt="Screen Shot 2022-06-05 at 11 05 25 AM" src="https://user-images.githubusercontent.com/584771/172059554-985bf4d4-4640-49ff-ac1d-6154662464ca.png">
<img width="380" alt="Screen Shot 2022-06-05 at 11 05 36 AM" src="https://user-images.githubusercontent.com/584771/172059557-2981e9bc-a80b-49d6-9669-f511c60b79fa.png">

