### PR TITLE
prevent scene naming conflicts

### DIFF
--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1267,6 +1267,11 @@ function display_folder_configure_modal(listItem) {
       folderNameInput,
       `<button>Save</button>`,
       function(newFolderName, input, event) {
+        let oldPath = harvest_full_path($(input));
+        if (oldPath.endsWith(`/${newFolderName}`)) {
+          close_sidebar_modal();
+          return;
+        }
         let foundItem = find_sidebar_list_item($(input));
         let updateFullPath = rename_folder(foundItem, newFolderName);
         if (updateFullPath === undefined) {


### PR DESCRIPTION
The sidebar doesn't know how to handle things that are named the same at the same folder path. This prevents saving scenes and folders if the name is already used. It will prompt the user at the same time.