### PR TITLE
Token Updates

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -102,6 +102,7 @@ Mousetrap.bind('q', function () {       //collapse/show sidebar. (q is next to t
 });
 
 Mousetrap.bind('esc', function () {     //deselect all buttons
+    console.log("Mousetrap.bind('esc'");
     stop_drawing();
     $('#select-button').click();
     close_token_context_menu();
@@ -110,6 +111,17 @@ Mousetrap.bind('esc', function () {     //deselect all buttons
     try {
         $( '.ui-draggable-dragging' ).draggable("option", { revert: true }).trigger( 'mouseup' ).draggable("option", {revert: false })
     } catch (whoCares) { }
+    let elementPreventingSidebarClose = $(".prevent-sidebar-modal-close");
+    if (elementPreventingSidebarClose.length > 0) {
+        if (elementPreventingSidebarClose.hasClass("sidebar-flyout") || elementPreventingSidebarClose.closest(".sidebar-flyout").length > 0) {
+            // it's a flyout... close it
+            elementPreventingSidebarClose.remove();
+        }
+        // any others that we want to close on esc?
+    } else {
+        // only close the sidebar if there isn't something on the screen explicitly trying to keep it open
+        close_sidebar_modal();
+    }
 });
 
 //menu specific shortcuts, select the nth element of menu when it's open

--- a/Load.js
+++ b/Load.js
@@ -73,6 +73,7 @@ let scripts = [
 	{ src: "ChatObserver.js" },
 	{ src: "DiceContextMenu/DiceContextMenu.js" },
 	{ src: "TokensPanel.js" },
+	{ src: "TokenCustomization.js" },
 	{ src: "built-in-tokens.js" },
 	// Files that execute when loaded
 	{ src: "ajaxQueue/ajaxQueueIndex.js", type: "module" },

--- a/Main.js
+++ b/Main.js
@@ -1736,7 +1736,7 @@ function init_things() {
 		window.ScenesHandler = new ScenesHandler(gameId);
 		window.EncounterHandler = new EncounterHandler(function(didSucceed) {
 			if (didSucceed === false) {
-				showGenericAlert();
+				showDebuggingAlert();
 			}
 			init_ui();
 			if (is_encounters_page()) {
@@ -2773,7 +2773,7 @@ $(function() {
 				if (errorType === "EncounterLimitException") {
 					alert("Failed to create a backing Encounter! AboveVTT requires 1 available Encounter, but it looks like you already have more than your subscription level allows. Try deleting some encounters (or renaming one of them to \"AboveVTT\") and try again");
 				} else {
-					showGenericAlert();
+					showDebuggingAlert();
 				}
 				$(".joindm").removeClass("button-loading");
 				return;
@@ -3509,6 +3509,7 @@ function adjust_site_bar() {
 	}
 }
 
-function showGenericAlert() {
-	alert("An unexpected error occurred! Please check the developer console for errors, and report this via the AboveVTT Discord.");
+const debuggingAlertText = "Please check the developer console (F12) for errors, and report this via the AboveVTT Discord.";
+function showDebuggingAlert(message = "An unexpected error occurred!") {
+	alert(`${message}\n${debuggingAlertText}`);
 }

--- a/Main.js
+++ b/Main.js
@@ -2445,6 +2445,15 @@ function init_ui() {
 		if (sidebarMonsterFilter.length > 0 && !event.target.closest("#monster-filter-iframe")) {
 			close_monster_filter_iframe();
 		}
+		if (event.which === 1 && $(".sidebar-flyout").length > 0) {
+			// check if the click was within the flyout
+			let flyout = event.target.closest(".sidebar-flyout");
+			let preventSidebarModalClose = event.target.closest(".prevent-sidebar-modal-close");
+			if (!flyout && !preventSidebarModalClose) {
+				remove_sidebar_flyout();
+			}
+		}
+
 
 	}
 

--- a/Main.js
+++ b/Main.js
@@ -1986,15 +1986,15 @@ function inject_chat_buttons() {
 	}
 	// AGGIUNGI CHAT
 	// the text has to be up against the left for it to style correctly
-	$(".glc-game-log").append($(`<div class='chat-text-wrapper sidebar-hovertext' data-hover="Dice Rolling Format: /cmd diceNotation action  &#xa;\
-'/r 1d20'&#xa;\
-'/roll 1d4 punch:damage'&#xa;\
-'/hit 2d20kh1+2 longsword ADV'&#xa;\
-'/dmg 1d8-2 longsword'&#xa;\
-'/save 2d20kl1 DEX DISADV'&#xa;\
-'/skill 1d20+1d4 Theives' Tools + Guidance'&#xa;\
-Advantage: 2d20kh1 (keep highest)&#xa;\
-Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;\
+	$(".glc-game-log").append($(`<div class='chat-text-wrapper sidebar-hover-text' data-hover="Dice Rolling Format: /cmd diceNotation action  &#xa;<br/>
+'/r 1d20'&#xa;<br/>
+'/roll 1d4 punch:damage'&#xa;<br/>
+'/hit 2d20kh1+2 longsword ADV'&#xa;<br/>
+'/dmg 1d8-2 longsword'&#xa;<br/>
+'/save 2d20kl1 DEX DISADV'&#xa;<br/>
+'/skill 1d20+1d4 Theives' Tools + Guidance'&#xa;<br/>
+Advantage: 2d20kh1 (keep highest)&#xa;<br/>
+Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 '/w [playername] a whisper to playername'"><input id='chat-text' autocomplete="off" placeholder='Chat, /r 1d20+4..'></div>`));
 
 	$(".glc-game-log").append($(`

--- a/Main.js
+++ b/Main.js
@@ -1733,6 +1733,8 @@ function init_things() {
 		window.CAMPAIGN_SECRET=$(".ddb-campaigns-invite-primary").text().split("/").pop();
 	}
 
+	fetch_token_customizations();
+
 	window.MB = new MessageBroker();
 	window.StatHandler = new StatHandler();
 

--- a/Main.js
+++ b/Main.js
@@ -1736,7 +1736,7 @@ function init_things() {
 		window.ScenesHandler = new ScenesHandler(gameId);
 		window.EncounterHandler = new EncounterHandler(function(didSucceed) {
 			if (didSucceed === false) {
-				alert("An unexpected error occurred! Please check the developer console for errors, and report this via the AboveVTT Discord.");
+				showGenericAlert();
 			}
 			init_ui();
 			if (is_encounters_page()) {
@@ -2773,7 +2773,7 @@ $(function() {
 				if (errorType === "EncounterLimitException") {
 					alert("Failed to create a backing Encounter! AboveVTT requires 1 available Encounter, but it looks like you already have more than your subscription level allows. Try deleting some encounters (or renaming one of them to \"AboveVTT\") and try again");
 				} else {
-					alert("An unexpected error occurred! Please check the developer console for errors, and report this via the AboveVTT Discord.");
+					showGenericAlert();
 				}
 				$(".joindm").removeClass("button-loading");
 				return;
@@ -3507,4 +3507,8 @@ function adjust_site_bar() {
 			"z-index": -1
 		});
 	}
+}
+
+function showGenericAlert() {
+	alert("An unexpected error occurred! Please check the developer console for errors, and report this via the AboveVTT Discord.");
 }

--- a/Main.js
+++ b/Main.js
@@ -782,13 +782,6 @@ function init_controls() {
 		sidebarControls.addClass("player");
 	}
 
-	
-	if (window.EXPERIMENTAL_SETTINGS["DEBUGddbDiceMonsterPanel"] === true) {
-		change_sidbar_tab($("#switch_monsters"));
-		$("#loading_overlay").css({ "opacity": "0.25" })
-		$(".sidebar-panel-loading-indicator").css({ "opacity": "0.25" })
-	}
-
 }
 
 const MAX_ZOOM_STEP = 20

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -192,7 +192,7 @@ function remove_all_player_image_mappings(playerId) {
 }
 
 function get_player_image_mappings(playerId) {
-	return get_player_token_customizations(playerId).tokenOptions.alternativeImages || [];
+	return get_player_token_customization(playerId).tokenOptions.alternativeImages || [];
 }
 
 function random_image_for_player_token(playerId) {

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -165,7 +165,7 @@ function add_player_image_mapping(playerId, imageUrl) {
 		return;
 	}
 
-	let customization = find_token_customization(SidebarListItem.TypePC, playerId);
+	let customization = find_token_customization(ItemType.PC, playerId);
 	if (!customization) {
 		return;
 	}
@@ -174,7 +174,7 @@ function add_player_image_mapping(playerId, imageUrl) {
 }
 
 function remove_player_image_mapping(playerId, imageUrl) {
-	let customization = find_token_customization(SidebarListItem.TypePC, playerId);
+	let customization = find_token_customization(ItemType.PC, playerId);
 	if (!customization) {
 		return;
 	}
@@ -183,7 +183,7 @@ function remove_player_image_mapping(playerId, imageUrl) {
 }
 
 function remove_all_player_image_mappings(playerId) {
-	let customization = find_token_customization(SidebarListItem.TypePC, playerId);
+	let customization = find_token_customization(ItemType.PC, playerId);
 	if (!customization) {
 		return;
 	}
@@ -193,7 +193,7 @@ function remove_all_player_image_mappings(playerId) {
 
 function get_player_image_mappings(playerId) {
 	try {
-		return find_or_create_token_customization(SidebarListItem.TypePC, playerId).tokenOptions.alternativeImages || [];
+		return find_or_create_token_customization(ItemType.PC, playerId).tokenOptions.alternativeImages || [];
 	} catch (error) {
 		console.error("get_player_image_mappings failed to find_or_create_token_customization", playerId, error)
 		return [];

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -193,7 +193,7 @@ function remove_all_player_image_mappings(playerId) {
 
 function get_player_image_mappings(playerId) {
 	try {
-		return find_or_create_token_customization(ItemType.PC, playerId, RootFolderId.Players).tokenOptions.alternativeImages || [];
+		return find_or_create_token_customization(ItemType.PC, playerId, RootFolder.Players.id).tokenOptions.alternativeImages || [];
 	} catch (error) {
 		console.error("get_player_image_mappings failed to find_or_create_token_customization", playerId, error)
 		return [];

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -203,6 +203,18 @@ function get_player_token_customizations(playerId) {
 	return customMappingData[playerId];
 }
 
+function set_player_token_customizations(playerId, customizations) {
+	if (playerId === undefined) {
+		return;
+	}
+	let customMappingData = read_player_token_customizations();
+	customMappingData[playerId] = {...customizations};
+	if (customMappingData[playerId].images === undefined) {
+		customMappingData[playerId].images = [];
+	}
+	write_player_token_customizations(customMappingData);
+}
+
 function get_player_image_mappings(playerId) {
 	let customizations = get_player_token_customizations(playerId);
 	if (customizations.images !== undefined) {

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -193,7 +193,7 @@ function remove_all_player_image_mappings(playerId) {
 
 function get_player_image_mappings(playerId) {
 	try {
-		return find_or_create_token_customization(ItemType.PC, playerId).tokenOptions.alternativeImages || [];
+		return find_or_create_token_customization(ItemType.PC, playerId, RootFolderId.Players).tokenOptions.alternativeImages || [];
 	} catch (error) {
 		console.error("get_player_image_mappings failed to find_or_create_token_customization", playerId, error)
 		return [];

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -165,7 +165,7 @@ function add_player_image_mapping(playerId, imageUrl) {
 		return;
 	}
 
-	let customization = find_player_token_customization(playerId);
+	let customization = find_token_customization(SidebarListItem.TypePC, playerId);
 	if (!customization) {
 		return;
 	}
@@ -174,7 +174,7 @@ function add_player_image_mapping(playerId, imageUrl) {
 }
 
 function remove_player_image_mapping(playerId, imageUrl) {
-	let customization = find_player_token_customization(playerId);
+	let customization = find_token_customization(SidebarListItem.TypePC, playerId);
 	if (!customization) {
 		return;
 	}
@@ -183,7 +183,7 @@ function remove_player_image_mapping(playerId, imageUrl) {
 }
 
 function remove_all_player_image_mappings(playerId) {
-	let customization = find_player_token_customization(playerId);
+	let customization = find_token_customization(SidebarListItem.TypePC, playerId);
 	if (!customization) {
 		return;
 	}
@@ -192,7 +192,12 @@ function remove_all_player_image_mappings(playerId) {
 }
 
 function get_player_image_mappings(playerId) {
-	return get_player_token_customization(playerId).tokenOptions.alternativeImages || [];
+	try {
+		return find_or_create_token_customization(SidebarListItem.TypePC, playerId).tokenOptions.alternativeImages || [];
+	} catch (error) {
+		console.error("get_player_image_mappings failed to find_or_create_token_customization", playerId, error)
+		return [];
+	}
 }
 
 function random_image_for_player_token(playerId) {

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -143,6 +143,7 @@ function gather_pcs() {
 	localStorage.setItem(`CampaignCharacters${campaignId}`, JSON.stringify(window.pcs));
 }
 
+// deprecated, but still necessary for migrations
 function read_player_token_customizations() {
 	let customMappingData = localStorage.getItem('PlayerTokenCustomization');
 	if (customMappingData !== undefined && customMappingData != null) {
@@ -152,6 +153,7 @@ function read_player_token_customizations() {
 	}
 }
 
+// deprecated, but still necessary for migrations
 function write_player_token_customizations(customMappingData) {
 	if (customMappingData !== undefined && customMappingData != null) {
 		localStorage.setItem("PlayerTokenCustomization", JSON.stringify(customMappingData));
@@ -159,68 +161,38 @@ function write_player_token_customizations(customMappingData) {
 }
 
 function add_player_image_mapping(playerId, imageUrl) {
-	if (playerId === undefined || imageUrl === undefined) {
+	if (typeof playerId !== "string" || playerId.length === 0 || typeof imageUrl !== "string" || imageUrl.length === 0) {
 		return;
 	}
-	let customMappingData = read_player_token_customizations();
-	if (customMappingData[playerId] === undefined) {
-		customMappingData[playerId] = { images: [] };
+
+	let customization = find_player_token_customization(playerId);
+	if (!customization) {
+		return;
 	}
-	customMappingData[playerId].images.push(imageUrl);
-	write_player_token_customizations(customMappingData);
+	customization.addAlternativeImage(imageUrl);
+	persist_token_customization(customization);
 }
 
-function remove_player_image_mapping(playerId, index) {
-	if (playerId === undefined || index === undefined) {
+function remove_player_image_mapping(playerId, imageUrl) {
+	let customization = find_player_token_customization(playerId);
+	if (!customization) {
 		return;
 	}
-	let customMappingData = read_player_token_customizations();
-	if (customMappingData[playerId] === undefined || customMappingData[playerId].images === undefined) {
-		return;
-	}
-
-	if (customMappingData[playerId].images.length > index) {
-		customMappingData[playerId].images.splice(index, 1);
-	}
-
-	write_player_token_customizations(customMappingData);
+	customization.removeAlternativeImage(imageUrl);
+	persist_token_customization(customization);
 }
 
 function remove_all_player_image_mappings(playerId) {
-	if (playerId === undefined) {
+	let customization = find_player_token_customization(playerId);
+	if (!customization) {
 		return;
 	}
-	let customMappingData = read_player_token_customizations();
-	customMappingData[playerId].images = [];
-	write_player_token_customizations(customMappingData);
-}
-
-function get_player_token_customizations(playerId) {
-	let customMappingData = read_player_token_customizations();
-	if (customMappingData[playerId] === undefined) {
-		return { images: [] };
-	}
-	return customMappingData[playerId];
-}
-
-function set_player_token_customizations(playerId, customizations) {
-	if (playerId === undefined) {
-		return;
-	}
-	let customMappingData = read_player_token_customizations();
-	customMappingData[playerId] = {...customizations};
-	if (customMappingData[playerId].images === undefined) {
-		customMappingData[playerId].images = [];
-	}
-	write_player_token_customizations(customMappingData);
+	customization.removeAllAlternativeImages();
+	persist_token_customization(customization);
 }
 
 function get_player_image_mappings(playerId) {
-	let customizations = get_player_token_customizations(playerId);
-	if (customizations.images !== undefined) {
-		return customizations.images;
-	}
-	return [];
+	return get_player_token_customizations(playerId).tokenOptions.alternativeImages || [];
 }
 
 function random_image_for_player_token(playerId) {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1534,7 +1534,7 @@ function init_scenes_panel() {
 
 	let addSceneButton = $(`<button class="token-row-button" title="Create New Scene"><span class="material-icons">add_photo_alternate</span></button>`);
 	addSceneButton.on("click", function (clickEvent) {
-		create_scene_inside(RootFolderPath.Scenes);
+		create_scene_inside(RootFolder.Scenes.path);
 	});
 
 	let addFolderButton = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
@@ -1544,7 +1544,7 @@ function init_scenes_panel() {
 		if (numberOfNewFolders > 0) {
 			newFolderName = `${newFolderName} ${numberOfNewFolders}`
 		}
-		let newFolderItem = SidebarListItem.Folder(path_to_html_id(RootFolderPath.Scenes, newFolderName), RootFolderPath.Scenes, newFolderName, true, path_to_html_id(RootFolderPath.Scenes, newFolderName));
+		let newFolderItem = SidebarListItem.Folder(path_to_html_id(RootFolder.Scenes.path, newFolderName), RootFolder.Scenes.path, newFolderName, true, path_to_html_id(RootFolder.Scenes.path, newFolderName));
 		window.sceneListFolders.push(newFolderItem);
 		display_folder_configure_modal(newFolderItem);
 		did_update_scenes();
@@ -1582,13 +1582,13 @@ function rebuild_scene_items_list() {
 	window.sceneListItems
 		.sort(SidebarListItem.folderDepthComparator)
 		.forEach(item => {
-		if (item.folderPath !== RootFolderPath.Root) {
+		if (item.folderPath !== RootFolder.Root.path) {
 			// we split the path and backfill empty every folder along the way if needed. This is really important for folders that hold subfolders, but not items
 			let parts = item.folderPath.split("/");
 			let backfillPath = "";
 			parts.forEach(part => {
 				let fullBackfillPath = sanitize_folder_path(`${backfillPath}/${part}`);
-				if (fullBackfillPath !== "" && fullBackfillPath !== "/" && fullBackfillPath !== RootFolderPath.Scenes && !window.sceneListFolders.find(fi => fi.fullPath() === fullBackfillPath)) {
+				if (fullBackfillPath !== "" && fullBackfillPath !== "/" && fullBackfillPath !== RootFolder.Scenes.path && !window.sceneListFolders.find(fi => fi.fullPath() === fullBackfillPath)) {
 					// we don't have this folder yet so add it
 					let backfillItem = SidebarListItem.Folder(path_to_html_id(backfillPath, part), backfillPath, part, true, path_to_html_id(backfillPath));
 					console.log("adding folder", backfillItem);
@@ -1618,10 +1618,10 @@ function redraw_scene_list(searchTerm) {
 	// this is similar to the structure of a SidebarListItem.Folder row.
 	// since we don't have root folders like the tokensPanel does, we want to treat the entire list like a subfolder
 	// this will allow us to reuse all the folder traversing functions that the tokensPanel uses
-	let list = $(`<div id="${path_to_html_id(RootFolderPath.Scenes)}" class="folder not-collapsible"><div class="folder-item-list" style="padding: 0;"></div></div>`);
+	let list = $(`<div id="${path_to_html_id(RootFolder.Scenes.path)}" class="folder not-collapsible"><div class="folder-item-list" style="padding: 0;"></div></div>`);
 	scenesPanel.body.empty();
 	scenesPanel.body.append(list);
-	set_full_path(list, RootFolderPath.Scenes);
+	set_full_path(list, RootFolder.Scenes.path);
 
 	// first let's add all folders because we need the folder to exist in order to add items into it
 	// don't filter folders by the searchTerm because we need the folder to exist in order to add items into it
@@ -1683,7 +1683,7 @@ function create_scene_inside(fullPath) {
 
 	let sceneData = default_scene_data();
 	sceneData.title = newSceneName;
-	sceneData.folderPath = fullPath.replace(RootFolderPath.Scenes, "");
+	sceneData.folderPath = fullPath.replace(RootFolder.Scenes.path, "");
 
 	window.ScenesHandler.scenes.push(sceneData);
 	window.ScenesHandler.persist_scene(window.ScenesHandler.scenes.length - 1,true);
@@ -1693,12 +1693,12 @@ function create_scene_inside(fullPath) {
 
 function create_scene_folder_inside(fullPath) {
 	let newFolderName = "New Folder";
-	let adjustedPath = sanitize_folder_path(fullPath.replace(RootFolderPath.Scenes, ""));
-	let numberOfNewFolders = window.sceneListFolders.filter(i => sanitize_folder_path(i.folderPath.replace(RootFolderPath.Scenes, "")) === adjustedPath && i.name.startsWith(newFolderName)).length;
+	let adjustedPath = sanitize_folder_path(fullPath.replace(RootFolder.Scenes.path, ""));
+	let numberOfNewFolders = window.sceneListFolders.filter(i => sanitize_folder_path(i.folderPath.replace(RootFolder.Scenes.path, "")) === adjustedPath && i.name.startsWith(newFolderName)).length;
 	if (numberOfNewFolders > 0) {
 		newFolderName = `${newFolderName} ${numberOfNewFolders}`
 	}
-	let newFolderFullPath = sanitize_folder_path(`${RootFolderPath.Scenes}/${adjustedPath}`);
+	let newFolderFullPath = sanitize_folder_path(`${RootFolder.Scenes.path}/${adjustedPath}`);
 	let newFolderItem = SidebarListItem.Folder(path_to_html_id(newFolderFullPath, newFolderName), newFolderFullPath, newFolderName, true, path_to_html_id(newFolderFullPath));
 	window.sceneListFolders.push(newFolderItem);
 	did_update_scenes();
@@ -1707,7 +1707,7 @@ function create_scene_folder_inside(fullPath) {
 
 function rename_scene_folder(item, newName, alertUser) {
 	console.groupCollapsed("rename_folder");
-	if (!item.isTypeFolder() || !item.folderPath.startsWith(RootFolderPath.Scenes)) {
+	if (!item.isTypeFolder() || !item.folderPath.startsWith(RootFolder.Scenes.path)) {
 		console.warn("rename_folder called with an incorrect item type", item);
 		console.groupEnd();
 		if (alertUser !== false) {
@@ -1724,8 +1724,8 @@ function rename_scene_folder(item, newName, alertUser) {
 		return;
 	}
 
-	let fromFullPath = sanitize_folder_path(item.fullPath().replace(RootFolderPath.Scenes, ""));
-	let fromFolderPath = sanitize_folder_path(item.folderPath.replace(RootFolderPath.Scenes, ""));
+	let fromFullPath = sanitize_folder_path(item.fullPath().replace(RootFolder.Scenes.path, ""));
+	let fromFolderPath = sanitize_folder_path(item.folderPath.replace(RootFolder.Scenes.path, ""));
 	let toFullPath = sanitize_folder_path(`${fromFolderPath}/${newName}`);
 	if (scene_path_exists(toFullPath)) {
 		console.warn(`Attempted to rename folder to ${newName}, which would be have a path: ${toFullPath} but a folder with that path already exists`);
@@ -1775,7 +1775,7 @@ function rename_scene_folder(item, newName, alertUser) {
  * @returns {boolean} whether or not the path exists
  */
 function scene_path_exists(folderPath) {
-	const comparison = folderPath.startsWith(RootFolderPath.Scenes) ? folderPath : sanitize_folder_path(`${RootFolderPath.Scenes}/${folderPath}`);
+	const comparison = folderPath.startsWith(RootFolder.Scenes.path) ? folderPath : sanitize_folder_path(`${RootFolder.Scenes.path}/${folderPath}`);
 	const existingScene = window.sceneListItems.find(s => s.fullPath() === comparison) !== undefined;
 	const existingFolder = window.sceneListFolders.find(f => f.fullPath() === comparison) !== undefined;
 	console.debug("scene_path_exists", comparison, existingScene, existingFolder);
@@ -1847,7 +1847,7 @@ function expand_folders_to_active_scenes() {
 
 function delete_scenes_within_folder(listItem) {
 	console.groupCollapsed(`delete_mytokens_within_folder`);
-	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
+	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 
 	console.log("about to delete all scenes within", adjustedPath);
 	console.debug("before deleting from scenes", window.ScenesHandler.scenes);
@@ -1866,8 +1866,8 @@ function delete_scenes_within_folder(listItem) {
 
 function move_scenes_to_parent_folder(listItem) {
 	console.groupCollapsed(`move_mytokens_to_parent_folder`);
-	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
-	let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(RootFolderPath.Scenes, ""));
+	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
+	let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(RootFolder.Scenes.path, ""));
 
 	console.debug("before moving scenes", window.ScenesHandler.scenes);
 	window.ScenesHandler.scenes
@@ -1898,17 +1898,17 @@ function delete_scenes_folder(listItem) {
 function move_scene_to_folder(listItem, folderPath) {
 	let sceneIndex = window.ScenesHandler.scenes.findIndex(s => s.id === listItem.sceneId);
 	let scene = window.ScenesHandler.scenes[sceneIndex];
-	scene.folderPath = sanitize_folder_path(folderPath.replace(RootFolderPath.Scenes, ""));
+	scene.folderPath = sanitize_folder_path(folderPath.replace(RootFolder.Scenes.path, ""));
 	window.ScenesHandler.persist_scene(sceneIndex);
 }
 
 function move_scenes_folder(listItem, folderPath) {
 	console.groupCollapsed(`move_scenes_folder`);
-	let fromPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
+	let fromPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 
 	// move the actual item
-	listItem.folderPath = sanitize_folder_path(folderPath.replace(RootFolderPath.Scenes, ""));
-	let toPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
+	listItem.folderPath = sanitize_folder_path(folderPath.replace(RootFolder.Scenes.path, ""));
+	let toPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 
 	// move subfolders. This isn't exactly necessary since we'll just rebuild the list anyway, but any empty folders need to be updated
 	window.sceneListFolders.forEach(f => {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1576,7 +1576,9 @@ function rebuild_scene_items_list() {
 	console.group("rebuild_scene_items_list");
 	window.sceneListItems = window.ScenesHandler.scenes.map(s => SidebarListItem.Scene(s)).sort(SidebarListItem.sortComparator);
 	// TODO: read scene folders from localStorage?
-	window.sceneListFolders = [];
+	if (!window.sceneListFolders) {
+		window.sceneListFolders = [];
+	}
 	window.sceneListItems
 		.sort(SidebarListItem.folderDepthComparator)
 		.forEach(item => {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1526,15 +1526,15 @@ function init_scenes_panel() {
 	let reorderButton = $(`<button class="token-row-button reorder-button" title="Reorder Scenes"><span class="material-icons">reorder</span></button>`);
 	reorderButton.on("click", function (clickEvent) {
 		if ($(clickEvent.currentTarget).hasClass("active")) {
-			disable_draggable_change_folder(SidebarListItem.TypeScene);
+			disable_draggable_change_folder(ItemType.Scene);
 		} else {
-			enable_draggable_change_folder(SidebarListItem.TypeScene);
+			enable_draggable_change_folder(ItemType.Scene);
 		}
 	});
 
 	let addSceneButton = $(`<button class="token-row-button" title="Create New Scene"><span class="material-icons">add_photo_alternate</span></button>`);
 	addSceneButton.on("click", function (clickEvent) {
-		create_scene_inside(SidebarListItem.PathScenes);
+		create_scene_inside(RootFolderPath.Scenes);
 	});
 
 	let addFolderButton = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
@@ -1544,7 +1544,7 @@ function init_scenes_panel() {
 		if (numberOfNewFolders > 0) {
 			newFolderName = `${newFolderName} ${numberOfNewFolders}`
 		}
-		let newFolderItem = SidebarListItem.Folder(SidebarListItem.PathScenes, newFolderName, true);
+		let newFolderItem = SidebarListItem.Folder(RootFolderPath.Scenes, newFolderName, true);
 		window.sceneListFolders.push(newFolderItem);
 		display_folder_configure_modal(newFolderItem);
 		did_update_scenes();
@@ -1582,7 +1582,7 @@ function rebuild_scene_items_list() {
 	window.sceneListItems
 		.sort(SidebarListItem.folderDepthComparator)
 		.forEach(item => {
-		if (item.folderPath !== SidebarListItem.PathRoot) {
+		if (item.folderPath !== RootFolderPath.Root) {
 			// we split the path and backfill empty every folder along the way if needed. This is really important for folders that hold subfolders, but not items
 			let parts = item.folderPath.split("/");
 			let backfillPath = "";
@@ -1621,7 +1621,7 @@ function redraw_scene_list(searchTerm) {
 	let list = $(`<div class="folder not-collapsible"><div class="folder-item-list" style="padding: 0;"></div></div>`);
 	scenesPanel.body.empty();
 	scenesPanel.body.append(list);
-	set_full_path(list, SidebarListItem.PathScenes);
+	set_full_path(list, RootFolderPath.Scenes);
 
 	// first let's add all folders because we need the folder to exist in order to add items into it
 	// don't filter folders by the searchTerm because we need the folder to exist in order to add items into it
@@ -1681,7 +1681,7 @@ function create_scene_inside(fullPath) {
 
 	let sceneData = default_scene_data();
 	sceneData.title = newSceneName;
-	sceneData.folderPath = fullPath.replace(SidebarListItem.PathScenes, "");
+	sceneData.folderPath = fullPath.replace(RootFolderPath.Scenes, "");
 
 	window.ScenesHandler.scenes.push(sceneData);
 	window.ScenesHandler.persist_scene(window.ScenesHandler.scenes.length - 1,true);
@@ -1691,12 +1691,12 @@ function create_scene_inside(fullPath) {
 
 function create_scene_folder_inside(fullPath) {
 	let newFolderName = "New Folder";
-	let adjustedPath = sanitize_folder_path(fullPath.replace(SidebarListItem.PathScenes, ""));
-	let numberOfNewFolders = window.sceneListFolders.filter(i => sanitize_folder_path(i.folderPath.replace(SidebarListItem.PathScenes, "")) === adjustedPath && i.name.startsWith(newFolderName)).length;
+	let adjustedPath = sanitize_folder_path(fullPath.replace(RootFolderPath.Scenes, ""));
+	let numberOfNewFolders = window.sceneListFolders.filter(i => sanitize_folder_path(i.folderPath.replace(RootFolderPath.Scenes, "")) === adjustedPath && i.name.startsWith(newFolderName)).length;
 	if (numberOfNewFolders > 0) {
 		newFolderName = `${newFolderName} ${numberOfNewFolders}`
 	}
-	let newFolderFullPath = sanitize_folder_path(`${SidebarListItem.PathScenes}/${adjustedPath}`);
+	let newFolderFullPath = sanitize_folder_path(`${RootFolderPath.Scenes}/${adjustedPath}`);
 	let newFolderItem = SidebarListItem.Folder(newFolderFullPath, newFolderName, true);
 	window.sceneListFolders.push(newFolderItem);
 	did_update_scenes();
@@ -1705,7 +1705,7 @@ function create_scene_folder_inside(fullPath) {
 
 function rename_scene_folder(item, newName, alertUser) {
 	console.groupCollapsed("rename_folder");
-	if (!item.isTypeFolder() || !item.folderPath.startsWith(SidebarListItem.PathScenes)) {
+	if (!item.isTypeFolder() || !item.folderPath.startsWith(RootFolderPath.Scenes)) {
 		console.warn("rename_folder called with an incorrect item type", item);
 		console.groupEnd();
 		if (alertUser !== false) {
@@ -1722,8 +1722,8 @@ function rename_scene_folder(item, newName, alertUser) {
 		return;
 	}
 
-	let fromFullPath = sanitize_folder_path(item.fullPath().replace(SidebarListItem.PathScenes, ""));
-	let fromFolderPath = sanitize_folder_path(item.folderPath.replace(SidebarListItem.PathScenes, ""));
+	let fromFullPath = sanitize_folder_path(item.fullPath().replace(RootFolderPath.Scenes, ""));
+	let fromFolderPath = sanitize_folder_path(item.folderPath.replace(RootFolderPath.Scenes, ""));
 	let toFullPath = sanitize_folder_path(`${fromFolderPath}/${newName}`);
 	if (scene_path_exists(toFullPath)) {
 		console.warn(`Attempted to rename folder to ${newName}, which would be have a path: ${toFullPath} but a folder with that path already exists`);
@@ -1773,7 +1773,7 @@ function rename_scene_folder(item, newName, alertUser) {
  * @returns {boolean} whether or not the path exists
  */
 function scene_path_exists(folderPath) {
-	const comparison = folderPath.startsWith(SidebarListItem.PathScenes) ? folderPath : sanitize_folder_path(`${SidebarListItem.PathScenes}/${folderPath}`);
+	const comparison = folderPath.startsWith(RootFolderPath.Scenes) ? folderPath : sanitize_folder_path(`${RootFolderPath.Scenes}/${folderPath}`);
 	const existingScene = window.sceneListItems.find(s => s.fullPath() === comparison) !== undefined;
 	const existingFolder = window.sceneListFolders.find(f => f.fullPath() === comparison) !== undefined;
 	console.debug("scene_path_exists", comparison, existingScene, existingFolder);
@@ -1845,7 +1845,7 @@ function expand_folders_to_active_scenes() {
 
 function delete_scenes_within_folder(listItem) {
 	console.groupCollapsed(`delete_mytokens_within_folder`);
-	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathScenes, ""));
+	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
 
 	console.log("about to delete all scenes within", adjustedPath);
 	console.debug("before deleting from scenes", window.ScenesHandler.scenes);
@@ -1864,8 +1864,8 @@ function delete_scenes_within_folder(listItem) {
 
 function move_scenes_to_parent_folder(listItem) {
 	console.groupCollapsed(`move_mytokens_to_parent_folder`);
-	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathScenes, ""));
-	let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(SidebarListItem.PathScenes, ""));
+	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
+	let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(RootFolderPath.Scenes, ""));
 
 	console.debug("before moving scenes", window.ScenesHandler.scenes);
 	window.ScenesHandler.scenes
@@ -1896,17 +1896,17 @@ function delete_scenes_folder(listItem) {
 function move_scene_to_folder(listItem, folderPath) {
 	let sceneIndex = window.ScenesHandler.scenes.findIndex(s => s.id === listItem.sceneId);
 	let scene = window.ScenesHandler.scenes[sceneIndex];
-	scene.folderPath = sanitize_folder_path(folderPath.replace(SidebarListItem.PathScenes, ""));
+	scene.folderPath = sanitize_folder_path(folderPath.replace(RootFolderPath.Scenes, ""));
 	window.ScenesHandler.persist_scene(sceneIndex);
 }
 
 function move_scenes_folder(listItem, folderPath) {
 	console.groupCollapsed(`move_scenes_folder`);
-	let fromPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathScenes, ""));
+	let fromPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
 
 	// move the actual item
-	listItem.folderPath = sanitize_folder_path(folderPath.replace(SidebarListItem.PathScenes, ""));
-	let toPath = sanitize_folder_path(listItem.fullPath().replace(SidebarListItem.PathScenes, ""));
+	listItem.folderPath = sanitize_folder_path(folderPath.replace(RootFolderPath.Scenes, ""));
+	let toPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.Scenes, ""));
 
 	// move subfolders. This isn't exactly necessary since we'll just rebuild the list anyway, but any empty folders need to be updated
 	window.sceneListFolders.forEach(f => {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1576,9 +1576,6 @@ function rebuild_scene_items_list() {
 	console.group("rebuild_scene_items_list");
 	window.sceneListItems = window.ScenesHandler.scenes.map(s => SidebarListItem.Scene(s)).sort(SidebarListItem.sortComparator);
 	// TODO: read scene folders from localStorage?
-	if (window.sceneListFolders === undefined) {
-		window.sceneListFolders = [];
-	}
 	window.sceneListFolders = [];
 	window.sceneListItems
 		.sort(SidebarListItem.folderDepthComparator)
@@ -1601,6 +1598,7 @@ function rebuild_scene_items_list() {
 			});
 		}
 	});
+	update_token_folders_remembered_state();
 	console.groupEnd();
 }
 

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1712,7 +1712,7 @@ function rename_scene_folder(item, newName, alertUser) {
 		console.groupEnd();
 		console.warn("rename_scene_folder called with an incorrect item type", item);
 		if (alertUser !== false) {
-			showGenericAlert();
+			showDebuggingAlert();
 		}
 		return;
 	}
@@ -1720,7 +1720,7 @@ function rename_scene_folder(item, newName, alertUser) {
 		console.groupEnd();
 		console.warn("rename_scene_folder Not allowed to rename folder", item);
 		if (alertUser !== false) {
-			showGenericAlert();
+			showDebuggingAlert();
 		}
 		return;
 	}

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1847,7 +1847,7 @@ function expand_folders_to_active_scenes() {
 }
 
 function delete_scenes_within_folder(listItem) {
-	console.groupCollapsed(`delete_mytokens_within_folder`);
+	console.groupCollapsed(`delete_scenes_within_folder`);
 	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 
 	console.log("about to delete all scenes within", adjustedPath);
@@ -1866,7 +1866,7 @@ function delete_scenes_within_folder(listItem) {
 }
 
 function move_scenes_to_parent_folder(listItem) {
-	console.groupCollapsed(`move_mytokens_to_parent_folder`);
+	console.groupCollapsed(`move_scenes_to_parent_folder`);
 	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 	let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(RootFolder.Scenes.path, ""));
 

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1548,7 +1548,7 @@ function init_scenes_panel() {
 		window.sceneListFolders.push(newFolderItem);
 		display_folder_configure_modal(newFolderItem);
 		did_update_scenes();
-		expand_all_folders_up_to(newFolderItem.fullPath(), scenesPanel.body);
+		expand_all_folders_up_to_item(newFolderItem);
 	});
 
 	let headerWrapper = $(`<div class="scenes-panel-add-buttons-wrapper"></div>`);
@@ -1579,6 +1579,7 @@ function rebuild_scene_items_list() {
 	if (window.sceneListFolders === undefined) {
 		window.sceneListFolders = [];
 	}
+	window.sceneListFolders = [];
 	window.sceneListItems
 		.sort(SidebarListItem.folderDepthComparator)
 		.forEach(item => {
@@ -1706,20 +1707,20 @@ function create_scene_folder_inside(fullPath) {
 }
 
 function rename_scene_folder(item, newName, alertUser) {
-	console.groupCollapsed("rename_folder");
+	console.groupCollapsed("rename_scene_folder");
 	if (!item.isTypeFolder() || !item.folderPath.startsWith(RootFolder.Scenes.path)) {
-		console.warn("rename_folder called with an incorrect item type", item);
 		console.groupEnd();
+		console.warn("rename_scene_folder called with an incorrect item type", item);
 		if (alertUser !== false) {
-			alert("An unexpected error occurred");
+			showGenericAlert();
 		}
 		return;
 	}
 	if (!item.canEdit()) {
-		console.warn("Not allowed to rename folder", item);
 		console.groupEnd();
+		console.warn("rename_scene_folder Not allowed to rename folder", item);
 		if (alertUser !== false) {
-			alert("An unexpected error occurred");
+			showGenericAlert();
 		}
 		return;
 	}
@@ -1837,11 +1838,11 @@ function register_scene_row_context_menu() {
 function expand_folders_to_active_scenes() {
 	let dmSceneItem = window.sceneListItems.find(i => i.sceneId === window.CURRENT_SCENE_DATA.id);
 	if (dmSceneItem) {
-		expand_all_folders_up_to(dmSceneItem.fullPath(), scenesPanel.body);
+		expand_all_folders_up_to_item(dmSceneItem);
 	}
 	let pcSceneItem = window.sceneListItems.find(i => i.sceneId === window.PLAYER_SCENE_ID);
 	if (pcSceneItem) {
-		expand_all_folders_up_to(pcSceneItem.fullPath(), scenesPanel.body);
+		expand_all_folders_up_to_item(pcSceneItem);
 	}
 }
 

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1544,7 +1544,7 @@ function init_scenes_panel() {
 		if (numberOfNewFolders > 0) {
 			newFolderName = `${newFolderName} ${numberOfNewFolders}`
 		}
-		let newFolderItem = SidebarListItem.Folder(RootFolderPath.Scenes, newFolderName, true);
+		let newFolderItem = SidebarListItem.Folder(path_to_html_id(RootFolderPath.Scenes, newFolderName), RootFolderPath.Scenes, newFolderName, true, path_to_html_id(RootFolderPath.Scenes, newFolderName));
 		window.sceneListFolders.push(newFolderItem);
 		display_folder_configure_modal(newFolderItem);
 		did_update_scenes();
@@ -1588,9 +1588,9 @@ function rebuild_scene_items_list() {
 			let backfillPath = "";
 			parts.forEach(part => {
 				let fullBackfillPath = sanitize_folder_path(`${backfillPath}/${part}`);
-				if (!window.sceneListFolders.find(fi => fi.fullPath() === fullBackfillPath)) {
+				if (fullBackfillPath !== "" && fullBackfillPath !== "/" && fullBackfillPath !== RootFolderPath.Scenes && !window.sceneListFolders.find(fi => fi.fullPath() === fullBackfillPath)) {
 					// we don't have this folder yet so add it
-					let backfillItem = SidebarListItem.Folder(backfillPath, part, true);
+					let backfillItem = SidebarListItem.Folder(path_to_html_id(backfillPath, part), backfillPath, part, true, path_to_html_id(backfillPath));
 					console.log("adding folder", backfillItem);
 					window.sceneListFolders.push(backfillItem);
 				} else {
@@ -1618,7 +1618,7 @@ function redraw_scene_list(searchTerm) {
 	// this is similar to the structure of a SidebarListItem.Folder row.
 	// since we don't have root folders like the tokensPanel does, we want to treat the entire list like a subfolder
 	// this will allow us to reuse all the folder traversing functions that the tokensPanel uses
-	let list = $(`<div class="folder not-collapsible"><div class="folder-item-list" style="padding: 0;"></div></div>`);
+	let list = $(`<div id="${path_to_html_id(RootFolderPath.Scenes)}" class="folder not-collapsible"><div class="folder-item-list" style="padding: 0;"></div></div>`);
 	scenesPanel.body.empty();
 	scenesPanel.body.append(list);
 	set_full_path(list, RootFolderPath.Scenes);
@@ -1629,7 +1629,8 @@ function redraw_scene_list(searchTerm) {
 		.sort(SidebarListItem.folderDepthComparator)
 		.forEach(item => {
 			let row = build_sidebar_list_row(item);
-			let folder = find_html_row_from_path(item.folderPath, scenesPanel.body).find(` > .folder-item-list`);
+			// let folder = find_html_row_from_path(item.folderPath, scenesPanel.body).find(` > .folder-item-list`);
+			let folder = $(`#${item.parentId} > .folder-item-list`);
 			if (folder.length > 0) {
 				console.debug("appending folder item", item, folder);
 				folder.append(row);
@@ -1644,7 +1645,8 @@ function redraw_scene_list(searchTerm) {
 		.filter(item => item.nameOrContainingFolderMatches(nameFilter))
 		.forEach(item => {
 			let row = build_sidebar_list_row(item);
-			let folder = find_html_row_from_path(item.folderPath, scenesPanel.body).find(` > .folder-item-list`);
+			let folder = $(`#${item.parentId} > .folder-item-list`);
+			// let folder = find_html_row_from_path(item.folderPath, scenesPanel.body).find(` > .folder-item-list`);
 			if (folder.length > 0) {
 				console.debug("appending scene item", item, folder);
 				folder.append(row);
@@ -1697,7 +1699,7 @@ function create_scene_folder_inside(fullPath) {
 		newFolderName = `${newFolderName} ${numberOfNewFolders}`
 	}
 	let newFolderFullPath = sanitize_folder_path(`${RootFolderPath.Scenes}/${adjustedPath}`);
-	let newFolderItem = SidebarListItem.Folder(newFolderFullPath, newFolderName, true);
+	let newFolderItem = SidebarListItem.Folder(path_to_html_id(newFolderFullPath, newFolderName), newFolderFullPath, newFolderName, true, path_to_html_id(newFolderFullPath));
 	window.sceneListFolders.push(newFolderItem);
 	did_update_scenes();
 	display_folder_configure_modal(newFolderItem);

--- a/Settings.js
+++ b/Settings.js
@@ -24,11 +24,11 @@ function token_setting_options() {
 			label: 'Token Style',
 			type: 'dropdown',
 			options: [
-				{ value: "circle", label: "Circle", description: "The token is a circle and is contained within the border. Great for portrait-style tokens!" },
-				{ value: "square", label: "Square", description: "The token is square and is contained within the border. Great for portrait-style tokens!" },
-				{ value: "virtualMiniCircle", label: "Virtual Mini w/ Round Base", description: "The token looks like a physical mini with a round base. The art is not contained within the border allowing the token art to extend beyond the token base. Great for top-down-style tokens!" },
-				{ value: "virtualMiniSquare", label: "Virtual Mini w/ Square Base", description: "The token looks like a physical mini with a round base. The art is not contained within the border allowing the token art to extend beyond the token base. Great for top-down-style tokens!" },
-				{ value: "noConstraint", label: "No Constraint", description: "The token does not conform to any provided structure. Choose between various settings to make the token look the way you want. We recommend using a different option." }
+				{ value: "circle", label: "Circle", description: `The token is round and is contained within the border. We set "Ignore Aspect Ratio" to true and "Square" to false. Great for tokens with a portrait art style!` },
+				{ value: "square", label: "Square", description: `The token is square and is contained within the border. We set "Ignore Aspect Ratio" to true and "Square" to true. Great for tokens with a portrait art style!` },
+				{ value: "virtualMiniCircle", label: "Virtual Mini w/ Round Base", description: `The token looks like a physical mini with a round base. The image will show up as it is naturally with the largest side being equal to the token size, we set "Ignore Aspect Ratio" to false and "Square" to true. We also add a virtual token base to this Style with Borders and Health Aura on the base of the token. Great for tokens with a top-down art style!` },
+				{ value: "virtualMiniSquare", label: "Virtual Mini w/ Square Base", description: `The token looks like a physical mini with a round base. The image will show up as it is naturally with The largest side being equal to the token size, we set "Ignore Aspect Ratio" to false and "Square" to true. We also add a virtual token base to this Style with Borders and Health Aura on the base of the token. Great for tokens with a top-down art style!` },
+				{ value: "noConstraint", label: "No Constraint", description: `The token will show up as it is naturally largest side being equal to token size, we set "Ignore Aspect Ratio" to false and "Square to true. Borders and Health Aura are drawn as a drop shadow to fit the shape of the token.` }
 			],
 			defaultValue: "circle"
 		},
@@ -37,12 +37,12 @@ function token_setting_options() {
 			label: 'Token Base Style',
 			type: 'dropdown',
 			options: [
-				{ value: "default", label: "Default", description: "The base of the token is a flat color instead of a texture." },
-				{ value: "grass", label: "Grass", description: "The base has a Grass texture on it." },
-				{ value: "tile", label: "Tile", description: "The base has a Tile texture on it." },
-				{ value: "sand", label: "Sand", description: "The base has a Sand texture on it." },
-				{ value: "rock", label: "Rock", description: "The base has a Rock texture on it." },
-				{ value: "water", label: "Water", description: "The base has a Water texture on it." }
+				{ value: "default", label: "Default", description: "A default dark semi-opaque plastic base." },
+				{ value: "grass", label: "Grass", description: "A grass covered base.." },
+				{ value: "tile", label: "Tile", description: "A tile base." },
+				{ value: "sand", label: "Sand", description: "A sand covered base." },
+				{ value: "rock", label: "Rock", description: "A rock base." },
+				{ value: "water", label: "Water", description: "A water base." }
 			],
 			defaultValue: "default"
 		},
@@ -455,7 +455,7 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 	let resetToDefaults = $(`<button class='token-image-modal-remove-all-button' title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px;">Reset Token Settings to Defaults</button>`);
 	resetToDefaults.on("click", function (clickEvent) {
 
-		let tokenOptionsFlyoutContainer = $(clickEvent.currentTarget).closest(".sidebar-token-options-flyout-container");
+		let tokenOptionsFlyoutContainer = $(clickEvent.currentTarget).parent();
 
 		// disable all toggle switches
 		tokenOptionsFlyoutContainer
@@ -469,10 +469,7 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 			.each(function () {
 				let el = $(this);
 				let matchingOption = availableOptions.find(o => o.name === el.attr("name"));
-				if (matchingOption?.defaultValue !== undefined) {
-					console.debug(`Resetting ${matchingOption.name} to`, matchingOption.defaultValue);
-					el.val(matchingOption.defaultValue);
-				}
+				el.find(`option[value=${matchingOption.defaultValue}]`).attr('selected','selected');
 			});
 
 		// This is why we want multiple callback functions.

--- a/Settings.js
+++ b/Settings.js
@@ -1,135 +1,183 @@
-const token_setting_options = [
-	{
-		name: 'tokenStyleSelect',
-		type: 'dropdown',
-		label: 'Token Style',
-		options: [
-			$(`<option value='1'>Circle</option>`), 
-			$(`<option value='2'>Square</option>`), 
-			$(`<option value='3'>No Constraint</option>`), 
-			$(`<option value='4'>Virtual Mini Circle</option>`), 
-			$(`<option value='5'>Virtual Mini Square</option>`)
- 		]
-	},
-	{
-		name: 'tokenBaseStyleSelect',
-		type: 'dropdown',
-		label: 'Token Base Style',
-		options: [
-			$(`<option value='1'>Default</option>`), 
-			$(`<option value='2'>Grass</option>`), 
-			$(`<option value='3'>Tile</option>`), 
-			$(`<option value='4'>Sand</option>`), 
-			$(`<option value='5'>Rock</option>`),
-			$(`<option value='6'>Water</option>`)
- 		]
-	},
-	{
-		name: 'hidden',
-		label: 'Hide',
-		enabledDescription: 'The token is hidden to players.',
-		disabledDescription: 'The token is visible to players.',
-		enabledValue: 'Hidden',
-		disabledValue: 'Visible'
-	},     
-	{
-		name: 'square',
-		label: 'Square Token',
-		enabledDescription: 'The token is square.',
-		disabledDescription: 'The token is clipped to fit within a circle.',
-		enabledValue: 'Square',
-		disabledValue: 'Round'
-	},
-	{
-		name: 'locked',
-		label: 'Disable All Interaction',
-		enabledDescription: "The token can not be interacted with in any way. Not movable, not selectable by players, no hp/ac displayed, no border displayed, no nothing. Players shouldn't even know it's a token.",
-		disabledDescription: 'The token can be interacted with.',
-		enabledValue: 'Interaction Disabled',
-		disabledValue: 'Interaction Allowed'
-	},
-	{
-		name: 'restrictPlayerMove',
-		label: 'Restrict Player Movement',
-		enabledDescription: 'Players can not move the token.',
-		disabledDescription: 'Players can move the token.',
-		enabledValue: 'Restricted',
-		disabledValue: 'Unrestricted'
-	},
-	{
-		name: 'disablestat',
-		label: 'Remove HP/AC',
-		enabledDescription: 'The token does not have HP/AC shown to either the DM or the players.',
-		disabledDescription: 'The token has HP/AC shown to only the DM.',
-		enabledValue: 'Removed',
-		disabledValue: 'Visible to DM'
-	},
-	{
-		name: 'hidestat',
-		label: 'Hide Player HP/AC',
-		enabledDescription: "Each player can see their own HP/AC, but can't see the HP/AC of other players.",
-		disabledDescription: "Each player can see their own HP/AC as well as the HP/AC of other players.",
-		enabledValue: 'Hidden',
-		disabledValue: 'Visible'
-	},
-	{
-		name: 'hidehpbar',
-		label: 'Only show HP values on hover',
-		enabledDescription: "HP values are only shown when you hover or select the token. The 'Disable HP/AC' option overrides this one.",
-		disabledDescription: "HP values are always displayed on the token. The 'Disable HP/AC' option overrides this one.",
-		enabledValue: 'On Hover',
-		disabledValue: 'Always'
-	},
-	{
-		name: 'disableborder',
-		label: 'Disable Border',
-		enabledDescription: 'The token has a border drawn around the image.',
-		disabledDescription: 'The token does not have a border drawn around the image.',
-		enabledValue: 'No Border',
-		disabledValue: 'Border'
-	},
-	{
-		name: 'disableaura',
-		label: 'Disable Health Aura',
-		enabledDescription: "An aura is drawn around the token's image that represents current health.",
-		disabledDescription: "Enable this to have an aura drawn around the token's image that represents current health.",
-		enabledValue: 'No Aura',
-		disabledValue: 'Health Aura'
-	},
-	{
-		name: 'enablepercenthpbar',
-		label: 'Enable Token HP% Bar',
-		enabledDescription: 'The token has a traditional visual hp% bar below it',
-		disabledDescription: 'The token does not have a traditional visual hp% bar below it',
-		enabledValue: 'Health Bar',
-		disabledValue: 'No Bar'
-	},
-	{
-		name: 'revealname',
-		label: 'Show name to players',
-		enabledDescription: "The token's name is visible to players",
-		disabledDescription: "The token's name is hidden from players",
-		enabledValue: 'Visible',
-		disabledValue: 'Hidden'
-	},
-	{
-		name: 'legacyaspectratio',
-		label: 'Ignore Image Aspect Ratio',
-		enabledDescription: "The token's image will stretch to fill the token space",
-		disabledDescription: "New token's image will respect the aspect ratio of the image provided",
-		enabledValue: 'Stretch',
-		disabledValue: 'Maintain'
-	},
-	{
-		name: "player_owned",
-		label: "Player Accessible Stats",
-		enabledDescription: "The token's stat block is accessible to players via the token context menu. Players can also alter the HP/AC of this token.",
-		disabledDescription: "The token's stat block is not accessible to players via the token context menu. Players can not alter the HP/AC of this token.",
-		enabledValue: 'Player & DM',
-		disabledValue: 'DM only'
-	}
 
-];
+function is_valid_token_option_value(tokenOptionName, value) {
+	return token_setting_options().find(o => o.name === tokenOptionName)?.options?.map(value).includes(value);
+}
+
+function convert_option_to_override_dropdown(tokenOption) {
+	// Note: Spread syntax effectively goes one level deep while copying an array. Therefore, it may be unsuitable for copying multidimensional arrays or objects
+	// we are explicitly not using the spread operator at this level because we need to deep copy the object
+	let converted = {
+		name: tokenOption.name,
+		label: tokenOption.label,
+		type: 'dropdown',
+		options: tokenOption.options.map(option => { return {...option} }),
+		defaultValue: undefined
+	};
+	converted.options.push({ value: undefined, label: "Not Overridden", description: "Changing this setting will override the default settings" });
+	return converted;
+}
+
+function token_setting_options() {
+	return [
+		{
+			name: 'tokenStyleSelect',
+			label: 'Token Style',
+			type: 'dropdown',
+			options: [
+				{ value: "circle", label: "Circle", description: "The token is a circle and is contained within the border. Great for portrait-style tokens!" },
+				{ value: "square", label: "Square", description: "The token is square and is contained within the border. Great for portrait-style tokens!" },
+				{ value: "virtualMiniCircle", label: "Virtual Mini w/ Round Base", description: "The token looks like a physical mini with a round base. The art is not contained within the border allowing the token art to extend beyond the token base. Great for top-down-style tokens!" },
+				{ value: "virtualMiniSquare", label: "Virtual Mini w/ Square Base", description: "The token looks like a physical mini with a round base. The art is not contained within the border allowing the token art to extend beyond the token base. Great for top-down-style tokens!" },
+				{ value: "noConstraint", label: "No Constraint", description: "The token does not conform to any provided structure. Choose between various settings to make the token look the way you want. We recommend using a different option." }
+			],
+			defaultValue: "circle"
+		},
+		{
+			name: 'tokenBaseStyleSelect',
+			label: 'Token Base Style',
+			type: 'dropdown',
+			options: [
+				{ value: "default", label: "Default", description: "The base of the token is a flat color instead of a texture." },
+				{ value: "grass", label: "Grass", description: "The base has a Grass texture on it." },
+				{ value: "tile", label: "Tile", description: "The base has a Tile texture on it." },
+				{ value: "sand", label: "Sand", description: "The base has a Sand texture on it." },
+				{ value: "rock", label: "Rock", description: "The base has a Rock texture on it." },
+				{ value: "water", label: "Water", description: "The base has a Water texture on it." }
+			],
+			defaultValue: "default"
+		},
+		{
+			name: 'hidden',
+			label: 'Hide',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "Hidden", description: "The token is hidden to players." },
+				{ value: false, label: "Visible", description: "The token is visible to players." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'square',
+			label: 'Square Token',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "Square", description: "The token is square." },
+				{ value: false, label: "Round", description: "The token is clipped to fit within a circle." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'locked',
+			label: 'Disable All Interaction',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "Interaction Disabled", description: "The token can not be interacted with in any way. Not movable, not selectable by players, no hp/ac displayed, no border displayed, no nothing. Players shouldn't even know it's a token." },
+				{ value: false, label: "Interaction Allowed", description: "The token can be interacted with." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'restrictPlayerMove',
+			label: 'Restrict Player Movement',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "Restricted", description: "Players can not move the token." },
+				{ value: false, label: "Unrestricted", description: "Players can move the token." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'disablestat',
+			label: 'Remove HP/AC',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "Removed", description: "The token does not have HP/AC shown to either the DM or the players." },
+				{ value: false, label: "Visible to DM", description: "The token has HP/AC shown to only the DM." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'hidestat',
+			label: 'Hide Player HP/AC',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "Hidden", description: "Each player can see their own HP/AC, but can't see the HP/AC of other players." },
+				{ value: false, label: "Visible", description: "Each player can see their own HP/AC as well as the HP/AC of other players." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'hidehpbar',
+			label: 'Only show HP values on hover',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "On Hover", description: "HP values are only shown when you hover or select the token. The 'Disable HP/AC' option overrides this one." },
+				{ value: false, label: "Always", description: "HP values are always displayed on the token. The 'Disable HP/AC' option overrides this one." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'disableborder',
+			label: 'Disable Border',
+			type: 'toggle',
+			options: [
+				{ value: true, label: 'No Border', description: "The token has a border drawn around the image." },
+				{ value: false, label: 'Border', description: "The token does not have a border drawn around the image." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'disableaura',
+			label: 'Disable Health Aura',
+			type: 'toggle',
+			options: [
+				{ value: true, label: 'No Aura', description: "An aura is drawn around the token's image that represents current health." },
+				{ value: false, label: 'Health Aura', description: "Enable this to have an aura drawn around the token's image that represents current health." }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'enablepercenthpbar',
+			label: 'Enable Token HP% Bar',
+			type: 'toggle',
+			options: [
+				{ value: true, label: 'Health Bar', description: "The token has a traditional visual hp% bar below it" },
+				{ value: false, label: 'No Bar', description: "The token does not have a traditional visual hp% bar below it" }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'revealname',
+			label: 'Show name to players',
+			type: 'toggle',
+			options: [
+				{ value: true, label: 'Visible', description: "The token's name is visible to players" },
+				{ value: false, label: 'Hidden', description: "The token's name is hidden from players" }
+			],
+			defaultValue: false
+		},
+		{
+			name: 'legacyaspectratio',
+			label: 'Ignore Image Aspect Ratio',
+			type: 'toggle',
+			options: [
+				{ value: true, label: 'Stretch', description: "The token's image will stretch to fill the token space" },
+				{ value: false, label: 'Maintain', description: "New token's image will respect the aspect ratio of the image provided" }
+			],
+			defaultValue: false
+		},
+		{
+			name: "player_owned",
+			label: "Player Accessible Stats",
+			type: 'toggle',
+			options: [
+				{ value: true, label: 'Player & DM', description: "The token's stat block is accessible to players via the token context menu. Players can also alter the HP/AC of this token." },
+				{ value: false, label: 'DM only', description: "The token's stat block is not accessible to players via the token context menu. Players can not alter the HP/AC of this token." }
+			],
+			defaultValue: false
+		}
+	];
+}
 
 function b64EncodeUnicode(str) {
         // first we use encodeURIComponent to get percent-encoded UTF-8,
@@ -234,7 +282,7 @@ function init_settings(){
 	let tokenOptionsButton = $(`<button class="sidebar-panel-footer-button">Change The Default Token Options</button>`);
 	tokenOptionsButton.on("click", function (clickEvent) {
 		build_and_display_sidebar_flyout(clickEvent.clientY, function (flyout) {
-			let optionsContainer = build_sidebar_token_options_flyout(token_setting_options, window.TOKEN_SETTINGS, TOKEN_OPTIONS_INPUT_TYPE_TOGGLE, function (name, value) {
+			let optionsContainer = build_sidebar_token_options_flyout(token_setting_options(), window.TOKEN_SETTINGS, function (name, value) {
 				if (value === true || value === false || typeof value === 'string') {
 					window.TOKEN_SETTINGS[name] = value;
 				} else {
@@ -254,20 +302,17 @@ function init_settings(){
 
 	const experimental_features = [
 		{
-			name: 'DEBUGddbDiceMonsterPanel',
-			label: 'Debug Monsters Tab Loading',
-			enabledDescription: "All of the loading indicators will be transparent, and the monsters tab will be selected by default. This is to allow developers to visually see what is happening while debugging. (Changing this requires a page reload)",
-			disabledDescription: "If you are not a developer, please ignore this feature. It is to allow developers to visually see what is happening in the monsters panel while debugging. (Changing this requires a page reload)",
-			dmOnly: true
+			name: 'streamDiceRolls',
+			label: 'Stream Dice Rolls',
+			type: 'toggle',
+			options: [
+				{ value: true, label: "Streaming", description: `You and your players can find the button to join the dice stream in the game log in the top right corner. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.` },
+				{ value: false, label: "Not Streaming", description: `This will enable the dice stream feature for everyone. You will all still have to join the dice stream. You and your players can find the button to do this in the game log in the top right corner once this feature is enabled. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.` }
+			],
+			defaultValue: false
 		}
 	];
-	
-	experimental_features.push({
-		name: 'streamDiceRolls',
-		label: 'Stream Dice Rolls',
-		enabledDescription: `You and your players can find the button to join the dice stream in the game log in the top right corner. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`,
-		disabledDescription: `This will enable the dice stream feature for everyone. You will all still have to join the dice stream. You and your players can find the button to do this in the game log in the top right corner once this feature is enabled. Disclaimer: the dice will start small then grow to normal size after a few rolls. They will be contained to the smaller of your window or the sending screen size.`
-	});
+
 	body.append(`
 		<br />
 		<h5 class="token-image-modal-footer-title">Experimental Features</h5>
@@ -278,11 +323,8 @@ function init_settings(){
 		if (setting.dmOnly === true && !window.DM) {
 			continue;
 		}
-		let currentValue = window.EXPERIMENTAL_SETTINGS[setting.name];
-		if (currentValue === undefined && setting.defaultValue !== undefined) {
-			currentValue = setting.defaultValue;
-		}
-		let inputWrapper = build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
+		let currentValue = window.EXPERIMENTAL_SETTINGS[setting.name] || setting.defaultValue;
+		let inputWrapper = build_toggle_input(setting, currentValue, function(name, newValue) {
 			console.log(`experimental setting ${name} is now ${newValue}`);
 			if (name === "streamDiceRolls") {
 				enable_dice_streaming_feature(newValue);
@@ -314,6 +356,7 @@ function init_settings(){
 }
 
 function redraw_settings_panel_token_examples(settings) {
+	console.log("redraw_settings_panel_token_examples", settings);
 	let mergedSettings = {...window.TOKEN_SETTINGS};
 	if (settings !== undefined) {
 		mergedSettings = {...mergedSettings, ...settings};
@@ -353,48 +396,47 @@ function build_example_token(options) {
 	return html;
 }
 
-const TOKEN_OPTIONS_INPUT_TYPE_TOGGLE = "toggle";
-const TOKEN_OPTIONS_INPUT_TYPE_SELECT = "select";
-const TOKEN_OPTIONS_INPUT_TYPE_DROPDOWN = "dropdown";
 // used for settings tab, and tokens tab configuration modals. For placed tokens, see `build_options_flyout_menu`
 // updateValue: function(name, newValue) {} // only update the data here
 // didChange: function() {} // do ui things here
-function build_sidebar_token_options_flyout(availableOptions, setValues, inputType, updateValue, didChange) {
-	const validInputTypes = [TOKEN_OPTIONS_INPUT_TYPE_TOGGLE, TOKEN_OPTIONS_INPUT_TYPE_SELECT];
-	if (!validInputTypes.includes(inputType)) {
-		console.error("build_sidebar_token_options_flyout received the wrong inputType. Expected one of", validInputTypes, "but received", inputType);
-		return;
+function build_sidebar_token_options_flyout(availableOptions, setValues, updateValue, didChange) {
+	if (typeof updateValue !== 'function') {
+		updateValue = function(name, newValue){
+			console.warn("build_sidebar_token_options_flyout was not given an updateValue function so we can't set ", name, "to", value);
+		};
 	}
+	if (typeof didChange !== 'function') {
+		didChange = function(){
+			console.log("build_sidebar_token_options_flyout was not given adidChange function");
+		};
+	}
+
 	let container = $(`<div class="sidebar-token-options-flyout-container prevent-sidebar-modal-close"></div>`);
+
+	// const updateValue = function(name, newValue) {
+	// 	if (is_valid_token_option_value(name, newValue)) {
+	// 		setValues[name] = newValue;
+	// 	} else {
+	// 		delete setValues[name];
+	// 	}
+	// };
+
 	availableOptions.forEach(option => {
 		const currentValue = setValues[option.name];
-		if(option.type == "dropdown"){
-			let inputWrapper = build_dropdown_input(option.name, option.label, currentValue, option.options, function(name, newValue) {
+		if (option.type === "dropdown") {
+			let inputWrapper = build_dropdown_input(option, currentValue, function(name, newValue) {
 				updateValue(name, newValue);
-				if (didChange) {
-					didChange();
-				}
+				didChange();
 			});
-			
 			container.append(inputWrapper);
-		
-		}
-		else if (inputType === TOKEN_OPTIONS_INPUT_TYPE_TOGGLE) {
-			let inputWrapper = build_toggle_input(option.name, option.label, currentValue, option.enabledDescription, option.disabledDescription, function (n, v) {
-				updateValue(n, v);
-				if (didChange) {
-					didChange();
-				}
+		} else if (option.type === "toggle") {
+			let inputWrapper = build_toggle_input(option, currentValue, function (name, newValue) {
+				updateValue(name, newValue);
+				didChange();
 			});
 			container.append(inputWrapper)
-		} else if (inputType === TOKEN_OPTIONS_INPUT_TYPE_SELECT) {
-			let inputWrapper = build_token_option_select_input(option, currentValue, function (n, v) {
-				updateValue(n, v);
-				if (didChange) {
-					didChange();
-				}
-			});
-			container.append(inputWrapper)
+		} else {
+			console.warn("build_sidebar_token_options_flyout failed to handle token setting option with type", option.type);
 		}
 	});
 
@@ -412,22 +454,31 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, inputTy
 
 	let resetToDefaults = $(`<button class='token-image-modal-remove-all-button' title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px;">Reset Token Settings to Defaults</button>`);
 	resetToDefaults.on("click", function (clickEvent) {
-		if (inputType === TOKEN_OPTIONS_INPUT_TYPE_TOGGLE) {
-			$(clickEvent.currentTarget)
-				.closest(".sidebar-token-options-flyout-container")
-				.find(".rc-switch")
-				.removeClass("rc-switch-checked")
-				.removeClass("rc-switch-unknown");
-		} else if (inputType === TOKEN_OPTIONS_INPUT_TYPE_SELECT) {
-			$(clickEvent.currentTarget)
-				.closest(".sidebar-token-options-flyout-container")
-				.find("select")
-				.val("default");
-		}
+
+		let tokenOptionsFlyoutContainer = $(clickEvent.currentTarget).closest(".sidebar-token-options-flyout-container");
+
+		// disable all toggle switches
+		tokenOptionsFlyoutContainer
+			.find(".rc-switch")
+			.removeClass("rc-switch-checked")
+			.removeClass("rc-switch-unknown");
+
+		// set all dropdowns to their default values
+		tokenOptionsFlyoutContainer
+			.find("select")
+			.each(function () {
+				let el = $(this);
+				let matchingOption = availableOptions.find(o => o.name === el.attr("name"));
+				if (matchingOption?.defaultValue !== undefined) {
+					console.debug(`Resetting ${matchingOption.name} to`, matchingOption.defaultValue);
+					el.val(matchingOption.defaultValue);
+				}
+			});
+
+		// This is why we want multiple callback functions.
+		// We're about to call updateValue a bunch of times and only need to update the UI (or do anything else really) one time
 		availableOptions.forEach(option => updateValue(option.name, undefined));
-		if (didChange) {
-			didChange();
-		}
+		didChange();
 	});
 	container.append(resetToDefaults);
 

--- a/Settings.js
+++ b/Settings.js
@@ -209,9 +209,13 @@ function init_settings(){
 	let tokenOptionsButton = $(`<button class="sidebar-panel-footer-button">Change The Default Token Options</button>`);
 	tokenOptionsButton.on("click", function (clickEvent) {
 		build_and_display_sidebar_flyout(clickEvent.clientY, function (flyout) {
-			let optionsContainer = build_sidebar_token_options_flyout(token_setting_options, window.TOKEN_SETTINGS, TOKEN_OPTIONS_INPUT_TYPE_TOGGLE, function(name, newValue) {
-				window.TOKEN_SETTINGS[name] = newValue;
-			}, function () {
+			let optionsContainer = build_sidebar_token_options_flyout(token_setting_options, window.TOKEN_SETTINGS, TOKEN_OPTIONS_INPUT_TYPE_TOGGLE, function (name, value) {
+				if (value === true || value === false) {
+					window.TOKEN_SETTINGS[name] = value;
+				} else {
+					delete window.TOKEN_SETTINGS[name];
+				}
+			}, function() {
 				persist_token_settings(window.TOKEN_SETTINGS);
 				redraw_settings_panel_token_examples();
 			});
@@ -285,16 +289,15 @@ function init_settings(){
 }
 
 function redraw_settings_panel_token_examples(settings) {
-	if (settings === undefined) {
-		settings = {...window.TOKEN_SETTINGS};
-	} else {
-		settings = {...settings, ...window.TOKEN_SETTINGS};
+	let mergedSettings = {...window.TOKEN_SETTINGS};
+	if (settings !== undefined) {
+		mergedSettings = {...mergedSettings, ...settings};
 	}
 	let items = $(".example-tokens-wrapper .example-token");
 	for (let i = 0; i < items.length; i++) {
 		let item = $(items[i]);
-		settings.imgsrc = item.find("img.token-image").attr("src");
-		item.replaceWith(build_example_token(settings));
+		mergedSettings.imgsrc = item.find("img.token-image").attr("src");
+		item.replaceWith(build_example_token(mergedSettings));
 	}
 }
 

--- a/Settings.js
+++ b/Settings.js
@@ -132,7 +132,7 @@ function init_settings(){
 		<h5 class="token-image-modal-footer-title">MIGRATE YOUR SCENES TO THE CLOUD</h5>
 		<div class="sidebar-panel-header-explanation">
 			<p>Your data is currently stored on your browser's cache. Press migrate to move your data into the AboveVTT cloud (<b>WARNING. YOU RISK LOOSING YOU DATA</b>) </p>
-			<button onclick='cloud_migration();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="This will migrate your data to the cloud. Be careful or you may loose your scenes">MIGRATE</button>
+			<button onclick='cloud_migration();' class="sidebar-panel-footer-button sidebar-hover-text" data-hover="This will migrate your data to the cloud. Be careful or you may loose your scenes">MIGRATE</button>
 		</div>
 		`)
 	}
@@ -147,8 +147,8 @@ function init_settings(){
 			<p>Export will download a file containing all of your scenes, custom tokens, and soundpads. 
 			Import will allow you to upload an exported file. Scenes from that file will be added to the scenes in this campaign.</p>
 			<div class="sidebar-panel-footer-horizontal-wrapper">
-			<button onclick='import_openfile();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="Upload a file containing scenes, custom tokens, and soundpads. This will not overwrite your existing scenes. Any scenes found in the uploaded file will be added to your current list scenes">IMPORT</button>
-			<button onclick='export_file();' class="sidebar-panel-footer-button sidebar-hovertext" data-hover="Download a file containing all of your scenes, custom tokens, and soundpads">EXPORT</button>
+			<button onclick='import_openfile();' class="sidebar-panel-footer-button sidebar-hover-text" data-hover="Upload a file containing scenes, custom tokens, and soundpads. This will not overwrite your existing scenes. Any scenes found in the uploaded file will be added to your current list scenes">IMPORT</button>
+			<button onclick='export_file();' class="sidebar-panel-footer-button sidebar-hover-text" data-hover="Download a file containing all of your scenes, custom tokens, and soundpads">EXPORT</button>
 				<input accept='.abovevtt' id='input_file' type='file' style='display: none' />
 		</div>
 	`);

--- a/Settings.js
+++ b/Settings.js
@@ -293,6 +293,7 @@ function redraw_settings_panel_token_examples(settings) {
 	if (settings !== undefined) {
 		mergedSettings = {...mergedSettings, ...settings};
 	}
+	delete mergedSettings.imageSize;
 	let items = $(".example-tokens-wrapper .example-token");
 	for (let i = 0; i < items.length; i++) {
 		let item = $(items[i]);

--- a/Settings.js
+++ b/Settings.js
@@ -4,7 +4,7 @@ function is_valid_token_option_value(tokenOptionName, value) {
 }
 
 function convert_option_to_override_dropdown(tokenOption) {
-	// Note: Spread syntax effectively goes one level deep while copying an array. Therefore, it may be unsuitable for copying multidimensional arrays or objects
+	// Note: Spread syntax effectively goes one level deep while copying an array/object. Therefore, it may be unsuitable for copying multidimensional arrays or objects
 	// we are explicitly not using the spread operator at this level because we need to deep copy the object
 	let converted = {
 		name: tokenOption.name,

--- a/Settings.js
+++ b/Settings.js
@@ -439,6 +439,7 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 			console.warn("build_sidebar_token_options_flyout failed to handle token setting option with type", option.type);
 		}
 	});
+	update_token_base_visibility(container);
 
 
 	// Build example tokens to show the settings changes
@@ -482,6 +483,16 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 	observe_hover_text(container);
 
 	return container;
+}
+
+function update_token_base_visibility(container) {
+	const selectedStyle = container.find("select[name=tokenStyleSelect]").val();
+	let styleSubSelect = container.find(`.token-image-modal-footer-select-wrapper[data-option-name=tokenBaseStyleSelect]`);
+	if(selectedStyle === "virtualMiniCircle" || selectedStyle === "virtualMiniSquare"){
+		styleSubSelect.show();
+	} else{
+		styleSubSelect.hide();
+	}
 }
 
 function enable_dice_streaming_feature(enabled){

--- a/Settings.js
+++ b/Settings.js
@@ -3,61 +3,97 @@ const token_setting_options = [
 		name: 'hidden',
 		label: 'Hide',
 		enabledDescription: 'New tokens will be hidden from players when placed on the scene',
-		disabledDescription: 'New tokens will be visible to players when placed on the scene'
+		disabledDescription: 'New tokens will be visible to players when placed on the scene',
+		enabledValue: 'Hidden',
+		disabledValue: 'Visible'
 	},
 	{
 		name: 'square',
 		label: 'Square Token',
 		enabledDescription: 'New tokens will be square',
-		disabledDescription: 'New tokens will be round'
+		disabledDescription: 'New tokens will be round',
+		enabledValue: 'Square',
+		disabledValue: 'Round'
 	},
 	{
 		name: 'locked',
 		label: 'Lock Token in Position',
 		enabledDescription: 'New tokens will not be movable',
-		disabledDescription: 'New tokens will be movable'
+		disabledDescription: 'New tokens will be movable',
+		enabledValue: 'Locked',
+		disabledValue: 'Movable'
 	},
 	{
 		name: 'restrictPlayerMove',
 		label: 'Restrict Player Movement',
 		enabledDescription: 'Player will not be able to move new tokens',
-		disabledDescription: 'Player will be able to move new tokens'
+		disabledDescription: 'Player will be able to move new tokens',
+		enabledValue: 'Restricted',
+		disabledValue: 'Unrestricted'
 	},
 	{
 		name: 'disablestat',
 		label: 'Disable HP/AC',
 		enabledDescription: 'New tokens will not have HP/AC shown to either the DM or the players. This is most useful for tokens that represent terrain, vehicles, etc.',
-		disabledDescription: 'New tokens will have HP/AC shown to only the DM.'
+		disabledDescription: 'New tokens will have HP/AC shown to only the DM.',
+		enabledValue: 'Disabled',
+		disabledValue: 'Enabled'
 	},
 	{
 		name: 'hidestat',
 		label: 'Hide HP/AC from players',
 		enabledDescription: "New player tokens will have their HP/AC hidden from other players. Each player will be able to see their own HP/AC, but won't be able to see the HP/AC of other players.",
-		disabledDescription: "New player tokens will have their HP/AC visible to other players. Each player will be able to see their own HP/AC as well as HP/AC of other players."
+		disabledDescription: "New player tokens will have their HP/AC visible to other players. Each player will be able to see their own HP/AC as well as HP/AC of other players.",
+		enabledValue: 'Hidden',
+		disabledValue: 'Visible'
+	},
+	{
+		name: 'hidehpbar',
+		label: 'Only show HP values on hover',
+		enabledDescription: "HP values will only be shown when you hover or select a token",
+		disabledDescription: "Enable this to hide HP values except when you hover or select a token.",
+		enabledValue: 'On Hover',
+		disabledValue: 'Always'
 	},
 	{
 		name: 'disableborder',
 		label: 'Disable Border',
 		enabledDescription: 'New tokens will not have a border around them',
-		disabledDescription: 'New tokens will have a border around them'
+		disabledDescription: 'New tokens will have a border around them',
+		enabledValue: 'No Border',
+		disabledValue: 'Border'
 	},
 	{
 		name: 'disableaura',
-		label: 'Disable Health Meter',
+		label: 'Disable Health Aura',
 		enabledDescription: 'New tokens will not have an aura around them that represents their current health',
-		disabledDescription: 'New tokens will have an aura around them that represents their current health'
+		disabledDescription: 'New tokens will have an aura around them that represents their current health',
+		enabledValue: 'No Aura',
+		disabledValue: 'Health Aura'
+	},
+	{
+		name: 'enablepercenthpbar',
+		label: 'Enable Token HP% Bar',
+		enabledDescription:'Token has a traditional visual hp% bar indicator',
+		disabledDescription: 'Token does not have a traditional visual hp% bar indicator',
+		enabledValue: 'Health Bar',
+		disabledValue: 'No Bar'
 	},
 	{
 		name: 'revealname',
 		label: 'Show name to players',
 		enabledDescription: 'New tokens will have their name visible to players',
-		disabledDescription: 'New tokens will have their name hidden from players'
+		disabledDescription: 'New tokens will have their name hidden from players',
+		enabledValue: 'Visible',
+		disabledValue: 'Hidden'
 	},
 	{
 		name: 'legacyaspectratio',
 		label: 'Ignore Image Aspect Ratio',
 		enabledDescription: 'New tokens will stretch non-square images to fill the token space',
-		disabledDescription: 'New tokens will respect the aspect ratio of the image provided'
+		disabledDescription: 'New tokens will respect the aspect ratio of the image provided',
+		enabledValue: 'Stretch',
+		disabledValue: 'Maintain'
 	}
 ];
 
@@ -154,149 +190,29 @@ function init_settings(){
 	`);
 
 	$("#input_file").change(import_readfile);
-	
+
 	body.append(`
 		<br />
 		<h5 class="token-image-modal-footer-title">Default Options when placing tokens</h5>
-		<div class="sidebar-panel-header-explanation">Every time you place a token on the scene, these settings will be used. Custom tokens allow you to override these settings on a per-token basis.</div>
+		<div class="sidebar-panel-header-explanation">Every time you place a token on the scene, these settings will be used. You can override these settings on a per-token basis by clicking the gear on a specific token row in the tokens tab.</div>
 	`);
 
-
-	const token_settings = [
-		{
-			name: 'hidden',
-			label: 'Hide',
-			enabledDescription: 'New tokens will be hidden from players when placed on the scene',
-			disabledDescription: 'New tokens will be visible to players when placed on the scene'
-		},
-		{
-			name: 'square',
-			label: 'Square Token',
-			enabledDescription: 'New tokens will be square',
-			disabledDescription: 'New tokens will be round'
-		},
-		{
-			name: 'locked',
-			label: 'Lock Token in Position',
-			enabledDescription: 'New tokens will not be movable',
-			disabledDescription: 'New tokens will be movable'
-		},
-		{
-			name: 'restrictPlayerMove',
-			label: 'Restrict Player Movement',
-			enabledDescription: 'Player will not be able to move new tokens',
-			disabledDescription: 'Player will be able to move new tokens'
-		},
-		{
-			name: 'disablestat',
-			label: 'Disable HP/AC',
-			enabledDescription: 'New tokens will not have HP/AC shown to either the DM or the players. This is most useful for tokens that represent terrain, vehicles, etc.',
-			disabledDescription: 'New tokens will have HP/AC shown to only the DM.'
-		},
-		{
-			name: 'hidestat',
-			label: 'Hide HP/AC from players',
-			enabledDescription: "New player tokens will have their HP/AC hidden from other players. Each player will be able to see their own HP/AC, but won't be able to see the HP/AC of other players.",
-			disabledDescription: "New player tokens will have their HP/AC visible to other players. Each player will be able to see their own HP/AC as well as HP/AC of other players."
-		},
-		{
-			name: 'hidehpbar',
-			label: 'Only show HP values on hover',
-			enabledDescription: "HP values will only be shown when you hover or select a token",
-			disabledDescription: "Enable this to hide HP values except when you hover or select a token."
-		},	
-		{
-			name: 'disableborder',
-			label: 'Disable Border',
-			enabledDescription: 'New tokens will not have a border around them',
-			disabledDescription: 'New tokens will have a border around them'
-		},
-		{
-			name: 'disableaura',
-			label: 'Disable Health Meter',
-			enabledDescription: 'New tokens will not have an aura around them that represents their current health',
-			disabledDescription: 'New tokens will have an aura around them that represents their current health'
-		},
-		{
-			name: 'enablepercenthpbar', 
-			label: 'Enable Token HP% Bar', 
-			enabledDescription:'Token has a traditional visual hp% bar indicator', 
-			disabledDescription: 'Token does not have a traditional visual hp% bar indicator'
-		},
-		{
-			name: 'hideaurafog',
-			label: 'Hide Aura when token in Fog',
-			enabledDescription: "Token's aura is hidden from players when in fog",
-			disabledDescription: "Token's aura is visible to players when token is in fog"
-		},
-		{
-			name: 'auraislight',
-			label: 'auraislight',
-			enabledDescription: "",
-			disabledDescription: ""
-		},
-		{
-			name: 'revealname',
-			label: 'Show name to players',
-			enabledDescription: 'New tokens will have their name visible to players',
-			disabledDescription: 'New tokens will have their name hidden from players'
-		},
-		{
-			name: 'legacyaspectratio',
-			label: 'Ignore Image Aspect Ratio',
-			enabledDescription: 'New tokens will stretch non-square images to fill the token space',
-			disabledDescription: 'New tokens will respect the aspect ratio of the image provided'
-		}
-	];
-
-	for(let i = 0; i < token_settings.length; i++) {
-		let setting = token_settings[i];
-		let currentValue = window.TOKEN_SETTINGS[setting.name];
-		let inputWrapper = build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
-			console.log(`${name} setting is now ${newValue}`);
-			window.TOKEN_SETTINGS[name] = newValue;
-			persist_token_settings(window.TOKEN_SETTINGS);
-			redraw_settings_panel_token_examples();
+	let tokenOptionsButton = $(`<button class="sidebar-panel-footer-button">Change The Default Token Options</button>`);
+	tokenOptionsButton.on("click", function (clickEvent) {
+		build_and_display_sidebar_flyout(clickEvent.clientY, function (flyout) {
+			let optionsContainer = build_sidebar_token_options_flyout(token_setting_options, window.TOKEN_SETTINGS, TOKEN_OPTIONS_INPUT_TYPE_TOGGLE, function(name, newValue) {
+				window.TOKEN_SETTINGS[name] = newValue;
+			}, function () {
+				persist_token_settings(window.TOKEN_SETTINGS);
+				redraw_settings_panel_token_examples();
+			});
+			optionsContainer.prepend(`<div class="sidebar-panel-header-explanation">Every time you place a token on the scene, these settings will be used. You can override these settings on a per-token basis by clicking the gear on a specific token row in the tokens tab.</div>`);
+			flyout.append(optionsContainer);
+			flyout.css("left", body[0].getBoundingClientRect().left - flyout.width());
 		});
-		if (setting.name == ('auraislight' || 'hideaurafog')){
-			continue
-		}
-		body.append(inputWrapper);
-	}
-
-	const build_example_token = function(imageUrl) {
-		return $(`
-			<div class="custom-token-image-item">
-				<div class="token-image-sizing-dummy"></div>
-				<img alt="example-token-img" class="token-image token-round" src="${imageUrl}" />
-			</div>
-		`);
-	}
-
-	// Build example tokens to show the settings changes
-	body.append(`<div class="token-image-modal-footer-title">Example Tokens</div>`);
-	let tokenExamplesWrapper = $(`<div class="example-tokens-wrapper"></div>`);
-	body.append(tokenExamplesWrapper);
-	// not square image to show aspect ratio
-	tokenExamplesWrapper.append(build_example_token("https://www.dndbeyond.com/avatars/thumbnails/6/359/420/618/636272697874197438.png"));
-	// perfectly square image
-	tokenExamplesWrapper.append(build_example_token("https://www.dndbeyond.com/avatars/8/441/636306375308314493.jpeg"));
-	// idk, something else I guess
-	tokenExamplesWrapper.append(build_example_token("https://i.imgur.com/2Lglcip.png"));
-
-	let resetToDefaults = $(`<button class="token-image-modal-remove-all-button" title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px 30px 0px;">Reset Token Settings to Defaults</button>`);
-	resetToDefaults.on("click", function () {
-		for (let i = 0; i < token_setting_options.length; i++) {
-			let setting = token_setting_options[i];
-			let toggle = body.find(`button[name=${setting.name}]`);
-			if (toggle.hasClass("rc-switch-checked")) {
-				toggle.click();
-			}
-		}
-		persist_token_settings(window.TOKEN_SETTINGS);
-		redraw_settings_panel_token_examples();
 	});
-	body.append(resetToDefaults);
+	body.append(tokenOptionsButton);
+	body.append(`<br />`);
 
 	const experimental_features = [
 		{
@@ -359,88 +275,111 @@ function init_settings(){
 	redraw_settings_panel_token_examples();
 }
 
-function redraw_settings_panel_token_examples() {
-	
-	let items = settingsPanel.body.find(".example-tokens-wrapper .custom-token-image-item");
-	items.css("margin", "auto");
-	items.css("width", "30%");
-
-	if (window.TOKEN_SETTINGS['hidden']) {
-		items.css("opacity", 0.5); // DM SEE HIDDEN TOKENS AS OPACITY 0.5
-	} else {
-		items.css("opacity", 1);
+function redraw_settings_panel_token_examples(settings) {
+	if (settings === undefined) {
+		settings = {...window.TOKEN_SETTINGS};
 	}
-
-	if (window.TOKEN_SETTINGS['square']) {
-		items.find("img").removeClass("token-round");
-	} else {
-		items.find("img").addClass("token-round");
+	let items = $(".example-tokens-wrapper .example-token");
+	for (let i = 0; i < items.length; i++) {
+		let item = $(items[i]);
+		settings.imgsrc = item.find("img.token-image").attr("src");
+		item.replaceWith(build_example_token(settings));
 	}
+}
 
-	if (window.TOKEN_SETTINGS['locked']) {
-		// nothing to show here?
-	} else {
-		// nothing to show here?
+function build_example_token(options) {
+	let mergedOptions = {...default_options(), ...window.TOKEN_SETTINGS, ...options};
+	mergedOptions.hp = 10;
+	mergedOptions.max_hp = 10;
+	mergedOptions.id = `exampleToken-${uuid()}`;
+	mergedOptions.size = 100;
+	mergedOptions.ac = 10;
+
+	// TODO: this is horribly inneficient. Clean up token.place and then update this
+	let token = new Token(mergedOptions);
+	token.place(0);
+	let html = $(`#tokens div[data-id='${mergedOptions.id}']`).clone();
+	token.delete();
+
+	html.addClass("example-token");
+	html.css({
+		float: "left",
+		width: "33%",
+		position: "relative",
+		opacity: 1,
+		top: 0,
+		left: 0
+	});
+	return html;
+}
+
+const TOKEN_OPTIONS_INPUT_TYPE_TOGGLE = "toggle";
+const TOKEN_OPTIONS_INPUT_TYPE_SELECT = "select";
+// used for settings tab, and tokens tab configuration modals. For placed tokens, see `build_options_flyout_menu`
+// updateValue: function(name, newValue) {} // only update the data here
+// didChange: function() {} // do ui things here
+function build_sidebar_token_options_flyout(availableOptions, setValues, inputType, updateValue, didChange) {
+	const validInputTypes = [TOKEN_OPTIONS_INPUT_TYPE_TOGGLE, TOKEN_OPTIONS_INPUT_TYPE_SELECT];
+	if (!validInputTypes.includes(inputType)) {
+		console.error("build_sidebar_token_options_flyout received the wrong inputType. Expected one of", validInputTypes, "but received", inputType);
+		return;
 	}
+	let container = $(`<div class="sidebar-token-options-flyout-container prevent-sidebar-modal-close"></div>`);
+	availableOptions.forEach(option => {
+		const currentValue = setValues[option.name];
+		if (inputType === TOKEN_OPTIONS_INPUT_TYPE_TOGGLE) {
+			let inputWrapper = build_toggle_input(option.name, option.label, currentValue, option.enabledDescription, option.disabledDescription, function (n, v) {
+				updateValue(n, v);
+				if (didChange) {
+					didChange();
+				}
+			});
+			container.append(inputWrapper)
+		} else if (inputType === TOKEN_OPTIONS_INPUT_TYPE_SELECT) {
+			let inputWrapper = build_token_option_select_input(option.name, option.label, option.disabledValue, option.enabledValue, currentValue, function (n, v) {
+				updateValue(n, v);
+				if (didChange) {
+					didChange();
+				}
+			});
+			container.append(inputWrapper)
+		}
+	});
 
-	if (window.TOKEN_SETTINGS['disablestat']) {
-		items.find(".hpbar").remove();
-		items.find(".ac").remove();
-	} else if (window.CURRENT_SCENE_DATA !== undefined && window.CURRENT_SCENE_DATA.hpps !== undefined) {
-		items.find(".hpbar").remove();
-		items.find(".ac").remove();
 
-		// only do this if we've loaded scene data. Otherwise this breaks because it tries to do math on undefined
-		let tok = new Token(default_options());
-		tok.options.size = items.width();
-		tok.options.max_hp = 10;
-		tok.options.hp = 10;
-		tok.options.ac = 10;
-		let hp = tok.build_hp();
-		items.append(hp);
-		let ac = tok.build_ac();
-		items.append(ac);
-	}
+	// Build example tokens to show the settings changes
+	container.append(`<h5 class="token-image-modal-footer-title" style="margin-top:15px;">Example Tokens</h5>`);
+	let tokenExamplesWrapper = $(`<div class="example-tokens-wrapper"></div>`);
+	container.append(tokenExamplesWrapper);
+	// not square image to show aspect ratio
+	tokenExamplesWrapper.append(build_example_token({imgsrc: "https://www.dndbeyond.com/avatars/thumbnails/6/359/420/618/636272697874197438.png"}));
+	// perfectly square image
+	tokenExamplesWrapper.append(build_example_token({imgsrc: "https://www.dndbeyond.com/avatars/8/441/636306375308314493.jpeg"}));
+	// idk, something else I guess
+	tokenExamplesWrapper.append(build_example_token({imgsrc: "https://i.imgur.com/2Lglcip.png"}));
 
-	if (window.TOKEN_SETTINGS['hidestat']) {
-		// anything to show here? This only affects players
-	} else {
-		// anything to show here? This only affects players
-	}
+	let resetToDefaults = $(`<button class='token-image-modal-remove-all-button' title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px;">Reset Token Settings to Defaults</button>`);
+	resetToDefaults.on("click", function (clickEvent) {
+		if (inputType === TOKEN_OPTIONS_INPUT_TYPE_TOGGLE) {
+			$(clickEvent.currentTarget)
+				.closest(".sidebar-token-options-flyout-container")
+				.find(".rc-switch")
+				.removeClass("rc-switch-checked")
+				.removeClass("rc-switch-unknown");
+		} else if (inputType === TOKEN_OPTIONS_INPUT_TYPE_SELECT) {
+			$(clickEvent.currentTarget)
+				.closest(".sidebar-token-options-flyout-container")
+				.find("select")
+				.val("default");
+		}
+		availableOptions.forEach(option => updateValue(option.name, undefined));
+		if (didChange) {
+			didChange();
+		}
+	});
+	container.append(resetToDefaults);
 
-	if (window.TOKEN_SETTINGS['restrictPlayerMove']) {
-		// anything to show here? This only affects players
-	} else {
-		// anything to show here? This only affects players
-	}
-
-	if (window.TOKEN_SETTINGS['disableborder']) {
-		items.find("img").css("border", "0px solid #000")
-	} else {
-		items.find("img").css("border", "4px solid #000")
-	}
-
-	if (window.TOKEN_SETTINGS['disableaura']) {
-		items.find("img").css("box-shadow", "");
-		items.find("img").css("transform", `scale(1)`);
-	} else {
-		items.find("img").css("box-shadow", "rgb(5 255 0 / 80%) 0px 0px 7px 7px");
-		items.find("img").css("transform", `scale(0.88)`); // close enough
-	}
-
-	if (window.TOKEN_SETTINGS['revealname']) {
-		// this messes with the size of the example tokens, and we can't use the `VTTToken` class because otherwise the scene will think it's a real token
-		// so for now, do nothing, and revisit this in the future
-		// items.addClass('hasTooltip');
-	} else {
-		// items.removeClass('hasTooltip');
-	}
-
-	if (window.TOKEN_SETTINGS['legacyaspectratio']) {
-		items.find("img").removeClass("preserve-aspect-ratio");
-	} else {
-		items.find("img").addClass("preserve-aspect-ratio");
-	}
+	return container;
 }
 
 function enable_dice_streaming_feature(enabled){

--- a/Settings.js
+++ b/Settings.js
@@ -2,99 +2,108 @@ const token_setting_options = [
 	{
 		name: 'hidden',
 		label: 'Hide',
-		enabledDescription: 'New tokens will be hidden from players when placed on the scene',
-		disabledDescription: 'New tokens will be visible to players when placed on the scene',
+		enabledDescription: 'The token is hidden to players.',
+		disabledDescription: 'The token is visible to players.',
 		enabledValue: 'Hidden',
 		disabledValue: 'Visible'
 	},
 	{
 		name: 'square',
 		label: 'Square Token',
-		enabledDescription: 'New tokens will be square',
-		disabledDescription: 'New tokens will be round',
+		enabledDescription: 'The token is square.',
+		disabledDescription: 'The token is clipped to fit within a circle.',
 		enabledValue: 'Square',
 		disabledValue: 'Round'
 	},
 	{
 		name: 'locked',
-		label: 'Lock Token in Position',
-		enabledDescription: 'New tokens will not be movable',
-		disabledDescription: 'New tokens will be movable',
-		enabledValue: 'Locked',
-		disabledValue: 'Movable'
+		label: 'Disable All Interaction',
+		enabledDescription: "The token can not be interacted with in any way. Not movable, not selectable by players, no hp/ac displayed, no border displayed, no nothing. Players shouldn't even know it's a token.",
+		disabledDescription: 'The token can be interacted with.',
+		enabledValue: 'Interaction Disabled',
+		disabledValue: 'Interaction Allowed'
 	},
 	{
 		name: 'restrictPlayerMove',
 		label: 'Restrict Player Movement',
-		enabledDescription: 'Player will not be able to move new tokens',
-		disabledDescription: 'Player will be able to move new tokens',
+		enabledDescription: 'Players can not move the token.',
+		disabledDescription: 'Players can move the token.',
 		enabledValue: 'Restricted',
 		disabledValue: 'Unrestricted'
 	},
 	{
 		name: 'disablestat',
-		label: 'Disable HP/AC',
-		enabledDescription: 'New tokens will not have HP/AC shown to either the DM or the players. This is most useful for tokens that represent terrain, vehicles, etc.',
-		disabledDescription: 'New tokens will have HP/AC shown to only the DM.',
-		enabledValue: 'Disabled',
-		disabledValue: 'Enabled'
+		label: 'Remove HP/AC',
+		enabledDescription: 'The token does not have HP/AC shown to either the DM or the players.',
+		disabledDescription: 'The token has HP/AC shown to only the DM.',
+		enabledValue: 'Removed',
+		disabledValue: 'Visible to DM'
 	},
 	{
 		name: 'hidestat',
-		label: 'Hide HP/AC from players',
-		enabledDescription: "New player tokens will have their HP/AC hidden from other players. Each player will be able to see their own HP/AC, but won't be able to see the HP/AC of other players.",
-		disabledDescription: "New player tokens will have their HP/AC visible to other players. Each player will be able to see their own HP/AC as well as HP/AC of other players.",
+		label: 'Hide Player HP/AC',
+		enabledDescription: "Each player can see their own HP/AC, but can't see the HP/AC of other players.",
+		disabledDescription: "Each player can see their own HP/AC as well as the HP/AC of other players.",
 		enabledValue: 'Hidden',
 		disabledValue: 'Visible'
 	},
 	{
 		name: 'hidehpbar',
 		label: 'Only show HP values on hover',
-		enabledDescription: "HP values will only be shown when you hover or select a token",
-		disabledDescription: "Enable this to hide HP values except when you hover or select a token.",
+		enabledDescription: "HP values are only shown when you hover or select the token. The 'Disable HP/AC' option overrides this one.",
+		disabledDescription: "HP values are always displayed on the token. The 'Disable HP/AC' option overrides this one.",
 		enabledValue: 'On Hover',
 		disabledValue: 'Always'
 	},
 	{
 		name: 'disableborder',
 		label: 'Disable Border',
-		enabledDescription: 'New tokens will not have a border around them',
-		disabledDescription: 'New tokens will have a border around them',
+		enabledDescription: 'The token has a border drawn around the image.',
+		disabledDescription: 'The token does not have a border drawn around the image.',
 		enabledValue: 'No Border',
 		disabledValue: 'Border'
 	},
 	{
 		name: 'disableaura',
 		label: 'Disable Health Aura',
-		enabledDescription: 'New tokens will not have an aura around them that represents their current health',
-		disabledDescription: 'New tokens will have an aura around them that represents their current health',
+		enabledDescription: "An aura is drawn around the token's image that represents current health.",
+		disabledDescription: "Enable this to have an aura drawn around the token's image that represents current health.",
 		enabledValue: 'No Aura',
 		disabledValue: 'Health Aura'
 	},
 	{
 		name: 'enablepercenthpbar',
 		label: 'Enable Token HP% Bar',
-		enabledDescription:'Token has a traditional visual hp% bar indicator',
-		disabledDescription: 'Token does not have a traditional visual hp% bar indicator',
+		enabledDescription: 'The token has a traditional visual hp% bar below it',
+		disabledDescription: 'The token does not have a traditional visual hp% bar below it',
 		enabledValue: 'Health Bar',
 		disabledValue: 'No Bar'
 	},
 	{
 		name: 'revealname',
 		label: 'Show name to players',
-		enabledDescription: 'New tokens will have their name visible to players',
-		disabledDescription: 'New tokens will have their name hidden from players',
+		enabledDescription: "The token's name is visible to players",
+		disabledDescription: "The token's name is hidden from players",
 		enabledValue: 'Visible',
 		disabledValue: 'Hidden'
 	},
 	{
 		name: 'legacyaspectratio',
 		label: 'Ignore Image Aspect Ratio',
-		enabledDescription: 'New tokens will stretch non-square images to fill the token space',
-		disabledDescription: 'New tokens will respect the aspect ratio of the image provided',
+		enabledDescription: "The token's image will stretch to fill the token space",
+		disabledDescription: "New token's image will respect the aspect ratio of the image provided",
 		enabledValue: 'Stretch',
 		disabledValue: 'Maintain'
+	},
+	{
+		name: "player_owned",
+		label: "Player Accessible Stats",
+		enabledDescription: "The token's stat block is accessible to players via the token context menu. Players can also alter the HP/AC of this token.",
+		disabledDescription: "The token's stat block is not accessible to players via the token context menu. Players can not alter the HP/AC of this token.",
+		enabledValue: 'Player & DM',
+		disabledValue: 'DM only'
 	}
+
 ];
 
 function b64EncodeUnicode(str) {
@@ -208,7 +217,7 @@ function init_settings(){
 			});
 			optionsContainer.prepend(`<div class="sidebar-panel-header-explanation">Every time you place a token on the scene, these settings will be used. You can override these settings on a per-token basis by clicking the gear on a specific token row in the tokens tab.</div>`);
 			flyout.append(optionsContainer);
-			flyout.css("left", body[0].getBoundingClientRect().left - flyout.width());
+			position_flyout_left_of(body, flyout);
 		});
 	});
 	body.append(tokenOptionsButton);
@@ -278,6 +287,8 @@ function init_settings(){
 function redraw_settings_panel_token_examples(settings) {
 	if (settings === undefined) {
 		settings = {...window.TOKEN_SETTINGS};
+	} else {
+		settings = {...settings, ...window.TOKEN_SETTINGS};
 	}
 	let items = $(".example-tokens-wrapper .example-token");
 	for (let i = 0; i < items.length; i++) {
@@ -336,7 +347,7 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, inputTy
 			});
 			container.append(inputWrapper)
 		} else if (inputType === TOKEN_OPTIONS_INPUT_TYPE_SELECT) {
-			let inputWrapper = build_token_option_select_input(option.name, option.label, option.disabledValue, option.enabledValue, currentValue, function (n, v) {
+			let inputWrapper = build_token_option_select_input(option, currentValue, function (n, v) {
 				updateValue(n, v);
 				if (didChange) {
 					didChange();
@@ -378,6 +389,8 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, inputTy
 		}
 	});
 	container.append(resetToDefaults);
+
+	observe_hover_text(container);
 
 	return container;
 }

--- a/Settings.js
+++ b/Settings.js
@@ -310,6 +310,18 @@ function init_settings(){
 		});
 	});
 	body.append(tokenOptionsButton);
+
+	const clearAllOverridesWarning = `This will remove ALL overridden token options from every player, monster, custom token, and folder in the Tokens Panel. This shouldn't remove any custom images from those tokens. This will not update any tokens that have been placed on a scene. This cannot be undone.`;
+	let clearAllTokenOverrides = $(`<button class='token-image-modal-remove-all-button sidebar-hover-text' data-hover="${clearAllOverridesWarning}" style="width:100%;padding:8px;margin:10px 0px;">Clear All Token Option Overrides</button>`);
+	clearAllTokenOverrides.on("click", function() {
+		if (confirm(clearAllOverridesWarning)) {
+			window.TOKEN_CUSTOMIZATIONS.forEach(tc => tc.clearTokenOptions());
+			persist_all_token_customizations(window.TOKEN_CUSTOMIZATIONS);
+		}
+	});
+	body.append(clearAllTokenOverrides);
+
+
 	body.append(`<br />`);
 
 	const experimental_features = [

--- a/Settings.js
+++ b/Settings.js
@@ -487,11 +487,21 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 
 function update_token_base_visibility(container) {
 	const selectedStyle = container.find("select[name=tokenStyleSelect]").val();
-	let styleSubSelect = container.find(`.token-image-modal-footer-select-wrapper[data-option-name=tokenBaseStyleSelect]`);
+	const findOtherOption = function(optionName) {
+		return container.find(`.token-image-modal-footer-select-wrapper[data-option-name=${optionName}]`);
+	}
+	let styleSubSelect = findOtherOption("tokenBaseStyleSelect");
 	if(selectedStyle === "virtualMiniCircle" || selectedStyle === "virtualMiniSquare"){
 		styleSubSelect.show();
 	} else{
 		styleSubSelect.hide();
+	}
+	if (selectedStyle === "noConstraint") {
+		findOtherOption("square").show();
+		findOtherOption("legacyaspectratio").show();
+	} else {
+		findOtherOption("square").hide();
+		findOtherOption("legacyaspectratio").hide();
 	}
 }
 

--- a/Settings.js
+++ b/Settings.js
@@ -689,6 +689,7 @@ function export_file(){
 			DataFile.tokendata.folders['AboveVTT BUILTIN']=tmp;
 			DataFile.mytokens=mytokens;
 			DataFile.mytokensfolders=mytokensfolders;
+			DataFile.tokencustomizations=window.TOKEN_CUSTOMIZATIONS;
 			DataFile.notes=window.JOURNAL.notes;
 			DataFile.journalchapters=window.JOURNAL.chapters;	
 			DataFile.soundpads=window.SOUNDPADS;
@@ -725,6 +726,18 @@ function import_readfile() {
 		}
 		$("#sounds-panel").remove(); init_audio();
 		persist_soundpad();
+
+		if (DataFile.tokencustomizations !== undefined) {
+			let customizations = [];
+			customizations = DataFile.tokencustomizations.forEach(json => {
+				try {
+					customizations = TokenCustomization.fromJson(json);
+				} catch (error) {
+					console.error("Failed to parse TokenCustomization from json", json);
+				}
+			});
+			persist_all_token_customizations(customizations);
+		}
 
 		if (DataFile.mytokens !== undefined) {
 			mytokens = DataFile.mytokens;

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -465,23 +465,6 @@ function build_dropdown_input(settingOption, currentValue, changeHandler) {
  */
 class SidebarListItem {
 
-  // the types of items that are supported
-  static TypeFolder = "folder";
-  static TypeMyToken = "myToken";
-  static TypePC = "pc";
-  static TypeMonster = "monster";
-  static TypeBuiltinToken = "builtinToken";
-  static TypeEncounter = "encounter";
-  static TypeScene = "scene";
-
-  static PathRoot = "/";
-  static PathPlayers = "/Players";
-  static PathMonsters = "/Monsters";
-  static PathMyTokens = "/My Tokens";
-  static PathAboveVTT = "/AboveVTT Tokens";
-  static PathEncounters = "/Encounters";
-  static PathScenes = "/Scenes";
-
   // folder names within the tokens panel
   static NamePlayers = "Players";
   static NameMonsters = "Monsters";
@@ -495,7 +478,7 @@ class SidebarListItem {
    * @param type {string} the type of item this represents. One of [folder, myToken, monster, pc]
    * @param folderPath {string} the folder this item is in
    */
-  constructor(name, image, type, folderPath = SidebarListItem.PathRoot) {
+  constructor(name, image, type, folderPath = RootFolderPath.Root) {
     this.name = name;
     this.image = image;
     this.type = type;
@@ -512,8 +495,9 @@ class SidebarListItem {
    * @constructor
    */
   static Folder(folderPath, name, collapsed, subtitle = undefined) {
+  // static Folder(folderPath, name, collapsed, subtitle = undefined) {
     console.debug(`SidebarListItem.Folder ${folderPath}/${name}, collapsed: ${collapsed}`);
-    let item = new SidebarListItem(name, `${window.EXTENSION_PATH}assets/folder.svg`, SidebarListItem.TypeFolder, folderPath);
+    let item = new SidebarListItem(name, `${window.EXTENSION_PATH}assets/folder.svg`, ItemType.Folder, folderPath);
     item.collapsed = collapsed;
     item.subtitle = subtitle;
     return item;
@@ -527,7 +511,7 @@ class SidebarListItem {
    */
   static MyToken(tokenData) {
     console.debug("SidebarListItem.MyToken", tokenData);
-    return new SidebarListItem(tokenData.name, tokenData.image, SidebarListItem.TypeMyToken, `${SidebarListItem.PathMyTokens}/${tokenData.folderPath}`);
+    return new SidebarListItem(tokenData.name, tokenData.image, ItemType.MyToken, `${RootFolderPath.MyTokens}/${tokenData.folderPath}`);
   }
 
   /**
@@ -538,7 +522,7 @@ class SidebarListItem {
    */
   static BuiltinToken(tokenData) {
     console.debug("SidebarListItem.BuiltinToken", tokenData);
-    return new SidebarListItem(tokenData.name, tokenData.image, SidebarListItem.TypeBuiltinToken, `${SidebarListItem.PathAboveVTT}/${tokenData.folderPath}`);
+    return new SidebarListItem(tokenData.name, tokenData.image, ItemType.BuiltinToken, `${RootFolderPath.AboveVTT}/${tokenData.folderPath}`);
   }
 
   /**
@@ -549,7 +533,7 @@ class SidebarListItem {
    */
   static Monster(monsterData) {
     console.debug("SidebarListItem.Monster", monsterData);
-    let item = new SidebarListItem(monsterData.name, monsterData.avatarUrl, SidebarListItem.TypeMonster, SidebarListItem.PathMonsters);
+    let item = new SidebarListItem(monsterData.name, monsterData.avatarUrl, ItemType.Monster, RootFolderPath.Monsters);
     item.monsterData = monsterData;
     return item;
   }
@@ -564,7 +548,7 @@ class SidebarListItem {
    */
   static PC(sheet, name, image) {
     console.debug("SidebarListItem.PC", sheet, name, image);
-    let item = new SidebarListItem(name, image, SidebarListItem.TypePC, SidebarListItem.PathPlayers);
+    let item = new SidebarListItem(name, image, ItemType.PC, RootFolderPath.Players);
     item.sheet = sheet;
     return item;
   }
@@ -581,8 +565,8 @@ class SidebarListItem {
     if ((typeof encounter.name == 'string') && encounter.name.length > 0) {
       name = encounter.name;
     }
-    console.debug(`SidebarListItem.Encounter ${SidebarListItem.PathEncounters}/${name}, collapsed: ${collapsed}`);
-    let item = new SidebarListItem(name, `${window.EXTENSION_PATH}assets/folder.svg`, SidebarListItem.TypeEncounter, SidebarListItem.PathEncounters);
+    console.debug(`SidebarListItem.Encounter ${RootFolderPath.Encounters}/${name}, collapsed: ${collapsed}`);
+    let item = new SidebarListItem(name, `${window.EXTENSION_PATH}assets/folder.svg`, ItemType.Encounter, RootFolderPath.Encounters);
     if ((typeof encounter.flavorText == 'string') && encounter.flavorText.length > 0) {
       item.description = encounter.flavorText;
     }
@@ -597,7 +581,7 @@ class SidebarListItem {
       name = sceneData.title;
     }
     let scenePath = sceneData.folderPath || "";
-    let item = new SidebarListItem(name, sceneData.player_map, SidebarListItem.TypeScene, sanitize_folder_path(`${SidebarListItem.PathScenes}/${scenePath}`));
+    let item = new SidebarListItem(name, sceneData.player_map, ItemType.Scene, sanitize_folder_path(`${RootFolderPath.Scenes}/${scenePath}`));
     console.debug(`SidebarListItem.Scene ${item.fullPath()}`);
     item.sceneId = sceneData.id;
     item.isVideo = sceneData.player_map_is_video == "1"; // explicity using `==` instead of `===` in case it's ever `1` or `"1"`
@@ -641,33 +625,33 @@ class SidebarListItem {
   }
 
   /** @returns {boolean} whether or not this item represents a Folder */
-  isTypeFolder() { return this.type === SidebarListItem.TypeFolder }
+  isTypeFolder() { return this.type === ItemType.Folder }
 
   /** @returns {boolean} whether or not this item represents a "My Token" */
-  isTypeMyToken() { return this.type === SidebarListItem.TypeMyToken }
+  isTypeMyToken() { return this.type === ItemType.MyToken }
 
   /** @returns {boolean} whether or not this item represents a Player */
-  isTypePC() { return this.type === SidebarListItem.TypePC }
+  isTypePC() { return this.type === ItemType.PC }
 
   /** @returns {boolean} whether or not this item represents a Monster */
-  isTypeMonster() { return this.type === SidebarListItem.TypeMonster }
+  isTypeMonster() { return this.type === ItemType.Monster }
 
   /** @returns {boolean} whether or not this item represents a Builtin Token */
-  isTypeBuiltinToken() { return this.type === SidebarListItem.TypeBuiltinToken }
+  isTypeBuiltinToken() { return this.type === ItemType.BuiltinToken }
 
   /** @returns {boolean} whether or not this item represents an Encounter */
-  isTypeEncounter() { return this.type === SidebarListItem.TypeEncounter }
+  isTypeEncounter() { return this.type === ItemType.Encounter }
 
   /** @returns {boolean} whether or not this item represents a Scene */
-  isTypeScene() { return this.type === SidebarListItem.TypeScene }
+  isTypeScene() { return this.type === ItemType.Scene }
 
   /** @returns {boolean} whether or not this item is listed in the tokens panel */
   isTokensPanelItem() {
     if (this.isTypeFolder()) {
-      if (this.folderPath === SidebarListItem.PathRoot) {
+      if (this.folderPath === RootFolderPath.Root) {
         return this.name === SidebarListItem.NamePlayers || this.name === SidebarListItem.NameMonsters || this.name === SidebarListItem.NameMyTokens || this.name === SidebarListItem.NameAboveVTT || this.name === SidebarListItem.NameEncounters;
       } else {
-        return this.folderPath.startsWith(SidebarListItem.PathPlayers) || this.folderPath.startsWith(SidebarListItem.PathMonsters) || this.folderPath.startsWith(SidebarListItem.PathMyTokens) || this.folderPath.startsWith(SidebarListItem.PathAboveVTT) || this.folderPath.startsWith(SidebarListItem.PathEncounters);
+        return this.folderPath.startsWith(RootFolderPath.Players) || this.folderPath.startsWith(RootFolderPath.Monsters) || this.folderPath.startsWith(RootFolderPath.MyTokens) || this.folderPath.startsWith(RootFolderPath.AboveVTT) || this.folderPath.startsWith(RootFolderPath.Encounters);
       }
     }
     return this.isTypeMyToken() || this.isTypePC() || this.isTypeMonster() || this.isTypeBuiltinToken()
@@ -676,15 +660,15 @@ class SidebarListItem {
   /** @returns {boolean} whether or not this item represents an object that can be edited by the user */
   canEdit() {
     switch (this.type) {
-      case SidebarListItem.TypeFolder:
-        return this.folderPath.startsWith(SidebarListItem.PathMyTokens) || this.folderPath.startsWith(SidebarListItem.PathScenes);
-      case SidebarListItem.TypeMyToken:
-      case SidebarListItem.TypePC:
-      case SidebarListItem.TypeMonster:
-      case SidebarListItem.TypeEncounter:
-      case SidebarListItem.TypeScene:
+      case ItemType.Folder:
+        return this.folderPath.startsWith(RootFolderPath.MyTokens) || this.folderPath.startsWith(RootFolderPath.Scenes);
+      case ItemType.MyToken:
+      case ItemType.PC:
+      case ItemType.Monster:
+      case ItemType.Encounter:
+      case ItemType.Scene:
         return true;
-      case SidebarListItem.TypeBuiltinToken:
+      case ItemType.BuiltinToken:
       default:
         return false;
     }
@@ -693,16 +677,16 @@ class SidebarListItem {
   /** @returns {boolean} whether or not this item represents an object that can be deleted by the user */
   canDelete() {
     switch (this.type) {
-      case SidebarListItem.TypeFolder:
+      case ItemType.Folder:
         // TODO: allow deleting scenes folders
-        return this.folderPath.startsWith(SidebarListItem.PathMyTokens) || this.folderPath.startsWith(SidebarListItem.PathScenes);
-      case SidebarListItem.TypeMyToken:
-      case SidebarListItem.TypeScene:
+        return this.folderPath.startsWith(RootFolderPath.MyTokens) || this.folderPath.startsWith(RootFolderPath.Scenes);
+      case ItemType.MyToken:
+      case ItemType.Scene:
         return true;
-      case SidebarListItem.TypePC:
-      case SidebarListItem.TypeMonster:
-      case SidebarListItem.TypeBuiltinToken:
-      case SidebarListItem.TypeEncounter: // we technically could support this, but I don't think we should
+      case ItemType.PC:
+      case ItemType.Monster:
+      case ItemType.BuiltinToken:
+      case ItemType.Encounter: // we technically could support this, but I don't think we should
       default:
         return false;
     }
@@ -735,15 +719,15 @@ class SidebarListItem {
 
   backingId() {
     switch (this.type) {
-      case SidebarListItem.TypePC:
+      case ItemType.PC:
         return this.sheet;
-      case SidebarListItem.TypeMonster:
+      case ItemType.Monster:
         return this.monsterData.id;
-      case SidebarListItem.TypeFolder:
-      case SidebarListItem.TypeMyToken:
-      case SidebarListItem.TypeScene:
-      case SidebarListItem.TypeBuiltinToken:
-      case SidebarListItem.TypeEncounter:
+      case ItemType.Folder:
+      case ItemType.MyToken:
+      case ItemType.Scene:
+      case ItemType.BuiltinToken:
+      case ItemType.Encounter:
       default:
         return this.id; // could be undefined
     }
@@ -756,7 +740,7 @@ class SidebarListItem {
  */
 function sanitize_folder_path(dirtyPath) {
   if (dirtyPath === undefined) {
-    return SidebarListItem.PathRoot;
+    return RootFolderPath.Root;
   }
   let cleanPath = dirtyPath.replaceAll("///", "/").replaceAll("//", "/");
   // remove trailing slashes before adding one at the beginning. Otherwise, we return an empty string
@@ -815,7 +799,7 @@ function find_sidebar_list_item_from_path(fullPath) {
   const matchingPath = function(item) { return item.fullPath() === fullPath };
 
   let foundItem;
-  if (fullPath.startsWith(SidebarListItem.PathScenes)) {
+  if (fullPath.startsWith(RootFolderPath.Scenes)) {
     foundItem = window.sceneListItems.find(matchingPath);
     if (foundItem === undefined) {
       foundItem = window.sceneListFolders.find(matchingPath);
@@ -973,8 +957,8 @@ function build_sidebar_list_row(listItem) {
   }
 
   switch (listItem.type) {
-    case SidebarListItem.TypeEncounter: // explicitly allowing encounter to fall through because we want them to be treated like folders
-    case SidebarListItem.TypeFolder:
+    case ItemType.Encounter: // explicitly allowing encounter to fall through because we want them to be treated like folders
+    case ItemType.Folder:
       subtitle.hide();
       row.append(`<div class="folder-item-list"></div>`);
       row.addClass("folder");
@@ -982,7 +966,7 @@ function build_sidebar_list_row(listItem) {
       if (listItem.collapsed === true) {
         row.addClass("collapsed");
       }
-      if (listItem.fullPath().startsWith(SidebarListItem.PathMyTokens)) {
+      if (listItem.fullPath().startsWith(RootFolderPath.MyTokens)) {
         // add buttons for creating subfolders and tokens
         let addFolder = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
         rowItem.append(addFolder);
@@ -1005,13 +989,13 @@ function build_sidebar_list_row(listItem) {
           reorderButton.on("click", function (clickEvent) {
             clickEvent.stopPropagation();
             if ($(clickEvent.currentTarget).hasClass("active")) {
-              disable_draggable_change_folder(SidebarListItem.TypeMyToken);
+              disable_draggable_change_folder(ItemType.MyToken);
             } else {
-              enable_draggable_change_folder(SidebarListItem.TypeMyToken);
+              enable_draggable_change_folder(ItemType.MyToken);
             }
           });
         }
-      } else if (listItem.fullPath().startsWith(SidebarListItem.PathScenes)) {
+      } else if (listItem.fullPath().startsWith(RootFolderPath.Scenes)) {
         // add buttons for creating subfolders and scenes
         let addFolder = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
         rowItem.append(addFolder);
@@ -1028,7 +1012,7 @@ function build_sidebar_list_row(listItem) {
           let clickedItem = find_sidebar_list_item(clickedRow);
           create_scene_inside(clickedItem.fullPath());
         });
-      } else if (listItem.fullPath() === SidebarListItem.PathMonsters) {
+      } else if (listItem.fullPath() === RootFolderPath.Monsters) {
         // add monster filter button on the root monsters folder
         let filterMonsters = $(`<button class="token-row-button monster-filter-button" title="Filter Monsters"><span class="material-icons">filter_alt</span></button>`);
         if (Object.keys(monster_search_filters).length > 0) {
@@ -1051,12 +1035,12 @@ function build_sidebar_list_row(listItem) {
         }
       }
       break;
-    case SidebarListItem.TypeMyToken:
+    case ItemType.MyToken:
       subtitle.hide();
       // TODO: Style specifically for My Tokens
       row.css("cursor", "default");
       break;
-    case SidebarListItem.TypePC:
+    case ItemType.PC:
       let playerData = window.PLAYER_STATS[listItem.sheet];
       if (playerData === undefined) {
         subtitle.text("loading character details");
@@ -1131,7 +1115,7 @@ function build_sidebar_list_row(listItem) {
       });
 
       break;
-    case SidebarListItem.TypeMonster:
+    case ItemType.Monster:
       row.attr("data-monster", listItem.monsterData.id);
       subtitle.append(`<div class="subtitle-attibute"><span class="plain-text">CR</span>${convert_challenge_rating_id(listItem.monsterData.challengeRatingId)}</div>`);
       if (listItem.monsterData.isHomebrew === true) {
@@ -1154,12 +1138,12 @@ function build_sidebar_list_row(listItem) {
       }
 
       break;
-    case SidebarListItem.TypeBuiltinToken:
+    case ItemType.BuiltinToken:
       subtitle.hide();
       // TODO: Style specifically for Builtin
       row.css("cursor", "default");
       break;
-    case SidebarListItem.TypeScene:
+    case ItemType.Scene:
       row.attr("data-scene-id", listItem.sceneId);
       row.addClass("scene-item");
       imgHolder.remove(); // we don't want the overhead of full images loading in. Clicking the row displays a preview of the image
@@ -1221,8 +1205,8 @@ function did_click_row(clickEvent) {
   console.log("did_click_row", clickedItem);
 
   switch (clickedItem.type) {
-    case SidebarListItem.TypeEncounter:
-    case SidebarListItem.TypeFolder:
+    case ItemType.Encounter:
+    case ItemType.Folder:
       if (clickedRow.hasClass("collapsed")) {
         clickedRow.removeClass("collapsed");
         clickedItem.collapsed = false;
@@ -1230,7 +1214,7 @@ function did_click_row(clickEvent) {
         clickedRow.addClass("collapsed");
         clickedItem.collapsed = true;
       }
-      if (clickedItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+      if (clickedItem.folderPath.startsWith(RootFolderPath.MyTokens)) {
         let backingObject = find_my_token_folder(clickedItem.fullPath());
         if (backingObject !== undefined) {
           backingObject.collapsed = clickedItem.collapsed;
@@ -1245,13 +1229,13 @@ function did_click_row(clickEvent) {
         fetch_encounter_monsters_if_necessary(clickedRow, clickedItem);
       }
       break;
-    case SidebarListItem.TypeMyToken:
+    case ItemType.MyToken:
       // display_sidebar_list_item_configuration_modal(clickedItem);
       break;
-    case SidebarListItem.TypePC:
+    case ItemType.PC:
       open_player_sheet(clickedItem.sheet);
       break;
-    case SidebarListItem.TypeMonster:
+    case ItemType.Monster:
       if (clickedItem.monsterData.isReleased === true || clickedItem.monsterData.isHomebrew === true) {
         console.log(`Opening monster with id ${clickedItem.monsterData.id}, url ${clickedItem.monsterData.url}`);
         open_monster_item(clickedItem);
@@ -1260,10 +1244,10 @@ function did_click_row(clickEvent) {
         window.open(clickedItem.monsterData.url, '_blank');
       }
       break;
-    case SidebarListItem.TypeBuiltinToken:
+    case ItemType.BuiltinToken:
       // display_builtin_token_details_modal(clickedItem);
       break;
-    case SidebarListItem.TypeScene:
+    case ItemType.Scene:
       // show the preview
       remove_sidebar_flyout();
       let flyout = $(`<div class='sidebar-flyout'></div>`);
@@ -1328,27 +1312,27 @@ function did_click_add_button(clickEvent) {
  */
 function display_sidebar_list_item_configuration_modal(listItem) {
   switch (listItem?.type) {
-    case SidebarListItem.TypeEncounter:
+    case ItemType.Encounter:
       // TODO: support editing in an iframe on the page?
       window.open(`https://www.dndbeyond.com/encounters/${listItem.encounterId}/edit`, '_blank');
       break;
-    case SidebarListItem.TypeFolder:
-      if (listItem.folderPath.startsWith(SidebarListItem.PathMyTokens) || listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+    case ItemType.Folder:
+      if (listItem.folderPath.startsWith(RootFolderPath.MyTokens) || listItem.folderPath.startsWith(RootFolderPath.Scenes)) {
         display_folder_configure_modal(listItem);
       } else {
         console.warn("Only allowed to folders within the My Tokens folder and Scenes");
         return;
       }
       break;
-    case SidebarListItem.TypeBuiltinToken:
+    case ItemType.BuiltinToken:
       display_builtin_token_details_modal(listItem);
       break;
-    case SidebarListItem.TypeMyToken:
-    case SidebarListItem.TypePC:
-    case SidebarListItem.TypeMonster:
+    case ItemType.MyToken:
+    case ItemType.PC:
+    case ItemType.Monster:
       display_token_configuration_modal(listItem);
       break;
-    case SidebarListItem.TypeScene:
+    case ItemType.Scene:
       let index = window.ScenesHandler.scenes.findIndex(s => s.id === listItem.sceneId);
       if (index >= 0) {
         edit_scene_dialog(index);
@@ -1368,9 +1352,9 @@ function create_folder_inside(listItem) {
     return;
   }
 
-  if (listItem.fullPath().startsWith(SidebarListItem.PathMyTokens)) {
+  if (listItem.fullPath().startsWith(RootFolderPath.MyTokens)) {
     create_mytoken_folder_inside(listItem);
-  } else if (listItem.fullPath().startsWith(SidebarListItem.PathScenes)) {
+  } else if (listItem.fullPath().startsWith(RootFolderPath.Scenes)) {
     create_scene_folder_inside(listItem.fullPath());
   } else {
     console.warn("create_folder_inside called with an incorrect item type", listItem);
@@ -1391,7 +1375,7 @@ function display_folder_configure_modal(listItem) {
   let sidebarModal = new SidebarPanel(sidebarId, true);
   let listItemFullPath = listItem.fullPath();
   let container;
-  if (listItemFullPath.startsWith(SidebarListItem.PathScenes)) {
+  if (listItemFullPath.startsWith(RootFolderPath.Scenes)) {
     container = scenesPanel.body;
   } else {
     container = tokensPanel.body;
@@ -1483,7 +1467,7 @@ function rename_folder(item, newName, alertUser = true) {
     return undefined;
   }
 
-  if (item.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+  if (item.folderPath.startsWith(ItemPath.MyTokens)) {
     return rename_mytoken_folder(item, newName, alertUser);
   } else if (item.folderPath.startsWith(SidebarListItem.PathScenes)) {
     return rename_scene_folder(item, newName, alertUser);
@@ -1504,15 +1488,15 @@ function delete_item(listItem) {
   }
 
   switch (listItem.type) {
-    case SidebarListItem.TypeFolder:
+    case ItemType.Folder:
       delete_folder_and_delete_children(listItem);
       break;
-    case SidebarListItem.TypeMyToken:
+    case ItemType.MyToken:
       let myToken = find_my_token(listItem.fullPath());
       array_remove_index_by_value(mytokens, myToken);
       did_change_mytokens_items();
       break;
-    case SidebarListItem.TypeScene:
+    case ItemType.Scene:
       if (confirm(`Are you sure that you want to delete the scene named "${listItem.name}"?`)) {
         window.ScenesHandler.delete_scene(listItem.sceneId);
         did_update_scenes();

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -378,68 +378,75 @@ function build_token_option_select_input(option, currentValue, changeHandler) {
   return wrapper;
 }
 
-function build_toggle_input(name, labelText, enabled, enabledHoverText, disabledHoverText, changeHandler) {
+function build_toggle_input(settingOption, currentValue, changeHandler) {
   if (typeof changeHandler !== 'function') {
     changeHandler = function(){};
   }
   let wrapper = $(`
     <div class="token-image-modal-footer-select-wrapper">
-      <div class="token-image-modal-footer-title">${labelText}</div>
+      <div class="token-image-modal-footer-title">${settingOption.label}</div>
     </div>
   `);
-  let input = $(`<button name="${name}" type="button" role="switch" class="rc-switch"><span class="rc-switch-inner"></span></button>`);
-  if (enabled === null) {
+  let input = $(`<button name="${settingOption.name}" type="button" role="switch" class="rc-switch"><span class="rc-switch-inner"></span></button>`);
+  if (currentValue === null) {
     input.addClass("rc-switch-unknown");
     update_hover_text(wrapper, "This has multiple values. Clicking this will enable it for all.");
-  } else if (enabled === true) {
-    input.addClass("rc-switch-checked");
-    update_hover_text(wrapper, enabledHoverText);
   } else {
-    update_hover_text(wrapper, disabledHoverText);
+    if (currentValue === true) {
+      input.addClass("rc-switch-checked");
+    }
+    const currentlySetOption = settingOption.options.find(o => o.value === currentValue) || settingOption.options.find(o => o.value === settingOption.defaultValue);
+    update_hover_text(wrapper, currentlySetOption?.description);
   }
   wrapper.append(input);
   input.click(function(clickEvent) {
     if ($(clickEvent.currentTarget).hasClass("rc-switch-checked")) {
       // it was checked. now it is no longer checked
       $(clickEvent.currentTarget).removeClass("rc-switch-checked");
-      update_hover_text(wrapper, disabledHoverText);
-      changeHandler(name, false);
+      changeHandler(settingOption.name, false);
+      const disabledOption = settingOption.options.find(o => o.value === false);
+      update_hover_text(wrapper, disabledOption?.description);
     } else {
       // it was not checked. now it is checked
       $(clickEvent.currentTarget).removeClass("rc-switch-unknown");
       $(clickEvent.currentTarget).addClass("rc-switch-checked");
-      update_hover_text(wrapper, enabledHoverText);
-      changeHandler(name, true);
+      changeHandler(settingOption.name, true);
+      const disabledOption = settingOption.options.find(o => o.value === true);
+      update_hover_text(wrapper, disabledOption?.description);
     }
   });
   return wrapper;
 }
 
-function build_dropdown_input(name, labelText, currentValue, options, changeHandler) {
-   if (typeof changeHandler !== 'function') {
+function build_dropdown_input(settingOption, currentValue, changeHandler) {
+  if (typeof changeHandler !== 'function') {
     changeHandler = function(){};
   }
-  
-  let wrapper = $(`<div id='tokenWrapper__${name}' class="token-image-modal-footer-title">${labelText}</div>`);
-  let tokenSelect = $(`<select id="tokenSelect__${name}" class='token-select-dropdown'></select>`)
+  let wrapper = $(`
+     <div class="token-image-modal-footer-select-wrapper">
+       <div class="token-image-modal-footer-title">${settingOption.label}</div>
+     </div>
+   `);
 
-  for(let i=0; i<options.length; i++){
-    tokenSelect.append(options[i]);
+  let input = $(`<select name="${settingOption.name}"></select>`);
+  wrapper.append(input);
+  for (const option of settingOption.options) {
+    input.append(`<option value="${option.value}">${option.label}</option>`);
   }
-  tokenSelect.val(currentValue);
+  if (currentValue !== undefined) {
+    input.find(`option[value=${currentValue}]`).attr('selected','selected');
+  } else {
+    input.find(`option[value=${settingOption.defaultValue}]`).attr('selected','selected');
+  }
 
-  tokenSelect.change(function(clickEvent) {
-    changeHandler(name, $(`#tokenSelect__${name} option:selected`).val());
-    if(name == "tokenStyleSelect"){
-      $(`#tokenWrapper__tokenBaseStyleSelect`).hide();
-      if($(`#tokenSelect__${name} option:selected`).val() == 4 || $(`#tokenSelect__${name} option:selected`).val() == 5){
-         $(`#tokenWrapper__tokenBaseStyleSelect`).show();
-      }
-    }
+  const currentlySetOption = settingOption.options.find(o => o.value === currentValue) || settingOption.options.find(o => o.value === settingOption.defaultValue);
+  update_hover_text(wrapper, currentlySetOption?.description);
+  input.change(function(event) {
+    let newValue = event.target.value;
+    changeHandler(settingOption.name, newValue);
+    const updatedOption = settingOption.options.find(o => o.value === newValue) || settingOption.options.find(o => o.value === settingOption.defaultValue);
+    update_hover_text(wrapper, updatedOption?.description);
   });
-  
-  wrapper.append(tokenSelect);
-
   return wrapper;
 }
 

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1367,7 +1367,7 @@ function display_sidebar_list_item_configuration_modal(listItem) {
         edit_scene_dialog(index);
       } else {
         console.error("Failed to find scene index for scene with id", listItem.sceneId);
-        showGenericAlert();
+        showDebuggingAlert();
       }
       break;
     default:
@@ -1494,7 +1494,7 @@ function rename_folder(item, newName, alertUser = true) {
   if (!item.isTypeFolder()) {
     console.warn("rename_folder called with an incorrect item type", item);
     if (alertUser !== false) {
-      showGenericAlert();
+      showDebuggingAlert();
     }
     return undefined;
   }
@@ -1508,7 +1508,7 @@ function rename_folder(item, newName, alertUser = true) {
   } else if (item.folderPath.startsWith(RootFolder.Scenes.path)) {
     return rename_scene_folder(item, newName, alertUser);
   } else if (alertUser !== false) {
-    showGenericAlert();
+    showDebuggingAlert();
   }
   return undefined;
 }

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -383,7 +383,7 @@ function build_toggle_input(settingOption, currentValue, changeHandler) {
     changeHandler = function(){};
   }
   let wrapper = $(`
-    <div class="token-image-modal-footer-select-wrapper">
+    <div class="token-image-modal-footer-select-wrapper" data-option-name="${settingOption.name}">
       <div class="token-image-modal-footer-title">${settingOption.label}</div>
     </div>
   `);
@@ -423,7 +423,7 @@ function build_dropdown_input(settingOption, currentValue, changeHandler) {
     changeHandler = function(){};
   }
   let wrapper = $(`
-     <div class="token-image-modal-footer-select-wrapper">
+     <div class="token-image-modal-footer-select-wrapper" data-option-name="${settingOption.name}">
        <div class="token-image-modal-footer-title">${settingOption.label}</div>
      </div>
    `);
@@ -446,6 +446,7 @@ function build_dropdown_input(settingOption, currentValue, changeHandler) {
     changeHandler(settingOption.name, newValue);
     const updatedOption = settingOption.options.find(o => o.value === newValue) || settingOption.options.find(o => o.value === settingOption.defaultValue);
     update_hover_text(wrapper, updatedOption?.description);
+    update_token_base_visibility(wrapper.parent());
   });
   return wrapper;
 }

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1317,7 +1317,7 @@ function did_click_add_button(clickEvent) {
   let clickedRow = $(clickEvent.target).closest(".list-item-identifier");
   let clickedItem = find_sidebar_list_item(clickedRow);
   console.log("did_click_add_button", clickedItem);
-  let hidden = clickEvent.shiftKey || window.TOKEN_SETTINGS["hidden"];
+  let hidden = clickEvent.shiftKey ? true : undefined; // we only want to force hidden if the shift key is help. otherwise let the global and override settings handle it
   create_and_place_token(clickedItem, hidden, undefined, undefined, undefined);
   update_pc_token_rows();
 }
@@ -1393,7 +1393,7 @@ function display_folder_configure_modal(listItem) {
   let itemType;
   if (listItemFullPath.startsWith(RootFolder.Scenes.path)) {
     itemType = ItemType.Scene;
-  } else if (listItemFullPath.startsWith(RootFolder.Scenes.path)) {
+  } else if (listItemFullPath.startsWith(RootFolder.MyTokens.path)) {
     itemType = ItemType.MyToken;
   }
 

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1421,18 +1421,13 @@ function display_folder_configure_modal(listItem) {
   set_full_path(folderNameInput, listItemFullPath);
   sidebarModal.body.append(build_text_input_wrapper("Folder Name", folderNameInput, undefined, renameFolder));
 
-  // Coming Soon...
-  // let folderOptions = {};
-  // let folderOptionsButton = build_override_token_options_button(sidebarModal, listItem, undefined, folderOptions, function () {
-  //   if (value === true || value === false) {
-  //     folderOptions[name] = value;
-  //   } else {
-  //     delete folderOptions[name];
-  //   }
-  // }, function () {
-  //
-  // });
-  // sidebarModal.body.append(folderOptionsButton);
+  let customization = find_or_create_token_customization(ItemType.Folder, listItem.id, listItem.parentId);
+  let folderOptionsButton = build_override_token_options_button(sidebarModal, listItem, undefined, customization.tokenOptions, function (key, value) {
+    customization.setTokenOption(key, value);
+  }, function () {
+    persist_token_customization(customization);
+  });
+  sidebarModal.body.append(folderOptionsButton);
 
   let saveButton = $(`<button class="sidebar-panel-footer-button" style="width:100%;padding:8px;margin-top:8px;margin-left:0px;">Save Folder</button>`);
   saveButton.on("click", function (clickEvent) {

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1239,9 +1239,7 @@ function did_click_row(clickEvent) {
         clickedRow.addClass("collapsed");
         clickedItem.collapsed = true;
       }
-      if (clickedItem.isTokensPanelItem()) {
-        persist_token_folders_remembered_state();
-      }
+      persist_folders_remembered_state();
       if (clickedItem.isTypeEncounter()) {
         // we explicitly allowed it to pass through and be treated like a folder so now we need to act on it
         fetch_encounter_monsters_if_necessary(clickedRow, clickedItem);

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1423,6 +1423,7 @@ function display_folder_configure_modal(listItem) {
         redraw_token_list();
         expand_all_folders_up_to_id(foundItem.id);
       }
+      sidebarModal.updateHeader(newFolderName, updatedFullPath, "Edit or delete this folder.");
       return updatedFullPath;
     } else {
       // there was a naming conflict, and the user has been alerted. select the entire text so they can easily change it
@@ -1491,6 +1492,7 @@ function rename_folder(item, newName, alertUser = true) {
     let customization = find_token_customization(item.type, item.id);
     customization.setTokenOption("name", newName);
     persist_token_customization(customization);
+    did_change_mytokens_items();
     return customization.fullPath();
   } else if (item.folderPath.startsWith(RootFolder.Scenes.path)) {
     return rename_scene_folder(item, newName, alertUser);

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -29,7 +29,7 @@ function init_sidebar_tabs() {
   $("#sounds-panel").remove();
   soundsPanel = new SidebarPanel("sounds-panel", false);
   sidebarContent.append(soundsPanel.build());
-	init_audio();
+  init_audio();
 
   $("#journal-panel").remove();
   journalPanel = new SidebarPanel("journal-panel", false);
@@ -46,6 +46,8 @@ function init_sidebar_tabs() {
     sidebarContent.append(settingsPanel.build());
     init_settings();
   }
+
+  observe_hover_text($(".sidebar__inner"));
 }
 
 function sidebar_modal_is_open() {
@@ -60,6 +62,19 @@ function close_sidebar_modal() {
 function display_sidebar_modal(sidebarPanel) {
   $("#VTTWRAPPER").append(sidebarPanel.build());
   window.current_sidebar_modal = sidebarPanel;
+  observe_hover_text(sidebarPanel.container);
+}
+
+function observe_hover_text(sidebarPanelContent) {
+  sidebarPanelContent.off("mouseenter mouseleave").on("mouseenter mouseleave", ".sidebar-hover-text", function(hoverEvent) {
+    const displayText = $(hoverEvent.currentTarget).attr("data-hover");
+    if (typeof displayText === "string" && displayText.length > 0) {
+      sidebar_flyout(hoverEvent, function (flyout) {
+        flyout.append(`<div class="sidebar-hover-text-flyout">${displayText}</div>`);
+        flyout.css("left", sidebarPanelContent[0].getBoundingClientRect().left - flyout.width());
+      });
+    }
+  });
 }
 
 class SidebarPanel {
@@ -293,10 +308,11 @@ function build_toggle_input(name, labelText, enabled, enabledHoverText, disabled
   let input = $(`<button name="${name}" type="button" role="switch" class="rc-switch"><span class="rc-switch-inner"></span></button>`);
   const updateHoverText = function(hoverElement, hoverText) {
     if (hoverText !== undefined && hoverText.length > 0) {
-      hoverElement.addClass("sidebar-hovertext");
+      hoverElement.addClass("sidebar-hover-text");
       hoverElement.attr("data-hover", hoverText);
+      $(".sidebar-flyout .sidebar-hover-text-flyout").text(hoverText);
     } else {
-      hoverElement.removeClass("sidebar-hovertext");
+      hoverElement.removeClass("sidebar-hover-text");
       hoverElement.removeAttr("data-hover");
     }
   }

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -545,7 +545,16 @@ class SidebarListItem {
   static BuiltinToken(tokenData) {
     console.debug("SidebarListItem.BuiltinToken", tokenData);
     let folderPath = sanitize_folder_path(`${RootFolder.AboveVTT.path}/${tokenData.folderPath}`);
-    return new SidebarListItem(path_to_html_id(folderPath, tokenData.name), tokenData.name, tokenData.image, ItemType.BuiltinToken, folderPath, path_to_html_id(folderPath));
+    let item = new SidebarListItem(path_to_html_id(folderPath, tokenData.name), tokenData.name, tokenData.image, ItemType.BuiltinToken, folderPath, path_to_html_id(folderPath));
+    item.tokenOptions = tokenData;
+    return item
+  }
+  static DDBToken(tokenData) {
+    console.debug("SidebarListItem.DDBToken", tokenData);
+    let folderPath = sanitize_folder_path(`${RootFolder.DDB.path}/${tokenData.folderPath}`);
+    let item = new SidebarListItem(path_to_html_id(folderPath, tokenData.name), tokenData.name, tokenData.alternativeImages[0], ItemType.DDBToken, folderPath, path_to_html_id(folderPath));
+    item.tokenOptions = tokenData;
+    return item
   }
 
   /**
@@ -663,6 +672,9 @@ class SidebarListItem {
   /** @returns {boolean} whether or not this item represents a Builtin Token */
   isTypeBuiltinToken() { return this.type === ItemType.BuiltinToken }
 
+  /** @returns {boolean} whether or not this item represents a Builtin Token */
+  isTypeDDBToken() { return this.type === ItemType.DDBToken }
+
   /** @returns {boolean} whether or not this item represents an Encounter */
   isTypeEncounter() { return this.type === ItemType.Encounter }
 
@@ -678,7 +690,7 @@ class SidebarListItem {
         return this.folderPath.startsWith(RootFolder.Players.path) || this.folderPath.startsWith(RootFolder.Monsters.path) || this.folderPath.startsWith(RootFolder.MyTokens.path) || this.folderPath.startsWith(RootFolder.AboveVTT.path) || this.folderPath.startsWith(RootFolder.Encounters.path);
       }
     }
-    return this.isTypeMyToken() || this.isTypePC() || this.isTypeMonster() || this.isTypeBuiltinToken()
+    return this.isTypeMyToken() || this.isTypePC() || this.isTypeMonster() || this.isTypeBuiltinToken() || this.isTypeDDBToken()
   }
 
   /** @returns {boolean} whether or not this item represents an object that can be edited by the user */
@@ -1164,8 +1176,8 @@ function build_sidebar_list_row(listItem) {
 
       break;
     case ItemType.BuiltinToken:
+    case ItemType.DDBToken:
       subtitle.hide();
-      // TODO: Style specifically for Builtin
       row.css("cursor", "default");
       break;
     case ItemType.Scene:
@@ -1204,7 +1216,7 @@ function build_sidebar_list_row(listItem) {
       break;
   }
 
-  if (listItem.canEdit() || listItem.isTypeBuiltinToken()) { // can't edit builtin, but need access to the list of images for drag and drop reasons.
+  if (listItem.canEdit() || listItem.isTypeBuiltinToken() || listItem.isTypeDDBToken()) { // can't edit builtin or DDB, but need access to the list of images for drag and drop reasons.
     let settingsButton = $(`
         <div class="token-row-gear" title="configure">
             <img src="${window.EXTENSION_PATH}assets/icons/cog.svg" style="width:100%;height:100%;"  alt="settings icon"/>
@@ -1341,6 +1353,7 @@ function display_sidebar_list_item_configuration_modal(listItem) {
       }
       break;
     case ItemType.BuiltinToken:
+    case ItemType.DDBToken:
       display_builtin_token_details_modal(listItem);
       break;
     case ItemType.MyToken:

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -465,13 +465,6 @@ function build_dropdown_input(settingOption, currentValue, changeHandler) {
  */
 class SidebarListItem {
 
-  // folder names within the tokens panel
-  static NamePlayers = "Players";
-  static NameMonsters = "Monsters";
-  static NameMyTokens = "My Tokens";
-  static NameAboveVTT = "AboveVTT Tokens";
-  static NameEncounters = "Encounters";
-
   /** Do not call this directly! It is a generic constructor for a SidebarListItem. Use one of the static functions instead.
    * @param id {string} a unique identifier for the backing item
    * @param name {string} the name displayed to the user
@@ -480,7 +473,7 @@ class SidebarListItem {
    * @param folderPath {string} the folder this item is in
    * @param parentId {string|undefined} a string id of the folder this item is in
    */
-  constructor(id, name, image, type, folderPath = RootFolderPath.Root, parentId = "root") {
+  constructor(id, name, image, type, folderPath = RootFolder.Root.path, parentId = "root") {
     this.id = id;
     this.name = name;
     this.image = image;
@@ -541,7 +534,7 @@ class SidebarListItem {
    */
   static BuiltinToken(tokenData) {
     console.debug("SidebarListItem.BuiltinToken", tokenData);
-    let folderPath = sanitize_folder_path(`${RootFolderPath.AboveVTT}/${tokenData.folderPath}`);
+    let folderPath = sanitize_folder_path(`${RootFolder.AboveVTT.path}/${tokenData.folderPath}`);
     return new SidebarListItem(path_to_html_id(folderPath, tokenData.name), tokenData.name, tokenData.image, ItemType.BuiltinToken, folderPath, path_to_html_id(folderPath));
   }
 
@@ -553,7 +546,7 @@ class SidebarListItem {
    */
   static Monster(monsterData) {
     console.debug("SidebarListItem.Monster", monsterData);
-    let item = new SidebarListItem(monsterData.id, monsterData.name, monsterData.avatarUrl, ItemType.Monster, RootFolderPath.Monsters, RootFolderId.Monsters);
+    let item = new SidebarListItem(monsterData.id, monsterData.name, monsterData.avatarUrl, ItemType.Monster, RootFolder.Monsters.path, RootFolder.Monsters.id);
     item.monsterData = monsterData;
     return item;
   }
@@ -568,7 +561,7 @@ class SidebarListItem {
    */
   static PC(sheet, name, image) {
     console.debug("SidebarListItem.PC", sheet, name, image);
-    let item = new SidebarListItem(sheet, name, image, ItemType.PC, RootFolderPath.Players, RootFolderId.Players);
+    let item = new SidebarListItem(sheet, name, image, ItemType.PC, RootFolder.Players.path, RootFolder.Players.id);
     item.sheet = sheet;
     return item;
   }
@@ -585,8 +578,8 @@ class SidebarListItem {
     if ((typeof encounter.name == 'string') && encounter.name.length > 0) {
       name = encounter.name;
     }
-    console.debug(`SidebarListItem.Encounter ${RootFolderPath.Encounters}/${name}, collapsed: ${collapsed}`);
-    let item = new SidebarListItem(encounter.id, name, `${window.EXTENSION_PATH}assets/folder.svg`, ItemType.Encounter, RootFolderPath.Encounters, RootFolderId.Encounter);
+    console.debug(`SidebarListItem.Encounter ${RootFolder.Encounters.path}/${name}, collapsed: ${collapsed}`);
+    let item = new SidebarListItem(encounter.id, name, `${window.EXTENSION_PATH}assets/folder.svg`, ItemType.Encounter, RootFolder.Encounters.path, RootFolder.Encounters.id);
     if ((typeof encounter.flavorText == 'string') && encounter.flavorText.length > 0) {
       item.description = encounter.flavorText;
     }
@@ -601,7 +594,7 @@ class SidebarListItem {
       name = sceneData.title;
     }
     let scenePath = sceneData.folderPath || "";
-    let folderPath = sanitize_folder_path(`${RootFolderPath.Scenes}/${scenePath}`);
+    let folderPath = sanitize_folder_path(`${RootFolder.Scenes.path}/${scenePath}`);
     let item = new SidebarListItem(sceneData.id, name, sceneData.player_map, ItemType.Scene, folderPath, path_to_html_id(folderPath));
     console.debug(`SidebarListItem.Scene ${item.fullPath()}`);
     item.sceneId = sceneData.id;
@@ -669,10 +662,10 @@ class SidebarListItem {
   /** @returns {boolean} whether or not this item is listed in the tokens panel */
   isTokensPanelItem() {
     if (this.isTypeFolder()) {
-      if (this.folderPath === RootFolderPath.Root) {
-        return this.name === SidebarListItem.NamePlayers || this.name === SidebarListItem.NameMonsters || this.name === SidebarListItem.NameMyTokens || this.name === SidebarListItem.NameAboveVTT || this.name === SidebarListItem.NameEncounters;
+      if (this.folderPath === RootFolder.Root.path) {
+        return this.name === RootFolder.Players.name || this.name === RootFolder.Monsters.name || this.name === RootFolder.MyTokens.name || this.name === RootFolder.AboveVTT.name || this.name === RootFolder.Encounters.name;
       } else {
-        return this.folderPath.startsWith(RootFolderPath.Players) || this.folderPath.startsWith(RootFolderPath.Monsters) || this.folderPath.startsWith(RootFolderPath.MyTokens) || this.folderPath.startsWith(RootFolderPath.AboveVTT) || this.folderPath.startsWith(RootFolderPath.Encounters);
+        return this.folderPath.startsWith(RootFolder.Players.path) || this.folderPath.startsWith(RootFolder.Monsters.path) || this.folderPath.startsWith(RootFolder.MyTokens.path) || this.folderPath.startsWith(RootFolder.AboveVTT.path) || this.folderPath.startsWith(RootFolder.Encounters.path);
       }
     }
     return this.isTypeMyToken() || this.isTypePC() || this.isTypeMonster() || this.isTypeBuiltinToken()
@@ -682,7 +675,7 @@ class SidebarListItem {
   canEdit() {
     switch (this.type) {
       case ItemType.Folder:
-        return this.folderPath.startsWith(RootFolderPath.MyTokens) || this.folderPath.startsWith(RootFolderPath.Scenes);
+        return this.folderPath.startsWith(RootFolder.MyTokens.path) || this.folderPath.startsWith(RootFolder.Scenes.path);
       case ItemType.MyToken:
       case ItemType.PC:
       case ItemType.Monster:
@@ -700,7 +693,7 @@ class SidebarListItem {
     switch (this.type) {
       case ItemType.Folder:
         // TODO: allow deleting scenes folders
-        return this.folderPath.startsWith(RootFolderPath.MyTokens) || this.folderPath.startsWith(RootFolderPath.Scenes);
+        return this.folderPath.startsWith(RootFolder.MyTokens.path) || this.folderPath.startsWith(RootFolder.Scenes.path);
       case ItemType.MyToken:
       case ItemType.Scene:
         return true;
@@ -745,7 +738,7 @@ class SidebarListItem {
  */
 function sanitize_folder_path(dirtyPath) {
   if (dirtyPath === undefined) {
-    return RootFolderPath.Root;
+    return RootFolder.Root.path;
   }
   let cleanPath = dirtyPath.replaceAll("///", "/").replaceAll("//", "/");
   // remove trailing slashes before adding one at the beginning. Otherwise, we return an empty string
@@ -804,7 +797,7 @@ function find_sidebar_list_item_from_path(fullPath) {
   const matchingPath = function(item) { return item.fullPath() === fullPath };
 
   let foundItem;
-  if (fullPath.startsWith(RootFolderPath.Scenes)) {
+  if (fullPath.startsWith(RootFolder.Scenes.path)) {
     foundItem = window.sceneListItems.find(matchingPath);
     if (foundItem === undefined) {
       foundItem = window.sceneListFolders.find(matchingPath);
@@ -979,7 +972,7 @@ function build_sidebar_list_row(listItem) {
       if (listItem.collapsed === true) {
         row.addClass("collapsed");
       }
-      if (listItem.fullPath().startsWith(RootFolderPath.MyTokens)) {
+      if (listItem.fullPath().startsWith(RootFolder.MyTokens.path)) {
         // add buttons for creating subfolders and tokens
         let addFolder = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
         rowItem.append(addFolder);
@@ -1008,7 +1001,7 @@ function build_sidebar_list_row(listItem) {
             }
           });
         }
-      } else if (listItem.fullPath().startsWith(RootFolderPath.Scenes)) {
+      } else if (listItem.fullPath().startsWith(RootFolder.Scenes.path)) {
         // add buttons for creating subfolders and scenes
         let addFolder = $(`<button class="token-row-button" title="Create New Folder"><span class="material-icons">create_new_folder</span></button>`);
         rowItem.append(addFolder);
@@ -1025,7 +1018,7 @@ function build_sidebar_list_row(listItem) {
           let clickedItem = find_sidebar_list_item(clickedRow);
           create_scene_inside(clickedItem.fullPath());
         });
-      } else if (listItem.fullPath() === RootFolderPath.Monsters) {
+      } else if (listItem.fullPath() === RootFolder.Monsters.path) {
         // add monster filter button on the root monsters folder
         let filterMonsters = $(`<button class="token-row-button monster-filter-button" title="Filter Monsters"><span class="material-icons">filter_alt</span></button>`);
         if (Object.keys(monster_search_filters).length > 0) {
@@ -1227,7 +1220,7 @@ function did_click_row(clickEvent) {
         clickedRow.addClass("collapsed");
         clickedItem.collapsed = true;
       }
-      if (clickedItem.folderPath.startsWith(RootFolderPath.MyTokens)) {
+      if (clickedItem.folderPath.startsWith(RootFolder.MyTokens.path)) {
         let backingObject = find_my_token_folder(clickedItem.fullPath());
         if (backingObject !== undefined) {
           backingObject.collapsed = clickedItem.collapsed;
@@ -1330,7 +1323,7 @@ function display_sidebar_list_item_configuration_modal(listItem) {
       window.open(`https://www.dndbeyond.com/encounters/${listItem.encounterId}/edit`, '_blank');
       break;
     case ItemType.Folder:
-      if (listItem.folderPath.startsWith(RootFolderPath.MyTokens) || listItem.folderPath.startsWith(RootFolderPath.Scenes)) {
+      if (listItem.folderPath.startsWith(RootFolder.MyTokens.path) || listItem.folderPath.startsWith(RootFolder.Scenes.path)) {
         display_folder_configure_modal(listItem);
       } else {
         console.warn("Only allowed to folders within the My Tokens folder and Scenes");
@@ -1365,9 +1358,9 @@ function create_folder_inside(listItem) {
     return;
   }
 
-  if (listItem.fullPath().startsWith(RootFolderPath.MyTokens)) {
+  if (listItem.fullPath().startsWith(RootFolder.MyTokens.path)) {
     create_mytoken_folder_inside(listItem);
-  } else if (listItem.fullPath().startsWith(RootFolderPath.Scenes)) {
+  } else if (listItem.fullPath().startsWith(RootFolder.Scenes.path)) {
     create_scene_folder_inside(listItem.fullPath());
   } else {
     console.warn("create_folder_inside called with an incorrect item type", listItem);
@@ -1388,7 +1381,7 @@ function display_folder_configure_modal(listItem) {
   let sidebarModal = new SidebarPanel(sidebarId, true);
   let listItemFullPath = listItem.fullPath();
   let container;
-  if (listItemFullPath.startsWith(RootFolderPath.Scenes)) {
+  if (listItemFullPath.startsWith(RootFolder.Scenes.path)) {
     container = scenesPanel.body;
   } else {
     container = tokensPanel.body;
@@ -1477,7 +1470,7 @@ function rename_folder(item, newName, alertUser = true) {
 
   if (item.folderPath.startsWith(ItemPath.MyTokens)) {
     return rename_mytoken_folder(item, newName, alertUser);
-  } else if (item.folderPath.startsWith(SidebarListItem.PathScenes)) {
+  } else if (item.folderPath.startsWith(RootFolder.Scenes.path)) {
     return rename_scene_folder(item, newName, alertUser);
   } else if (alertUser !== false) {
     alert("An unexpected error occurred");
@@ -1510,13 +1503,13 @@ function delete_item(listItem) {
         did_update_scenes();
       }
       break;
-    case SidebarListItem.TypePC:
+    case ItemType.PC:
       console.warn("Not allowed to delete player", listItem);
       break;
-    case SidebarListItem.TypeMonster:
+    case ItemType.Monster:
       console.warn("Not allowed to delete monster", listItem);
       break;
-    case SidebarListItem.TypeBuiltinToken:
+    case ItemType.BuiltinToken:
       console.warn("Not allowed to delete builtin token", listItem);
       break;
   }
@@ -1553,12 +1546,12 @@ function delete_folder_and_delete_children(listItem) {
     return;
   }
 
-  if (listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+  if (listItem.folderPath.startsWith(RootFolder.MyTokens.path)) {
     delete_mytokens_within_folder(listItem);
     delete_mytokens_folder(listItem);
     did_change_mytokens_items();
     expand_all_folders_up_to(listItem.folderPath, tokensPanel.body);
-  } else if (listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+  } else if (listItem.folderPath.startsWith(RootFolder.Scenes.path)) {
     delete_scenes_within_folder(listItem);
     delete_scenes_folder(listItem);
     did_update_scenes();
@@ -1583,12 +1576,12 @@ function delete_folder_and_move_children_up_one_level(listItem) {
     return;
   }
 
-  if (listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+  if (listItem.folderPath.startsWith(RootFolder.MyTokens.path)) {
     move_mytokens_to_parent_folder(listItem);
     delete_mytokens_folder(listItem);
     did_change_mytokens_items();
     expand_all_folders_up_to(listItem.folderPath, tokensPanel.body);
-  } else if (listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+  } else if (listItem.folderPath.startsWith(RootFolder.Scenes.path)) {
     move_scenes_to_parent_folder(listItem);
     delete_scenes_folder(listItem);
     did_update_scenes();
@@ -1646,7 +1639,7 @@ function list_item_image_flyout(hoverEvent) {
 function disable_draggable_change_folder(listItemType) {
   $(".token-row-drag-handle").remove();
   switch (listItemType) {
-    case SidebarListItem.TypeMyToken:
+    case ItemType.MyToken:
       tokensPanel.body.find(".token-row-button").show();
       tokensPanel.body.find(".token-row-button.reorder-button").show();
       tokensPanel.body.find(".reorder-button").removeClass("active");
@@ -1662,7 +1655,7 @@ function disable_draggable_change_folder(listItemType) {
         tokensPanel.body.find(".sidebar-list-item-row").droppable("destroy");
       } catch (e) {} // don't care if it fails, just try
       break;
-    case SidebarListItem.TypeScene:
+    case ItemType.Scene:
       scenesPanel.body.find(".token-row-gear").show();
       scenesPanel.body.find(".token-row-button").show();
       scenesPanel.header.find(".token-row-gear").show();
@@ -1700,7 +1693,7 @@ function add_expand_collapse_buttons_to_header(sidebarPanel) {
 
 /**
  * allows you to drag items from one folder to another
- * @param listItemType {string} SidebarListItem.TypeMyTokens || SidebarListItem.TypeScene
+ * @param listItemType {string} ItemType.MyTokens || ItemType.Scene
  */
 function enable_draggable_change_folder(listItemType) {
 
@@ -1716,10 +1709,10 @@ function enable_draggable_change_folder(listItemType) {
       let droppedFolder = $(dropEvent.target);
       if (droppedFolder.hasClass("sidebar-panel-body")) {
         // they dropped it on the header so find the root folder
-        if (listItemType === SidebarListItem.TypeScene) {
-          move_item_into_folder(draggedItem, SidebarListItem.PathScenes);
-        } else if (listItemType === SidebarListItem.TypeMyToken) {
-          move_item_into_folder(draggedItem, SidebarListItem.PathMyTokens);
+        if (listItemType === ItemType.Scene) {
+          move_item_into_folder(draggedItem, RootFolder.Scenes.path);
+        } else if (listItemType === ItemType.MyToken) {
+          move_item_into_folder(draggedItem, RootFolder.MyTokens.path);
         } else {
           console.warn("Unable to reorder item by dropping it on the body", listItemType, draggedItem);
         }
@@ -1732,7 +1725,7 @@ function enable_draggable_change_folder(listItemType) {
   };
 
   switch (listItemType) {
-    case SidebarListItem.TypeMyToken:
+    case ItemType.MyToken:
 
       redraw_token_list("", false);
 
@@ -1746,7 +1739,7 @@ function enable_draggable_change_folder(listItemType) {
       tokensPanel.updateHeader("Tokens", "", "Drag items to move them between folders");
       add_expand_collapse_buttons_to_header(tokensPanel);
 
-      let myTokensRootItem = tokens_rootfolders.find(i => i.name === SidebarListItem.NameMyTokens);
+      let myTokensRootItem = tokens_rootfolders.find(i => i.name === RootFolder.MyTokens.name);
       let myTokensRootFolder = find_html_row(myTokensRootItem, tokensPanel.body);
       // make sure we expand all folders that can be dropped on
       myTokensRootFolder.show();
@@ -1776,7 +1769,7 @@ function enable_draggable_change_folder(listItemType) {
           if (draggedRow.hasClass("drag-cancelled")) {
             draggedRow.removeClass("drag-cancelled");
             redraw_token_list("", false);
-            enable_draggable_change_folder(SidebarListItem.TypeMyToken);
+            enable_draggable_change_folder(ItemType.MyToken);
           }
         }
       });
@@ -1787,7 +1780,7 @@ function enable_draggable_change_folder(listItemType) {
       tokensPanel.body.droppable(droppableOptions);  // allow dropping on folders within MyTokens folder
 
       break;
-    case SidebarListItem.TypeScene:
+    case ItemType.Scene:
       scenesPanel.header.find(".token-row-button").hide();
       scenesPanel.header.find(".scenes-panel-add-buttons-wrapper input").hide();
       scenesPanel.header.find(".scenes-panel-add-buttons-wrapper .reorder-explanation").show();
@@ -1818,7 +1811,7 @@ function enable_draggable_change_folder(listItemType) {
           if (draggedRow.hasClass("drag-cancelled")) {
             draggedRow.removeClass("drag-cancelled");
             redraw_scene_list("");
-            enable_draggable_change_folder(SidebarListItem.TypeScene);
+            enable_draggable_change_folder(ItemType.Scene);
           }
         }
       });
@@ -1838,20 +1831,20 @@ function move_item_into_folder(listItem, folderPath) {
     move_mytoken_to_folder(listItem, folderPath);
     persist_my_tokens();
     rebuild_token_items_list();
-    enable_draggable_change_folder(SidebarListItem.TypeMyToken);
+    enable_draggable_change_folder(ItemType.MyToken);
   } else if (listItem.isTypeScene()) {
     move_scene_to_folder(listItem, folderPath);
     did_update_scenes();
-    enable_draggable_change_folder(SidebarListItem.TypeScene);
-  } else if (listItem.isTypeFolder() && listItem.folderPath.startsWith(SidebarListItem.PathMyTokens)) {
+    enable_draggable_change_folder(ItemType.Scene);
+  } else if (listItem.isTypeFolder() && listItem.folderPath.startsWith(RootFolder.MyTokens.path)) {
     move_mytokens_folder(listItem, folderPath);
     persist_my_tokens();
     rebuild_token_items_list();
-    enable_draggable_change_folder(SidebarListItem.TypeMyToken);
-  } else if (listItem.isTypeFolder() && listItem.folderPath.startsWith(SidebarListItem.PathScenes)) {
+    enable_draggable_change_folder(ItemType.MyToken);
+  } else if (listItem.isTypeFolder() && listItem.folderPath.startsWith(RootFolder.Scenes.path)) {
     move_scenes_folder(listItem, folderPath);
     did_update_scenes();
-    enable_draggable_change_folder(SidebarListItem.TypeScene);
+    enable_draggable_change_folder(ItemType.Scene);
   } else {
     console.warn("move_item_into_folder was called with invalid item type", listItem)
   }

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -724,6 +724,22 @@ class SidebarListItem {
     return this.name.toLowerCase().includes(searchTerm.toLowerCase()) // any item with a partially matching name
     || this.containingFolderName().toLowerCase().includes(searchTerm.toLowerCase()) // all items within a folder with a partially matching name
   }
+
+  backingId() {
+    switch (this.type) {
+      case SidebarListItem.TypePC:
+        return this.sheet;
+      case SidebarListItem.TypeMonster:
+        return this.monsterData.id;
+      case SidebarListItem.TypeFolder:
+      case SidebarListItem.TypeMyToken:
+      case SidebarListItem.TypeScene:
+      case SidebarListItem.TypeBuiltinToken:
+      case SidebarListItem.TypeEncounter:
+      default:
+        return this.id; // could be undefined
+    }
+  }
 }
 
 /**

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1572,10 +1572,7 @@ function delete_folder_and_delete_children(listItem) {
   }
 
   if (listItem.folderPath.startsWith(RootFolder.MyTokens.path)) {
-    delete_mytokens_within_folder(listItem);
-    delete_mytokens_folder(listItem);
-    did_change_mytokens_items();
-    expand_all_folders_up_to_item(listItem);
+    delete_mytokens_folder_and_everything_in_it(listItem);
   } else if (listItem.folderPath.startsWith(RootFolder.Scenes.path)) {
     delete_scenes_within_folder(listItem);
     delete_scenes_folder(listItem);
@@ -1602,10 +1599,10 @@ function delete_folder_and_move_children_up_one_level(listItem) {
   }
 
   if (listItem.folderPath.startsWith(RootFolder.MyTokens.path)) {
-    move_mytokens_to_parent_folder(listItem);
-    delete_mytokens_folder(listItem);
-    did_change_mytokens_items();
-    expand_all_folders_up_to_item(listItem);
+    move_mytokens_to_parent_folder_and_delete_folder(listItem, function (didSucceed, errorType) {
+      did_change_mytokens_items();
+      expand_all_folders_up_to_id(listItem.parentId);
+    });
   } else if (listItem.folderPath.startsWith(RootFolder.Scenes.path)) {
     move_scenes_to_parent_folder(listItem);
     delete_scenes_folder(listItem);

--- a/Token.js
+++ b/Token.js
@@ -1725,10 +1725,7 @@ function place_token_at_map_point(tokenObject, x, y) {
 			}
 		}
 	}
-	for (let i = 0; i < token_setting_options.length; i++) {
-		// all global token settings default to false
-		setReasonableDefault(token_setting_options[i].name, false);
-	}
+	token_setting_options().forEach(option => setReasonableDefault(option.name, option.defaultValue));
 	// unless otherwise specified, tokens should not be hidden when they are placed
 	setReasonableDefault("hidden", false);
 

--- a/Token.js
+++ b/Token.js
@@ -2028,23 +2028,23 @@ function setTokenBase(token, options) {
 }
 
 function get_custom_monster_images(monsterId) {
-	return find_token_customization(SidebarListItem.TypeMonster, monsterId)?.tokenOptions?.alternativeImages || [];
+	return find_token_customization(ItemType.Monster, monsterId)?.tokenOptions?.alternativeImages || [];
 }
 
 function add_custom_monster_image_mapping(monsterId, imgsrc) {
-	let customization = find_or_create_token_customization(SidebarListItem.TypeMonster, monsterId);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId);
 	customization.addAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_custom_monster_image(monsterId, imgsrc) {
-	let customization = find_or_create_token_customization(SidebarListItem.TypeMonster, monsterId);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId);
 	customization.removeAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_all_custom_monster_images(monsterId) {
-	let customization = find_or_create_token_customization(SidebarListItem.TypeMonster, monsterId);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId);
 	customization.removeAllAlternativeImages();
 	persist_token_customization(customization);
 }

--- a/Token.js
+++ b/Token.js
@@ -2032,19 +2032,19 @@ function get_custom_monster_images(monsterId) {
 }
 
 function add_custom_monster_image_mapping(monsterId, imgsrc) {
-	let customization = find_or_create_token_customization(ItemType.Monster, monsterId);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolderId.Monsters);
 	customization.addAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_custom_monster_image(monsterId, imgsrc) {
-	let customization = find_or_create_token_customization(ItemType.Monster, monsterId);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolderId.Monsters);
 	customization.removeAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_all_custom_monster_images(monsterId) {
-	let customization = find_or_create_token_customization(ItemType.Monster, monsterId);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolderId.Monsters);
 	customization.removeAllAlternativeImages();
 	persist_token_customization(customization);
 }

--- a/Token.js
+++ b/Token.js
@@ -1960,7 +1960,7 @@ function remove_all_custom_monster_images(monsterId) {
 function load_custom_monster_image_mapping() {
 	window.CUSTOM_TOKEN_IMAGE_MAP = {};
 	let customMappingData = localStorage.getItem('CustomDefaultTokenMapping');
-	if(customMappingData != null){
+	if(customMappingData != null) {
 		window.CUSTOM_TOKEN_IMAGE_MAP = $.parseJSON(customMappingData);
 	}
 }
@@ -1977,7 +1977,7 @@ function copy_to_clipboard(text) {
 	$temp.val(text).select();
 	document.execCommand("copy");
 	$temp.remove();
-};
+}
 
 const radToDeg = 180 / Math.PI;
 

--- a/Token.js
+++ b/Token.js
@@ -1914,49 +1914,30 @@ function setTokenAuras (token, options) {
 	}
 }
 
-function get_custom_monster_images(monsterId) {
-	if (monsterId == undefined) {
-		return [];
-	}
-	if (window.CUSTOM_TOKEN_IMAGE_MAP == undefined) {
-		load_custom_monster_image_mapping();
-	}
-	var customImages = window.CUSTOM_TOKEN_IMAGE_MAP[monsterId];
-	if (customImages == undefined) {
-		customImages = [];
-	}
-	return customImages;
-}
 
-function get_random_custom_monster_image(monsterId) {
-	let customImgs = get_custom_monster_images(monsterId);
-	let randomIndex = getRandomInt(0, customImgs.length);
-	return customImgs[randomIndex];
+function get_custom_monster_images(monsterId) {
+	return find_monster_token_customization(monsterId)?.tokenOptions?.alternativeImages || [];
 }
 
 function add_custom_monster_image_mapping(monsterId, imgsrc) {
-	if (monsterId == undefined) {
-		return;
-	}
-	var customImages = get_custom_monster_images(monsterId);
-	customImages.push(parse_img(imgsrc));
-	window.CUSTOM_TOKEN_IMAGE_MAP[monsterId] = customImages;
-	save_custom_monster_image_mapping();
+	let customization = get_monster_token_customization(monsterId);
+	customization.addAlternativeImage(imgsrc);
+	persist_token_customization(customization);
 }
 
-function remove_custom_monster_image(monsterId, index) {
-	var customImages = get_custom_monster_images(monsterId);;
-	if (customImages.length > index) {
-		window.CUSTOM_TOKEN_IMAGE_MAP[monsterId].splice(index, 1);
-	}
-	save_custom_monster_image_mapping();
+function remove_custom_monster_image(monsterId, imgsrc) {
+	let customization = get_monster_token_customization(monsterId);
+	customization.removeAlternativeImage(imgsrc);
+	persist_token_customization(customization);
 }
 
 function remove_all_custom_monster_images(monsterId) {
-	delete window.CUSTOM_TOKEN_IMAGE_MAP[monsterId];
-	save_custom_monster_image_mapping();
+	let customization = get_monster_token_customization(monsterId);
+	customization.removeAllAlternativeImages();
+	persist_token_customization(customization);
 }
 
+// deprecated, but still required for migrations
 function load_custom_monster_image_mapping() {
 	window.CUSTOM_TOKEN_IMAGE_MAP = {};
 	let customMappingData = localStorage.getItem('CustomDefaultTokenMapping');
@@ -1965,6 +1946,7 @@ function load_custom_monster_image_mapping() {
 	}
 }
 
+// deprecated, but still required for migrations
 function save_custom_monster_image_mapping() {
 	let customMappingData = JSON.stringify(window.CUSTOM_TOKEN_IMAGE_MAP);
 	localStorage.setItem("CustomDefaultTokenMapping", customMappingData);

--- a/Token.js
+++ b/Token.js
@@ -1921,9 +1921,9 @@ function setTokenAuras (token, options) {
 
 
 function setTokenBase(token, options) {
-	if(options.tokenStyleSelect == 1 || options.tokenStyleSelect == 2 || options.tokenStyleSelect == 3){
-		$(`.token[data-id='${options.id}']>.base`).remove();
-	}
+	// if (["circle", "square", "noConstraint"].includes(options.tokenStyleSelect)) {
+	// 	$(`.token[data-id='${options.id}']>.base`).remove();
+	// }
 	$(`.token[data-id='${options.id}']>.base`).remove();
 	let base = $(`<div class='base'></div>`);
 	if(options.size < 150){
@@ -1933,33 +1933,33 @@ function setTokenBase(token, options) {
 		$(base).toggleClass("large-or-smaller-base", false);
 	}
 
-	if(options.tokenStyleSelect == 4){
+	if (options.tokenStyleSelect === "virtualMiniCircle") {
 		base.toggleClass('square', false);
 		base.toggleClass('circle', true);		
 	}
-	if (options.tokenStyleSelect == 5){
+	if (options.tokenStyleSelect === "virtualMiniSquare"){
 		base.toggleClass('square', true);
 		base.toggleClass('circle', false);
 	}
-	if(options.tokenStyleSelect !== 3){
+	if (options.tokenStyleSelect !== "noConstraint") {
 		token.children("img").toggleClass("freeform", false);
 	}
 	
-	if(options.tokenStyleSelect == 1){
+	if (options.tokenStyleSelect === "circle") {
 		//Circle
 		options.square = false;
 		options.legacyaspectratio = true;
 		token.children("img").css("border-radius", "50%")
 		token.children("img").removeClass("preserve-aspect-ratio");
 	}
-	else if(options.tokenStyleSelect == 2){
+	else if(options.tokenStyleSelect === "square"){
 		//Square
 		options.square = true;
 		options.legacyaspectratio = true;
 		token.children("img").css("border-radius", "0");
 		token.children("img").removeClass("preserve-aspect-ratio");
 	}
-	else if(options.tokenStyleSelect == 3){
+	else if(options.tokenStyleSelect === "noConstraint") {
 		//Freeform
 		options.square = true;
 		options.legacyaspectratio = false;
@@ -1967,7 +1967,7 @@ function setTokenBase(token, options) {
 		token.children("img").addClass("preserve-aspect-ratio");
 		token.children("img").toggleClass("freeform", true);
 	}
-	else if(options.tokenStyleSelect == 4){
+	else if(options.tokenStyleSelect === "virtualMiniCircle"){
 		$(`.token[data-id='${options.id}']`).prepend(base);
 		//Virtual Mini Circle
 		options.square = true;
@@ -1975,7 +1975,7 @@ function setTokenBase(token, options) {
 		token.children("img").css("border-radius", "0");
 		token.children("img").addClass("preserve-aspect-ratio");
 	}
-	else if(options.tokenStyleSelect == 5){
+	else if(options.tokenStyleSelect === "virtualMiniSquare"){
 		$(`.token[data-id='${options.id}']`).prepend(base);
 		//Virtual Mini Square
 		options.square = true;
@@ -1984,7 +1984,7 @@ function setTokenBase(token, options) {
 		token.children("img").addClass("preserve-aspect-ratio");
 	}
 
-	if(options.tokenStyleSelect == 5 || options.tokenStyleSelect == 4){
+	if(options.tokenStyleSelect === "virtualMiniCircle" || options.tokenStyleSelect === "virtualMiniSquare"){
 		if(options.disableborder == true){
 			token.children(".base").toggleClass("noborder", true);
 		}
@@ -2006,38 +2006,23 @@ function setTokenBase(token, options) {
 	token.children(".base").toggleClass("tile-base", false);
 	token.children(".base").toggleClass("sand-base", false);
 	token.children(".base").toggleClass("water-base", false);
-	if(options.tokenBaseStyleSelect == 2){
+	if(options.tokenBaseStyleSelect === "grass"){
 		token.children(".base").toggleClass("grass-base", true);
 	}
-	else if(options.tokenBaseStyleSelect == 3){
+	else if(options.tokenBaseStyleSelect === "tile"){
 		token.children(".base").toggleClass("tile-base", true);
 	}
-	else if(options.tokenBaseStyleSelect == 4){
+	else if(options.tokenBaseStyleSelect === "sand"){
 		token.children(".base").toggleClass("sand-base", true);
 	}
-	else if(options.tokenBaseStyleSelect == 5){
+	else if(options.tokenBaseStyleSelect === "rock"){
 		token.children(".base").toggleClass("rock-base", true);
 	}
-	else if(options.tokenBaseStyleSelect == 6){
+	else if(options.tokenBaseStyleSelect === "water"){
 		token.children(".base").toggleClass("water-base", true);
 	}
 			
 }
-
-function get_custom_monster_images(monsterId) {
-	if (monsterId == undefined) {
-		return [];
-	}
-	if (window.CUSTOM_TOKEN_IMAGE_MAP == undefined) {
-		load_custom_monster_image_mapping();
-	}
-	var customImages = window.CUSTOM_TOKEN_IMAGE_MAP[monsterId];
-	if (customImages == undefined) {
-		customImages = [];
-	}
-	return customImages;
-}
-
 
 function get_custom_monster_images(monsterId) {
 	return find_token_customization(SidebarListItem.TypeMonster, monsterId)?.tokenOptions?.alternativeImages || [];

--- a/Token.js
+++ b/Token.js
@@ -395,7 +395,7 @@ class Token {
 			token.css('--token-temp-hp', "transparent");
 		} 
 		else {
-			if(this.options.tokenStyleSelect == 1 || this.options.tokenStyleSelect == 2){
+			if(this.options.tokenStyleSelect === "circle" || this.options.tokenStyleSelect === "square"){
 				tokenWidth = tokenWidth - 6;
 				tokenHeight = tokenHeight - 6;
 			}
@@ -412,7 +412,7 @@ class Token {
 			$("token:before").css('--token-border-color', 'transparent');
 		} 
 		else {
-			if(this.options.tokenStyleSelect == 1 || this.options.tokenStyleSelect == 2){
+			if(this.options.tokenStyleSelect === "circle" || this.options.tokenStyleSelect === "square"){
 				tokenWidth = tokenWidth - 1;
 				tokenHeight = tokenHeight - 1;
 			}
@@ -1921,9 +1921,6 @@ function setTokenAuras (token, options) {
 
 
 function setTokenBase(token, options) {
-	// if (["circle", "square", "noConstraint"].includes(options.tokenStyleSelect)) {
-	// 	$(`.token[data-id='${options.id}']>.base`).remove();
-	// }
 	$(`.token[data-id='${options.id}']>.base`).remove();
 	let base = $(`<div class='base'></div>`);
 	if(options.size < 150){

--- a/Token.js
+++ b/Token.js
@@ -2043,23 +2043,23 @@ function get_custom_monster_images(monsterId) {
 
 
 function get_custom_monster_images(monsterId) {
-	return find_monster_token_customization(monsterId)?.tokenOptions?.alternativeImages || [];
+	return find_token_customization(SidebarListItem.TypeMonster, monsterId)?.tokenOptions?.alternativeImages || [];
 }
 
 function add_custom_monster_image_mapping(monsterId, imgsrc) {
-	let customization = get_monster_token_customization(monsterId);
+	let customization = find_or_create_token_customization(SidebarListItem.TypeMonster, monsterId);
 	customization.addAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_custom_monster_image(monsterId, imgsrc) {
-	let customization = get_monster_token_customization(monsterId);
+	let customization = find_or_create_token_customization(SidebarListItem.TypeMonster, monsterId);
 	customization.removeAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_all_custom_monster_images(monsterId) {
-	let customization = get_monster_token_customization(monsterId);
+	let customization = find_or_create_token_customization(SidebarListItem.TypeMonster, monsterId);
 	customization.removeAllAlternativeImages();
 	persist_token_customization(customization);
 }

--- a/Token.js
+++ b/Token.js
@@ -2032,19 +2032,19 @@ function get_custom_monster_images(monsterId) {
 }
 
 function add_custom_monster_image_mapping(monsterId, imgsrc) {
-	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolderId.Monsters);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolder.Monsters.id);
 	customization.addAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_custom_monster_image(monsterId, imgsrc) {
-	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolderId.Monsters);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolder.Monsters.id);
 	customization.removeAlternativeImage(imgsrc);
 	persist_token_customization(customization);
 }
 
 function remove_all_custom_monster_images(monsterId) {
-	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolderId.Monsters);
+	let customization = find_or_create_token_customization(ItemType.Monster, monsterId, RootFolder.Monsters.id);
 	customization.removeAllAlternativeImages();
 	persist_token_customization(customization);
 }

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -35,6 +35,7 @@ class RootFolderPath {
             case RootFolderId.MyTokens: return RootFolderPath.MyTokens;
             case RootFolderId.BuiltinTokens: return RootFolderPath.AboveVTT;
             case RootFolderId.Encounter: return RootFolderPath.Encounters;
+            case RootFolderId.Scenes: return RootFolderPath.Scenes;
             default: return undefined;
         }
     }
@@ -46,13 +47,15 @@ class RootFolderId {
     static MyTokens = "myTokensFolder";
     static BuiltinTokens = "builtinTokensFolder";
     static Encounter = "encountersFolder";
+    static Scenes = "scenesFolder";
     static allValues() {
         return [
             RootFolderId.Players,
             RootFolderId.Monsters,
             RootFolderId.MyTokens,
             RootFolderId.BuiltinTokens,
-            RootFolderId.Encounter
+            RootFolderId.Encounter,
+            RootFolderId.Scenes,
         ]
     }
 }
@@ -241,6 +244,18 @@ class TokenCustomization {
             }
         }
         return n;
+    }
+    isTypeMyToken() {
+        return this.tokenType === ItemType.MyToken;
+    }
+    isTypeFolder() {
+        return this.tokenType === ItemType.Folder;
+    }
+    isTypePC() {
+        return this.tokenType === ItemType.PC;
+    }
+    isTypeMonster() {
+        return this.tokenType === ItemType.Monster;
     }
 }
 

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -271,11 +271,12 @@ function find_token_customization(type, id) {
 /**
  * @param type {string} the type of customization you're looking for. EX: ItemType.Monster
  * @param id {string|number} the id of the customization you're looking for. EX: pc.sheet, monsterData.id, etc
+ * @param parentId {string|number} the id of the parent that will be created. EX: pc.sheet, monsterData.id, etc
  * @returns {TokenCustomization|undefined} a token customization for the item if found. If not found, a new TokenCustomization object will be created and returned.
  * @throws an error if a customization object cannot be created
  */
-function find_or_create_token_customization(type, id) {
-    return find_token_customization(type, id) || new TokenCustomization(id, type, {});
+function find_or_create_token_customization(type, id, parentId) {
+    return find_token_customization(type, id) || new TokenCustomization(id, type, parentId, {});
 }
 
 /**

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -296,6 +296,18 @@ class TokenCustomization {
         });
         return combinedOptions;
     }
+
+    // this does not change tokenOptions.name or tokenOptions.alternativeImages. Everything else will be removed.
+    clearTokenOptions() {
+        let clearedOptions = {};
+        if (this.tokenOptions.name !== undefined) {
+            clearedOptions.name = name;
+        }
+        if (Array.isArray(this.tokenOptions.alternativeImages)) {
+            clearedOptions.alternativeImages = [...this.tokenOptions.alternativeImages];
+        }
+        this.tokenOptions = clearedOptions;
+    }
 }
 
 /**

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -451,6 +451,7 @@ function migrate_token_customizations() {
                         window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate = true;
                         save_custom_monster_image_mapping();
                         console.log("migrate_token_customizations successfully persisted migrated customizations", newCustomizations);
+                        did_change_mytokens_items();
                     } else {
                         console.error("migrate_token_customizations failed to persist new customizations", newCustomizations, errorType);
                     }

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -597,6 +597,47 @@ function fetch_token_customizations(callback) {
     });
 }
 
+// deletes everything within a folder
+function delete_token_customization_by_parent_id(parentId, callback) {
+    if (typeof callback !== 'function') {
+        callback = function(){};
+    }
+    if (typeof parentId !== "string" || parentId.length === 0) {
+        console.warn("delete_token_customization_by_parent_id received an invalid parentId", parentId);
+        callback(false);
+        return;
+    }
+
+    window.TOKEN_CUSTOMIZATIONS = window.TOKEN_CUSTOMIZATIONS.filter(tc => tc.parentId !== parentId);
+
+    persist_all_token_customizations(window.TOKEN_CUSTOMIZATIONS, callback);
+
+    return; // TODO: remove everything above, and just do this instead
+
+    let http_api_gw="https://services.abovevtt.net";
+    let searchParams = new URLSearchParams(window.location.search);
+    if(searchParams.has("dev")){
+        http_api_gw="https://jiv5p31gj3.execute-api.eu-west-1.amazonaws.com";
+    }
+
+    window.ajaxQueue.addRequest({
+        url: `${http_api_gw}/services?action=deleteTokenCustomizations&parentId=${parentId}&userId=todo`, // TODO: figure this out
+        type: "DELETE",
+        success: function (response) {
+            console.warn(`delete_token_customization succeeded`, response);
+            let index = window.TOKEN_CUSTOMIZATIONS.findIndex(tc => tc.tokenType === customization.tokenType && tc.id === customization.id);
+            if (index >= 0) {
+                window.TOKEN_CUSTOMIZATIONS.splice(index, 1);
+            }
+            callback(true);
+        },
+        error: function (errorMessage) {
+            console.warn(`delete_token_customization failed`, errorMessage);
+            callback(false, errorMessage?.responseJSON?.type);
+        }
+    });
+}
+
 function delete_token_customization_by_type_and_id(itemType, id, callback) {
     if (typeof callback !== 'function') {
         callback = function(){};

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -304,7 +304,7 @@ class TokenCustomization {
     clearTokenOptions() {
         let clearedOptions = {};
         if (this.tokenOptions.name !== undefined) {
-            clearedOptions.name = name;
+            clearedOptions.name = this.tokenOptions.name;
         }
         if (Array.isArray(this.tokenOptions.alternativeImages)) {
             clearedOptions.alternativeImages = [...this.tokenOptions.alternativeImages];
@@ -765,7 +765,6 @@ function rebuild_ddb_npcs(redrawList = false) {
         portraitIds.forEach(pId => {
             altImages = altImages.concat(window.ddbPortraits.filter(p => p.raceId === pId).map(p => p.avatarUrl))
         });
-        console.log("hey", altImages);
         if (altImages.length > 0) { // no need to add it if DDB doesn't have any images for it
             window.tokenListItems.push(SidebarListItem.DDBToken({
                 folderPath: "/",

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -398,10 +398,7 @@ function migrate_token_customizations() {
             if (typeof parentId !== "string" || parentId.length === 0) {
                 parentId = RootFolder.MyTokens.id;
             }
-            let newCustomization = TokenCustomization.Folder(folder.id, parentId, {
-                name: folder.name,
-                collapsed: folder.collapsed
-            });
+            let newCustomization = TokenCustomization.Folder(folder.id, parentId, { name: folder.name });
             newCustomizations.push(newCustomization);
             console.debug("migrate_token_customizations migrated", sanitize_folder_path(`${folder.folderPath}/${folder.name}`), "to", newCustomization);
         });

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -535,13 +535,14 @@ function persist_token_customization(customization, callback) {
         }
 
         let existingIndex = window.TOKEN_CUSTOMIZATIONS.findIndex(c => c.tokenType === customization.tokenType && c.id === customization.id);
-        if (existingIndex) {
+        if (existingIndex >= 0) {
             window.TOKEN_CUSTOMIZATIONS[existingIndex] = customization;
         } else {
             window.TOKEN_CUSTOMIZATIONS.push(customization);
         }
 
-        window.persist_all_token_customizations(window.TOKEN_CUSTOMIZATIONS);
+        // TODO: call the API with a single object instead of persisting everything
+        persist_all_token_customizations(window.TOKEN_CUSTOMIZATIONS, callback);
 
     } catch (error) {
         console.error("failed to persist customization", customization, error);

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -289,8 +289,10 @@ class TokenCustomization {
 
     allCombinedOptions() {
         let combinedOptions = {};
-        this.findAncestors().reverse().forEach(option => {
-            combinedOptions = {...combinedOptions, ...option};
+        this.findAncestors().reverse().forEach(tc => {
+            if (typeof tc.tokenOptions === "object") {
+                combinedOptions = {...combinedOptions, ...tc.tokenOptions};
+            }
         });
         return combinedOptions;
     }

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -563,6 +563,7 @@ function persist_token_customization(customization, callback) {
 }
 
 function fetch_token_customizations(callback) {
+    if (!window.DM) return;
     if (typeof callback !== 'function') {
         callback = function(){};
     }

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -1,0 +1,544 @@
+
+class ItemType {
+    static Folder = "folder";
+    static MyToken = "myToken";
+    static PC = "pc";
+    static Monster = "monster";
+    static BuiltinToken = "builtinToken";
+    static Encounter = "encounter";
+    static Scene = "scene";
+}
+
+class RootFolderPath {
+    static Root = "/";
+    static Players = "/Players";
+    static Monsters = "/Monsters";
+    static MyTokens = "/My Tokens";
+    static AboveVTT = "/AboveVTT Tokens";
+    static Encounters = "/Encounters";
+    static Scenes = "/Scenes";
+    static allValues() {
+        return [
+            RootFolderPath.Root,
+            RootFolderPath.Players,
+            RootFolderPath.Monsters,
+            RootFolderPath.MyTokens,
+            RootFolderPath.AboveVTT,
+            RootFolderPath.Encounters,
+            RootFolderPath.Scenes
+        ]
+    }
+    static matchingId(rootFolderId) {
+        switch (rootFolderId) {
+            case RootFolderId.Players: return RootFolderPath.Players;
+            case RootFolderId.Monsters: return RootFolderPath.Monsters;
+            case RootFolderId.MyTokens: return RootFolderPath.MyTokens;
+            case RootFolderId.BuiltinTokens: return RootFolderPath.AboveVTT;
+            case RootFolderId.Encounter: return RootFolderPath.Encounters;
+            default: return undefined;
+        }
+    }
+}
+
+class RootFolderId {
+    static Players = "playersFolder";
+    static Monsters = "monstersFolder";
+    static MyTokens = "myTokensFolder";
+    static BuiltinTokens = "builtinTokensFolder";
+    static Encounter = "encountersFolder";
+    static allValues() {
+        return [
+            RootFolderId.Players,
+            RootFolderId.Monsters,
+            RootFolderId.MyTokens,
+            RootFolderId.BuiltinTokens,
+            RootFolderId.Encounter
+        ]
+    }
+}
+
+/**
+ * @param name {string} the name displayed to the user
+ * @param image {string} the src of the img tag
+ * @param type {string} the type of item this represents. One of [folder, myToken, monster, pc]
+ * @param folderPath {string} the folder this item is in */
+class TokenCustomization {
+
+    /** {string} The id of the TokenCustomization object. Typically, an uuid */
+    id;
+
+    /** {string} The type of item this TokenCustomization represents. See `validTypes` for possible options */
+    type;
+
+    /** {string} The id of the folder this object is in. Typically, an uuid or one of the options in RootFolderId */
+    parentId;
+
+    /** {object} The same object structure as Token.options. This gets set on token.options during token creation */
+    tokenOptions;
+
+    /** Used internally during TokenCustomization construction to ensure data integrety */
+    static validTypes = [ItemType.PC, ItemType.Monster, ItemType.MyToken, ItemType.Folder];
+
+    /**
+     * @param playerSheet {string} the id of the DDB character
+     * @param tokenOptions {object} the overrides for token.options
+     * @returns {TokenCustomization} the token customization for the player
+     * @constructor
+     */
+    static PC(playerSheet, tokenOptions) {
+        return new TokenCustomization(playerSheet, ItemType.PC, RootFolderId.Players, tokenOptions);
+    }
+
+    /**
+     * @param monsterId {number|string} the id of the DDB monster
+     * @param tokenOptions {object} the overrides for token.options
+     * @returns {TokenCustomization} the token customization for the monster
+     * @constructor
+     */
+    static Monster(monsterId, tokenOptions) {
+        return new TokenCustomization(`${monsterId}`, ItemType.Monster, RootFolderId.Monsters, tokenOptions);
+    }
+
+    /**
+     * @param id {string} the id of the MyToken object. eg: uuid()
+     * @param parentId {string} the id of the Folder this belongs to. eg: uuid() or one of the options in RootFolderId
+     * @param tokenOptions {object} the overrides for token.options
+     * @returns {TokenCustomization} the token customization for the MyToken
+     * @constructor
+     */
+    static MyToken(id, parentId, tokenOptions) {
+        return new TokenCustomization(id, ItemType.MyToken, parentId, tokenOptions);
+    }
+
+    /**
+     * @param id {string} the id of the Folder object. eg: uuid()
+     * @param parentId {string} the id of the Folder this belongs to. eg: uuid() or one of the options in RootFolderId
+     * @param tokenOptions {object} the overrides for token.options
+     * @returns {TokenCustomization} the token customization for the Folder
+     * @constructor
+     */
+    static Folder(id, parentId, tokenOptions) {
+        return new TokenCustomization(id, ItemType.Folder, parentId, tokenOptions);
+    }
+
+    /**
+     * @param obj {object} the raw JSON object with the same structure as a TokenCustomization object
+     * @returns {TokenCustomization} a typed object instead of the raw JSON object that was given
+     */
+    static fromJson(obj) {
+        return new TokenCustomization(obj.id, obj.tokenType, obj.parentId, obj.tokenOptions);
+    }
+
+    // never call this directly! use the static functions above
+    constructor(id, tokenType, parentId, tokenOptions) {
+        if (typeof id !== "string" || id.length === 0) {
+            throw `Invalid id ${id}`;
+        }
+        if (!TokenCustomization.validTypes.includes(tokenType)) {
+            throw `Invalid Type ${tokenType}`;
+        }
+        if (typeof parentId !== "string" || parentId.length === 0) {
+            throw `Invalid parentId ${parentId}`;
+        }
+        this.id = id;
+        this.tokenType = tokenType;
+        this.parentId = parentId;
+        if (typeof tokenOptions === "object") {
+            this.tokenOptions = {...tokenOptions}; // copy it
+        } else {
+            this.tokenOptions = {};
+        }
+    }
+
+    setTokenOption(key, value) {
+        console.debug("setTokenOption", key, value);
+        if (value === undefined) {
+            delete this.tokenOptions[key];
+        } else if (value === true || value === "true") {
+            this.tokenOptions[key] = true;
+        } else if (value === false || value === "false") {
+            this.tokenOptions[key] = false;
+        } else if (!isNaN(value) && typeof value === "string") {
+            if (value.includes(".")) {
+                this.tokenOptions[key] = parseFloat(value);
+            } else {
+                this.tokenOptions[key] = parseInt(value);
+            }
+        } else {
+            this.tokenOptions[key] = value;
+        }
+    }
+
+    addAlternativeImage(imageUrl) {
+        if (imageUrl.startsWith("data:")) {
+            return;
+        }
+        if (this.tokenOptions.alternativeImages === undefined) {
+            this.tokenOptions.alternativeImages = [];
+        }
+        const parsed = parse_img(imageUrl);
+        if (!this.tokenOptions.alternativeImages.includes(parsed)) {
+            this.tokenOptions.alternativeImages.push(parsed);
+        }
+    }
+    removeAlternativeImage(imageUrl) {
+        if (this.tokenOptions.alternativeImages === undefined) {
+            return;
+        }
+        let index = this.tokenOptions.alternativeImages.findIndex(i => i === imageUrl);
+        if (typeof index === "number" && index >= 0) {
+            this.tokenOptions.alternativeImages.splice(index, 1);
+        }
+        const parsed = parse_img(imageUrl);
+        let parsedIndex = this.tokenOptions.alternativeImages.findIndex(i => i === parsed);
+        if (typeof parsedIndex === "number" && parsedIndex >= 0) {
+            this.tokenOptions.alternativeImages.splice(parsedIndex, 1);
+        }
+    }
+    removeAllAlternativeImages() {
+        this.tokenOptions.alternativeImages = [];
+    }
+    randomImage() {
+        if (this.tokenOptions.alternativeImages && this.tokenOptions.alternativeImages.length > 0) {
+            let randomIndex = getRandomInt(0, this.tokenOptions.alternativeImages.length);
+            return this.tokenOptions.alternativeImages[randomIndex];
+        }
+        return undefined;
+    }
+
+    findParent() {
+        return window.TOKEN_CUSTOMIZATIONS.find(tc => tc.id === this.parentId);
+    }
+    folderPath() {
+        if (RootFolderId.allValues().includes(this.id)) {
+            return RootFolderPath.Root;
+        }
+        if (RootFolderId.allValues().includes(this.parentId)) {
+            return RootFolderPath.matchingId(this.parentId);
+        }
+        const parent = this.findParent();
+        if (parent) {
+            return parent.fullPath();
+        } else {
+            return undefined; // idk what do here yet... I wouldn't expect this to ever happen
+        }
+    }
+    fullPath() {
+        return sanitize_folder_path(`${this.folderPath()}/${this.name()}`);
+    }
+    name() {
+        let n;
+        if (this.tokenType === ItemType.PC) {
+            let pc = window.pcs.find(pc => pc.sheet === this.id);
+            n = pc?.name;
+            if (!n) {
+                console.warn("Failed to find pc name for token customization. This might happen if this pc is not part of this campaign", pc, this);
+            }
+        } else {
+            n = this.tokenOptions?.name;
+            if (!n) {
+                console.warn("Failed to find the name of a token customization", this);
+            }
+        }
+        return n;
+    }
+}
+
+/**
+ * @param type {string} the type of customization you're looking for. EX: ItemType.Monster
+ * @param id {string|number} the id of the customization you're looking for. EX: pc.sheet, monsterData.id, etc
+ * @returns {TokenCustomization|undefined} a token customization for the item if found, else undefined
+ */
+function find_token_customization(type, id) {
+    return window.TOKEN_CUSTOMIZATIONS.find(c => c.tokenType === type && c.id === `${id}`); // convert it to a string just to be safe. DDB monsters use numbers for ids, but we use strings for everything
+}
+
+/**
+ * @param type {string} the type of customization you're looking for. EX: ItemType.Monster
+ * @param id {string|number} the id of the customization you're looking for. EX: pc.sheet, monsterData.id, etc
+ * @returns {TokenCustomization|undefined} a token customization for the item if found. If not found, a new TokenCustomization object will be created and returned.
+ * @throws an error if a customization object cannot be created
+ */
+function find_or_create_token_customization(type, id) {
+    return find_token_customization(type, id) || new TokenCustomization(id, type, {});
+}
+
+/**
+ * @param playerSheet {string} the id of the DDB character
+ * @returns {TokenCustomization|undefined} a token customization for the monster or undefined if not found
+ */
+function find_player_token_customization(playerSheet) {
+    return window.TOKEN_CUSTOMIZATIONS.find(c => c.tokenType === ItemType.PC && c.id === playerSheet);
+}
+
+/**
+ * @param playerSheet {string} the id of the DDB character
+ * @returns {TokenCustomization} a token customization for the player. If it doesn't already exist, a new one will be created and returned
+ */
+function get_player_token_customization(playerSheet) {
+    return find_player_token_customization(playerSheet) || TokenCustomization.PC(playerSheet, {});
+}
+
+function migrate_token_customizations() {
+    load_custom_monster_image_mapping();
+    if (window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate === true) {
+        console.log("migrate_token_customizations has already completed");
+        return;
+    }
+    try {
+        let newCustomizations = [];
+
+        // PC customizations migration
+        console.log("migrate_token_customizations starting to migrate player customizations");
+        // converting from a map with the id as the key to a list of objects with the id inside the object
+        let oldCustomizations = read_player_token_customizations();
+        for (let playerId in oldCustomizations) {
+            if (typeof playerId === "string" && playerId.length > 0) {
+                let tokenOptions = {...oldCustomizations[playerId]};
+                if (tokenOptions.images) {
+                    // Note: Spread syntax effectively goes one level deep while copying an array/object. Therefore, it may be unsuitable for copying multidimensional arrays/objects
+                    // images should be the only non-primitive. We need to make sure it's properly copied and not referencing the old objet in any way
+                    tokenOptions.alternativeImages = [...tokenOptions.images];
+                    delete tokenOptions.images;
+                }
+                delete tokenOptions.didMigrate;
+                const newCustomization = TokenCustomization.PC(playerId, tokenOptions);
+                newCustomizations.push(newCustomization);
+                oldCustomizations[playerId].didMigrate = true;
+                console.debug("migrate_token_customizations migrated", oldCustomizations[playerId], "to", newCustomization);
+            } else {
+                console.debug("migrate_token_customizations did not migrate", oldCustomizations[playerId]);
+            }
+        }
+        console.log("migrate_token_customizations finished migrating player customizations");
+
+        // Monster customizations migration
+        let monsterIdsToFetch = new Set();
+        console.log("migrate_token_customizations starting to migrate monster customizations");
+        for(let monsterIdNumber in window.CUSTOM_TOKEN_IMAGE_MAP) {
+            const images = window.CUSTOM_TOKEN_IMAGE_MAP[monsterIdNumber];
+            if (Array.isArray(images)) {
+                const monsterId = `${monsterIdNumber}`; // monster ids are numbers, but we want it to be a string to be consistent with other ids
+                const newCustomization = TokenCustomization.Monster(monsterId, { alternativeImages: [...images] });
+                newCustomizations.push(newCustomization);
+                console.debug("migrate_token_customizations migrated", monsterIdNumber, images, "to", newCustomization);
+                monsterIdsToFetch.add(monsterIdNumber);
+            }
+        }
+        console.log("migrate_token_customizations finished migrating monster customizations");
+
+        // MyToken and MyToken folders migration
+        backfill_mytoken_folders(); // just in case
+        let easyFolderReference = {};
+        mytokensfolders.forEach(folder => {
+            // old structure: { name: folderKey, folderPath: currentFolderPath, collapsed: true }
+            folder.id = uuid();
+            let fullPath = sanitize_folder_path(`${folder.folderPath}/${folder.name}`);
+            easyFolderReference[fullPath] = folder;
+        });
+
+        console.log("migrate_token_customizations starting to migrate mytokenfolders customizations");
+        mytokensfolders.forEach(folder => {
+            // old structure: { name: folderKey, folderPath: currentFolderPath, collapsed: true }
+            let parentPath = sanitize_folder_path(folder.folderPath);
+            let parentId = easyFolderReference[parentPath]?.id;
+            if (typeof parentId !== "string" || parentId.length === 0) {
+                parentId = RootFolderId.MyTokens;
+            }
+            let newCustomization = TokenCustomization.Folder(folder.id, parentId, {
+                name: folder.name,
+                collapsed: folder.collapsed
+            });
+            newCustomizations.push(newCustomization);
+            console.debug("migrate_token_customizations migrated", sanitize_folder_path(`${folder.folderPath}/${folder.name}`), "to", newCustomization);
+        });
+        console.log("migrate_token_customizations finished migrating mytokenfolders customizations");
+
+        // MyToken migration
+        console.log("migrate_token_customizations starting to migrate mytokens customizations");
+        mytokens.forEach(myToken => {
+            let parentPath = sanitize_folder_path(myToken.folderPath);
+            let parentId = easyFolderReference[parentPath]?.id;
+            if (typeof parentId !== "string" || parentId.length === 0) {
+                parentId = RootFolderId.MyTokens;
+            }
+            let tokenOptions = {...myToken};
+            if (myToken.alternativeImages) {
+                // Note: Spread syntax effectively goes one level deep while copying an array/object. Therefore, it may be unsuitable for copying multidimensional arrays/objects
+                // alternativeImages should be the only non-primitive. We need to make sure it's properly copied and not referencing the old objet in any way
+                tokenOptions.alternativeImages = [...myToken.alternativeImages]; //
+            }
+            delete tokenOptions.image;
+            delete tokenOptions.folderpath;
+            delete tokenOptions.folderPath;
+            delete tokenOptions.didMigrateToMyToken;
+            delete tokenOptions.oldFolderKey;
+            let newCustomization = TokenCustomization.MyToken(uuid(), parentId, tokenOptions);
+            newCustomizations.push(newCustomization);
+            console.debug("migrate_token_customizations migrated", sanitize_folder_path(`${myToken.folderPath}/${myToken.name}`), "to", newCustomization);
+        });
+        console.log("migrate_token_customizations finished migrating mytokens customizations");
+
+
+        // fetch monsters so we can get the monster names
+        console.log("migrate_token_customizations starting to fetch monsters to fill names");
+        window.EncounterHandler.fetch_monsters([...monsterIdsToFetch], function (response) {
+            if (typeof response === "object") {
+                response.forEach(m => {
+                    let found = newCustomizations.find(c => c.tokenType === ItemType.Monster && c.id === `${m.id}`);
+                    console.debug("migrate_token_customizations", found, m);
+                    if (found && found.tokenOptions) {
+                        found.tokenOptions.name = m.name;
+                    }
+                });
+                console.log("migrate_token_customizations updated monsters with names");
+                console.log("migrate_token_customizations attempting to persist all customizations");
+                // Persist everything
+                persist_all_token_customizations(newCustomizations, function (success, errorType) {
+                    if (success === true) {
+                        // TODO: remove them entirely at some point
+                        write_player_token_customizations(oldCustomizations);
+                        window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate = true;
+                        save_custom_monster_image_mapping();
+                        console.log("migrate_token_customizations successfully persisted migrated customizations", newCustomizations);
+                    } else {
+                        console.error("migrate_token_customizations failed to persist new customizations", newCustomizations, errorType);
+                    }
+                });
+            } else {
+                console.error("migrate_token_customizations failed", error);
+                console.log("migrate_token_customizations attempting to rollback the migration");
+                rollback_token_customizations_migration();
+            }
+        });
+    } catch (error) {
+        console.error("migrate_token_customizations failed", error);
+        console.log("migrate_token_customizations attempting to rollback the migration");
+        rollback_token_customizations_migration();
+    }
+}
+
+function rollback_token_customizations_migration() {
+    try {
+        localStorage.setItem("TokenCustomizations", JSON.stringify([]));
+        let playerCustomizations = read_player_token_customizations();
+        for (let playerId in playerCustomizations) {
+            playerCustomizations[playerId].didMigrate = false;
+        }
+        write_player_token_customizations(playerCustomizations);
+        window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate = false;
+        save_custom_monster_image_mapping();
+    } catch (error) {
+        console.error("Failed to rollback token customization", error);
+    }
+}
+
+function persist_all_token_customizations(customizations, callback) {
+    if (typeof callback !== 'function') {
+        callback = function(){};
+    }
+    console.log("persist_all_token_customizations starting");
+    // TODO: send to cloud instead of storing locally
+    localStorage.setItem("TokenCustomizations", JSON.stringify(customizations));
+    window.TOKEN_CUSTOMIZATIONS = customizations;
+    callback(true);
+
+    return; // TODO: remove everything above, and just do this instead
+
+    let http_api_gw="https://services.abovevtt.net";
+    let searchParams = new URLSearchParams(window.location.search);
+    if(searchParams.has("dev")){
+        http_api_gw="https://jiv5p31gj3.execute-api.eu-west-1.amazonaws.com";
+    }
+
+    window.ajaxQueue.addRequest({
+        url: `${http_api_gw}/services?action=setTokenCustomizations&userId=todo`, // TODO: figure this out
+        success: function (response) {
+            console.log(`persist_all_token_customizations succeeded`, response);
+            window.TOKEN_CUSTOMIZATIONS = customizations;
+            callback(true);
+        },
+        error: function (errorMessage) {
+            console.warn(`persist_all_token_customizations failed`, errorMessage);
+            callback(false, errorMessage?.responseJSON?.type);
+        }
+    })
+}
+
+function persist_token_customization(customization, callback) {
+    if (typeof callback !== 'function') {
+        callback = function(){};
+    }
+    try {
+        if (
+            customization === undefined
+            || typeof customization.id !== "string" || customization.id.length === 0
+            || !TokenCustomization.validTypes.includes(customization.tokenType)
+            || !customization.tokenOptions
+        ) {
+            console.warn("Not persisting invalid customization", customization);
+            callback(false, "Invalid Customization");
+            return;
+        }
+
+        let existingIndex = window.TOKEN_CUSTOMIZATIONS.findIndex(c => c.tokenType === customization.tokenType && c.id === customization.id);
+        if (existingIndex) {
+            window.TOKEN_CUSTOMIZATIONS[existingIndex] = customization;
+        } else {
+            window.TOKEN_CUSTOMIZATIONS.push(customization);
+        }
+
+        window.persist_all_token_customizations(window.TOKEN_CUSTOMIZATIONS);
+
+    } catch (error) {
+        console.error("failed to persist customization", customization, error);
+        callback(false);
+    }
+}
+
+function fetch_token_customizations(callback) {
+    if (typeof callback !== 'function') {
+        callback = function(){};
+    }
+    try {
+        console.log("persist_token_customizations starting");
+        // TODO: fetch from the cloud instead of storing locally
+        let customMappingData = localStorage.getItem('TokenCustomizations');
+        let parsedCustomizations = [];
+        if (customMappingData !== undefined && customMappingData != null) {
+            $.parseJSON(customMappingData).forEach(obj => {
+                try {
+                    parsedCustomizations.push(TokenCustomization.fromJson(obj));
+                } catch (error) {
+                    // this one failed, but keep trying to parse the others
+                    console.error("persist_token_customizations failed to parse customization object", obj);
+                }
+            });
+        }
+        window.TOKEN_CUSTOMIZATIONS = parsedCustomizations;
+        callback(window.TOKEN_CUSTOMIZATIONS);
+    } catch (error) {
+        console.error("persist_token_customizations failed");
+        callback(false);
+    }
+
+    return; // TODO: remove everything above, and just do this instead
+
+    let http_api_gw="https://services.abovevtt.net";
+    let searchParams = new URLSearchParams(window.location.search);
+    if(searchParams.has("dev")){
+        http_api_gw="https://jiv5p31gj3.execute-api.eu-west-1.amazonaws.com";
+    }
+
+    window.ajaxQueue.addRequest({
+        url: `${http_api_gw}/services?action=getTokenCustomizations&userId=todo`, // TODO: figure this out
+        success: function (response) {
+            console.warn(`persist_token_customizations succeeded`, response);
+            callback(response); // TODO: grabe the actual list of objects from the response
+        },
+        error: function (errorMessage) {
+            console.warn(`persist_token_customizations failed`, errorMessage);
+            callback(false, errorMessage?.responseJSON?.type);
+        }
+    });
+}

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -90,7 +90,7 @@ class TokenCustomization {
      * @constructor
      */
     static Monster(monsterId, tokenOptions) {
-        return new TokenCustomization(`${monsterId}`, ItemType.Monster, RootFolder.Monsters.id, tokenOptions);
+        return new TokenCustomization(monsterId, ItemType.Monster, RootFolder.Monsters.id, tokenOptions);
     }
 
     /**
@@ -125,6 +125,9 @@ class TokenCustomization {
 
     // never call this directly! use the static functions above
     constructor(id, tokenType, parentId, tokenOptions) {
+        if (tokenType === ItemType.Monster) {
+            id = `${id}`; // DDB uses numbers for monster ids, but we want to use strings to keep everything consistent
+        }
         if (typeof id !== "string" || id.length === 0) {
             throw `Invalid id ${id}`;
         }

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -168,7 +168,7 @@ class TokenCustomization {
 
     addAlternativeImage(imageUrl) {
         if (imageUrl.startsWith("data:")) {
-            return;
+            return false;
         }
         if (this.tokenOptions.alternativeImages === undefined) {
             this.tokenOptions.alternativeImages = [];
@@ -177,6 +177,7 @@ class TokenCustomization {
         if (!this.tokenOptions.alternativeImages.includes(parsed)) {
             this.tokenOptions.alternativeImages.push(parsed);
         }
+        return true;
     }
     removeAlternativeImage(imageUrl) {
         if (this.tokenOptions.alternativeImages === undefined) {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1024,10 +1024,12 @@ function build_token_image_scale_input(startingScale, didUpdate) {
 		else if(event.target.value < 0.2){
 			imageSize = 0.2;
 		}
-		if (event.key == "Enter") {
+		if (event.key === "Enter") {
 			imageSizeInput.val(imageSize);
 			imageSizeInputRange.val(imageSize);
 			didUpdate(imageSize);
+		} else if (event.key === "Escape") {
+			$(event.target).blur();
 		}
 		imageSizeInputRange.val(imageSizeInput.val());
 	});

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -297,13 +297,8 @@ function token_context_menu_expanded(tokenIds, e) {
 		optionsRow.hover(function (hoverEvent) {
 			context_menu_flyout("options-flyout", hoverEvent, function(flyout) {
 				flyout.append(build_options_flyout_menu(tokenIds));
-			})		
-			if($(`#tokenSelect__tokenStyleSelect option:selected`).val() == 4 || $(`#tokenSelect__tokenStyleSelect option:selected`).val() == 5){
-				$(`#tokenWrapper__tokenBaseStyleSelect`).show();
-			}
-			else{
-			 	$(`#tokenWrapper__tokenBaseStyleSelect`).hide();
-			}	
+				update_token_base_visibility(flyout);
+			});
 		});
 		body.append(optionsRow);
 	}
@@ -1119,7 +1114,7 @@ function build_options_flyout_menu(tokenIds) {
 	})
 
 	let token_settings = token_setting_options();
-	if (tokens.length == 1 && !tokens[0].isPlayer()){		
+	if (tokens.length === 1 && !tokens[0].isPlayer()){
 		let removename = "hidestat";
 		token_settings = $.grep(token_settings, function(e){
 		     return e.name != removename;

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -441,7 +441,17 @@ function build_token_auras_inputs(tokenIds) {
 		</div>
 	`);
 
-	let enabledAurasInput = build_toggle_input("auraVisible", "Enable Token Auras", auraIsEnabled, undefined, undefined, function(name, newValue) {
+	const auraOption = {
+		name: "auraVisible",
+		label: "Enable Token Auras",
+		type: "toggle",
+		options: [
+			{ value: true, label: "Visible", description: "Token Auras are visible." },
+			{ value: false, label: "Hidden", description: "Token Auras are hidden." }
+		],
+		defaultValue: false
+	};
+	let enabledAurasInput = build_toggle_input( auraOption, auraIsEnabled, function(name, newValue) {
 		console.log(`${name} setting is now ${newValue}`);
 		tokens.forEach(token => {
 			token.options[name] = newValue;
@@ -454,7 +464,18 @@ function build_token_auras_inputs(tokenIds) {
 		}
 	});
 	wrapper.prepend(enabledAurasInput);
-	let auraIsLightInput = build_toggle_input("auraislight", "Change aura appearance to light", auraIsLightEnabled, "Token's aura is visually changed to look like light", "Default aura visual", function(name, newValue) {
+
+	const auraIsLightOption = {
+		name: "auraislight",
+		label: "Change aura appearance to light",
+		type: "toggle",
+		options: [
+			{ value: true, label: "Light", description: "The token's aura is visually changed to look like light." },
+			{ value: false, label: "Default", description: "Enable this to make the token's aura look like light." }
+		],
+		defaultValue: false
+	};
+	let auraIsLightInput = build_toggle_input(auraIsLightOption, auraIsLightEnabled, function(name, newValue) {
 		console.log(`${name} setting is now ${newValue}`);
 		tokens.forEach(token => {
 			token.options[name] = newValue;
@@ -462,7 +483,18 @@ function build_token_auras_inputs(tokenIds) {
 		});
 	});	
 	wrapper.find(".token-config-aura-wrapper").prepend(auraIsLightInput);
-	let hideAuraInFog = build_toggle_input("hideaurafog", "Hide aura when hidden in fog", hideAuraIsEnabled, "Token's aura is hidden from players when in fog", "Token's aura is visible to players when token is in fog", function(name, newValue) {
+
+	const hideAuraInFogOption = {
+		name: "hideaurafog",
+		label: "Hide aura when hidden in fog",
+		type: "toggle",
+		options: [
+			{ value: true, label: "Hidden", description: "The token's aura is hidden from players when the token is in fog." },
+			{ value: false, label: "Visible", description: "The token's aura is visible to players when the token is in fog." }
+		],
+		defaultValue: false
+	};
+	let hideAuraInFog = build_toggle_input(hideAuraInFogOption, hideAuraIsEnabled, function(name, newValue) {
 		console.log(`${name} setting is now ${newValue}`);
 		tokens.forEach(token => {
 			token.options[name] = newValue;
@@ -1086,7 +1118,7 @@ function build_options_flyout_menu(tokenIds) {
 		padding: "5px"
 	})
 
-	let token_settings = [...token_setting_options];
+	let token_settings = token_setting_options();
 	if (tokens.length == 1 && !tokens[0].isPlayer()){		
 		let removename = "hidestat";
 		token_settings = $.grep(token_settings, function(e){
@@ -1101,33 +1133,27 @@ function build_options_flyout_menu(tokenIds) {
 		if (uniqueSettings.length === 1) {
 			currentValue = uniqueSettings[0];
 		}
-		if(setting.name == 'square' || setting.name == 'legacyaspectratio')
+		if(setting.name === 'square' || setting.name === 'legacyaspectratio')
 			continue;
-		if(setting.name =='tokenBaseStyleSelect'){
-			
-		}
-		if(setting.type == "dropdown"){
-			let inputWrapper = build_dropdown_input(setting.name, setting.label, currentValue, setting.options, function(name, newValue) {
-				console.log(`${name} setting is now ${newValue}`);
 
-				tokens.forEach(token => {
-					token.options[name] = newValue;
-					token.place_sync_persist();
-				});
-			});
-			
-			body.append(inputWrapper);
-		
-		}
-		else{
-			let inputWrapper = build_toggle_input(setting.name, setting.label, currentValue, setting.enabledDescription, setting.disabledDescription, function(name, newValue) {
-				console.log(`${name} setting is now ${newValue}`);
+		if (setting.type === "dropdown") {
+			let inputWrapper = build_dropdown_input(setting, currentValue, function(name, newValue) {
 				tokens.forEach(token => {
 					token.options[name] = newValue;
 					token.place_sync_persist();
 				});
 			});
 			body.append(inputWrapper);
+		} else if (setting.type === "toggle") {
+			let inputWrapper = build_toggle_input(setting, currentValue, function (name, newValue) {
+				tokens.forEach(token => {
+					token.options[name] = newValue;
+					token.place_sync_persist();
+				});
+			});
+			body.append(inputWrapper);
+		} else {
+			console.warn("build_options_flyout_menu failed to handle token setting option with type", setting.type);
 		}
 	}
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1074,21 +1074,7 @@ function build_options_flyout_menu(tokenIds) {
 		padding: "5px"
 	})
 
-	let token_settings = [
-		{ name: "hidden", label: "Hide", enabledDescription:"Token is hidden to players", disabledDescription: "Token is visible to players" },
-		{ name: "square", label: "Square Token", enabledDescription:"Token is square", disabledDescription: "Token is round" },
-		{ name: "locked", label: "Lock Token in Position", enabledDescription:"Token is not moveable, Players can not select this token", disabledDescription: "Token is moveable by at least the DM, players can select it however" },
-		{ name: "restrictPlayerMove", label: "Restrict Player Movement", enabledDescription:"Token is not moveable by players", disabledDescription: "Token is moveable by any player" },
-		{ name: "disablestat", label: "Disable HP/AC", enabledDescription:"Token stats are not visible", disabledDescription: "Token stats are visible to at least the DM" },
-		{ name: "hidestat", label: "Hide Player HP/AC from players", enabledDescription:"Token stats are hidden from players", disabledDescription: "Token stats are visible to players" },
-		{ name: "hidehpbar", label: "Only show HP values on hover", enabledDescription:"HP values will only be shown when you hover or select a token", disabledDescription: "Enable this to hide HP values except when you hover or select a token." },
-		{ name: "disableborder", label: "Disable Border", enabledDescription:"Token has no border", disabledDescription: "Token has a random coloured border"  },
-		{ name: "disableaura", label: "Disable Health Meter", enabledDescription:"Token has no health glow", disabledDescription: "Token has health glow corresponding with their current health" },
-		{ name: "enablepercenthpbar", label: "Enable Token HP% Bar", enabledDescription:"Token has a traditional visual hp% bar indicator", disabledDescription: "Token does not have a traditional visual hp% bar indicator" },
-		{ name: "revealname", label: "Show name to players", enabledDescription:"Token on hover name is visible to players", disabledDescription: "Token name is hidden to players" },
-		{ name: "legacyaspectratio", label: "Ignore Image Aspect Ratio", enabledDescription:"Token will stretch non-square images to fill the token space", disabledDescription: "Token will respect the aspect ratio of the image provided" },
-		{ name: "player_owned", label: "Player access to sheet/stats", enabledDescription:"Tokens' sheet is accessible to players via RMB click on token. If token stats is visible to players, players can modify the hp of the token", disabledDescription: "Tokens' sheet is not accessible to players. Players can't modify token stats"}
-	];
+	let token_settings = [...token_setting_options];
 	if (tokens.length == 1 && !tokens[0].isPlayer()){		
 		let removename = "hidestat";
 		token_settings = $.grep(token_settings, function(e){

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -932,76 +932,15 @@ function build_adjustments_flyout_menu(tokenIds) {
 	body.append(sizeInputs);
 
 	//image scaling size
-	let imageSizeInput = $(`<input class="image-scale-input-number" type="number" max="6" min="0.2" step="0.1" title="Token Image Scale" placeholder="1.0" name="Image Scale">`);
-	let imageSizeInputRange = $(`<input class="image-scale-input-range" type="range" value="1" min="0.2" max="6" step="0.1"/>`);
 	let tokenImageScales = tokens.map(t => t.options.imageSize);
-	if(tokenImageScales.length === 1) {
-		imageSizeInput.val(tokenImageScales[0] || 1);	
-		imageSizeInputRange.val(tokenImageScales[0] || 1);
-	}
-	imageSizeInput.on('keyup', function(event) {
-		var imageSize;
-		if(event.target.value <= 6 && event.target.value >= 0.2) { 
-			imageSize = event.target.value;
-		}
-		else if(event.target.value > 6){
-			imageSize = 6;
-		}
-		else if(event.target.value < 0.2){
-			imageSize = 0.2;
-		}
-		if (event.key == "Enter") {
-			imageSizeInput.val(imageSize);	
-			imageSizeInputRange.val(imageSize);
-			tokens.forEach(token => {
-				token.options.imageSize = imageSize;
-				token.place_sync_persist();
-			});
-		}
-		imageSizeInputRange.val(imageSizeInput.val());
-	});
-	imageSizeInput.on('focusout', function(event) {
-		var imageSize;
-		if(event.target.value <= 6 && event.target.value >= 0.2) { 
-			imageSize = event.target.value;
-		}
-		else if(event.target.value > 6){
-			imageSize = 6;
-			imageSizeInput.val(imageSize);	
-			imageSizeInputRange.val(imageSize);
-		}
-		else if(event.target.value < 0.2){
-			imageSize = 0.2;
-			imageSizeInput.val(imageSize);	
-			imageSizeInputRange.val(imageSize);
-		}	
-		tokens.forEach(token => {
-			token.options.imageSize = imageSize;
-			token.place_sync_persist();
-		});
-
-		imageSizeInputRange.val(imageSizeInput.val());
-	});
-	imageSizeInput.on(' input change', function(){
-   	 	imageSizeInputRange.val(imageSizeInput.val());
-	});
-	imageSizeInputRange.on(' input change', function(){
-   	 	imageSizeInput.val(imageSizeInputRange.val());
-	});
-	imageSizeInputRange.on('mouseup', function(){
-   	 	let imageSize = imageSizeInputRange.val();
+	let uniqueScales = [...new Set(tokenImageScales)];
+	let startingScale = uniqueScales.length === 1 ? uniqueScales[0] : 1;
+	let imageSizeWrapper = build_token_image_scale_input(startingScale, function (imageSize) {
 		tokens.forEach(token => {
 			token.options.imageSize = imageSize;
 			token.place_sync_persist();
 		});
 	});
-	let imageSizeWrapper = $(`
-		<div class="token-image-modal-url-label-wrapper image-size-wrapper">
-			<div class="token-image-modal-footer-title image-size-title">Token Image Scale</div>
-		</div>
-	`);
-	imageSizeWrapper.append(imageSizeInput); // Beside Label
-	imageSizeWrapper.append(imageSizeInputRange); // input below label
 	body.append(imageSizeWrapper);
 
 	//border color selections
@@ -1064,6 +1003,71 @@ function build_adjustments_flyout_menu(tokenIds) {
 	});
 
 	return body;
+}
+
+function build_token_image_scale_input(startingScale, didUpdate) {
+	if (isNaN(startingScale)) {
+		startingScale = 1;
+	}
+	let imageSizeInput = $(`<input class="image-scale-input-number" type="number" max="6" min="0.2" step="0.1" title="Token Image Scale" placeholder="1.0" name="Image Scale">`);
+	let imageSizeInputRange = $(`<input class="image-scale-input-range" type="range" value="1" min="0.2" max="6" step="0.1"/>`);
+	imageSizeInput.val(startingScale || 1);
+	imageSizeInputRange.val(startingScale || 1);
+	imageSizeInput.on('keyup', function(event) {
+		var imageSize;
+		if(event.target.value <= 6 && event.target.value >= 0.2) {
+			imageSize = event.target.value;
+		}
+		else if(event.target.value > 6){
+			imageSize = 6;
+		}
+		else if(event.target.value < 0.2){
+			imageSize = 0.2;
+		}
+		if (event.key == "Enter") {
+			imageSizeInput.val(imageSize);
+			imageSizeInputRange.val(imageSize);
+			didUpdate(imageSize);
+		}
+		imageSizeInputRange.val(imageSizeInput.val());
+	});
+	imageSizeInput.on('focusout', function(event) {
+		var imageSize;
+		if(event.target.value <= 6 && event.target.value >= 0.2) {
+			imageSize = event.target.value;
+		}
+		else if(event.target.value > 6){
+			imageSize = 6;
+			imageSizeInput.val(imageSize);
+			imageSizeInputRange.val(imageSize);
+		}
+		else if(event.target.value < 0.2){
+			imageSize = 0.2;
+			imageSizeInput.val(imageSize);
+			imageSizeInputRange.val(imageSize);
+		}
+		didUpdate(imageSize);
+
+		imageSizeInputRange.val(imageSizeInput.val());
+	});
+	imageSizeInput.on(' input change', function(){
+		imageSizeInputRange.val(imageSizeInput.val());
+	});
+	imageSizeInputRange.on(' input change', function(){
+		imageSizeInput.val(imageSizeInputRange.val());
+	});
+	imageSizeInputRange.on('mouseup', function(){
+		let imageSize = imageSizeInputRange.val();
+		didUpdate(imageSize);
+	});
+	let imageSizeWrapper = $(`
+		<div class="token-image-modal-url-label-wrapper image-size-wrapper">
+			<div class="token-image-modal-footer-title image-size-title">Token Image Scale</div>
+		</div>
+	`);
+	imageSizeWrapper.append(imageSizeInput); // Beside Label
+	imageSizeWrapper.append(imageSizeInputRange); // input below label
+	return imageSizeWrapper;
 }
 
 function build_options_flyout_menu(tokenIds) {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -37,6 +37,7 @@ function context_menu_flyout(id, hoverEvent, buildFunction) {
 
 		buildFunction(flyout);
 		$("#tokenOptionsContainer").append(flyout);
+		observe_hover_text(flyout);
 
 		let contextMenuCenter = (contextMenu.height() / 2);
 		let flyoutHeight = flyout.height();

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1159,14 +1159,31 @@ function build_options_flyout_menu(tokenIds) {
 
 	let resetToDefaults = $(`<button class='token-image-modal-remove-all-button' title="Reset all token settings back to their default values." style="width:100%;padding:8px;margin:10px 0px;">Reset Token Settings to Defaults</button>`);
 	resetToDefaults.on("click", function (clickEvent) {
-		for (let i = 0; i < token_settings.length; i++) {
-			let setting = token_settings[i];
-			let toggle = $(clickEvent.target).parent().find(`button[name=${setting.name}]`);
-			toggle.removeClass("rc-switch-checked");
-			toggle.removeClass("rc-switch-unknown");
-			tokens.forEach(token => token.options[setting.name] = false);
-		}
+		let formContainer = $(clickEvent.currentTarget).parent();
+
+		// disable all toggle switches
+		formContainer
+			.find(".rc-switch")
+			.removeClass("rc-switch-checked")
+			.removeClass("rc-switch-unknown");
+
+		// set all dropdowns to their default values
+		formContainer
+			.find("select")
+			.each(function () {
+				let el = $(this);
+				let matchingOption = token_settings.find(o => o.name === el.attr("name"));
+				el.find(`option[value=${matchingOption.defaultValue}]`).attr('selected','selected');
+			});
+
+		// This is why we want multiple callback functions.
+		// We're about to call updateValue a bunch of times and only need to update the UI (or do anything else really) one time
+		token_settings.forEach(option => {
+			tokens.forEach(token => token.options[option.name] = option.defaultValue);
+		});
 		tokens.forEach(token => token.place_sync_persist());
+
+
 	});
 	body.append(resetToDefaults);
 	return body;

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1234,8 +1234,9 @@ function display_builtin_token_details_modal(listItem, placedToken) {
  * @param sidebarPanel {SidebarPanel} the modal to display objects in
  * @param listItem {SidebarListItem} the list item the modal represents
  * @param placedToken {Token|undefined} undefined if this modal does not represnet a token that is placed on the scene; else the Token object that corresponds to a token that is placed on the scene
+ * @param drawInline {boolean} If you need to add elements to the body AFTER all the images have been drawn, then pass true. Otherwise, images will be drawn in their own setTimeout to avoid blocking the UI. If you're adding things to the sidebarPanle.body, you might consider adding them to the footer or between the body and the footer instead.
  */
-function redraw_token_images_in_modal(sidebarPanel, listItem, placedToken) {
+function redraw_token_images_in_modal(sidebarPanel, listItem, placedToken, drawInline = false) {
     if (sidebarPanel === undefined) {
         console.warn("redraw_token_images_in_modal was called without a sidebarPanel");
         return;
@@ -1277,16 +1278,28 @@ function redraw_token_images_in_modal(sidebarPanel, listItem, placedToken) {
         modalBody.append(tokenDiv);
     }
 
+
     for (let i = 0; i < alternativeImages.length; i++) {
-        let tokenDiv = buildTokenDiv(alternativeImages[i]);
-        modalBody.append(tokenDiv);
+        if (drawInline) {
+            let tokenDiv = buildTokenDiv(alternativeImages[i]);
+            modalBody.append(tokenDiv);
+        } else {
+            setTimeout(function () {
+                // JS doesn't have threads, but setTimeout allows us to execute this inefficient block of code after the rest of the modal has finished drawing.
+                // This gives the appearance of a faster UI because the modal will display and then these images will pop in.
+                // most of the time, this isn't needed, but if there are a lot of images (like /DDBTokens/Human), this make a pretty decent impact.
+                let tokenDiv = buildTokenDiv(alternativeImages[i]);
+                modalBody.append(tokenDiv);
+            });
+        }
     }
 
-    if (alternative_images_for_item(listItem).length === 0) {
+    if (alternativeImages.length === 0) {
         sidebarPanel.footer.find(".token-image-modal-url-label-add-wrapper > .token-image-modal-url-label-wrapper > .token-image-modal-footer-title").text("Replace The Default Image");
     } else {
         sidebarPanel.footer.find(".token-image-modal-url-label-add-wrapper > .token-image-modal-url-label-wrapper > .token-image-modal-footer-title").text("Add More Custom Images");
     }
+
 }
 
 /**

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1245,6 +1245,8 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
                 } else {
                     $(event.target).select();
                 }
+            } else if (event.key === "Escape") {
+                $(event.target).blur();
             }
         });
         inputWrapper.append(nameInput);
@@ -2265,3 +2267,58 @@ function move_mytokens_folder(listItem, folderPath) {
         console.warn("move_mytoken_to_folder was called with the wrong item type", listItem);
     }
 }
+
+// these are potentially what the cloud data will look like
+// const tokenCustomizationExamples = [
+//     {
+//         id: "/userid/characterId",
+//         type: "pc",
+//         alternativeImages: [],
+//         tokenOptions: {}
+//     },
+//     {
+//         id: "17001",
+//         type: "monster",
+//         alternativeImages: [],
+//         tokenOptions: {}
+//     },
+//     // probably don't need to do any of the below, but we could
+//     {
+//         id: "playersFolder",
+//         type: "folder",
+//         alternativeImages: [], // will always be empty because folders don't have images
+//         tokenOptions: {}
+//     },
+//     {
+//         id: "monstersFolder",
+//         type: "folder",
+//         alternativeImages: [], // will always be empty because folders don't have images
+//         tokenOptions: {}
+//     },
+//     {
+//         id: "myTokensFolder",
+//         type: "folder",
+//         alternativeImages: [], // will always be empty because folders don't have images
+//         tokenOptions: {}
+//     }
+// ];
+//
+// const myTokenExamples = [
+//     {
+//         id: uuid(),
+//         name: "Wagon",
+//         type: "myToken",
+//         folderPath: "/Vehicles",
+//         alternativeImages: [],
+//         tokenOptions: {}
+//     },
+//     {
+//         id: uuid(),
+//         name: "Vehicles",
+//         type: "Folder",
+//         folderPath: "/",
+//         alternativeImages: [],
+//         tokenOptions: {}
+//     }
+// ];
+

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -404,6 +404,7 @@ function init_tokens_panel() {
     }
 
     migrate_to_my_tokens();
+    migrate_token_customizations();
     rebuild_token_items_list();
     update_token_folders_remembered_state();
 
@@ -1312,33 +1313,34 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
         inputWrapper.append(saveButton);
     } else if (listItem.isTypePC()) {
 
-        let playerOptions = get_player_token_customizations(listItem.sheet);
+        let playerCustomization = get_player_token_customizations(listItem.sheet);
 
         // token size
         let tokenSizeInput = build_token_size_input(tokenSize, function (newSize) {
-            playerOptions.tokenSize = newSize;
-            set_player_token_customizations(listItem.sheet, playerOptions);
+            playerCustomization.setTokenOption("tokenSize", newSize);
+            persist_token_customization(playerCustomization);
             decorate_modal_images(sidebarPanel, listItem, placedToken);
         });
         inputWrapper.append(tokenSizeInput);
 
         // image scale
-        let imageScaleWrapper = build_token_image_scale_input(playerOptions.imageSize, function (imageSize) {
-            playerOptions.imageSize = imageSize;
-            set_player_token_customizations(listItem.sheet, playerOptions);
+        let startingScale = playerCustomization.tokenOptions.imageSize || 1;
+        let imageScaleWrapper = build_token_image_scale_input(startingScale, function (imageSize) {
+            playerCustomization.setTokenOption("imageSize", imageSize);
+            persist_token_customization(playerCustomization);
             decorate_modal_images(sidebarPanel, listItem, placedToken);
         });
         inputWrapper.append(imageScaleWrapper);
 
-        let tokenOptionsButton = build_override_token_options_button(sidebarPanel, listItem, placedToken, playerOptions, function(name, value) {
+        let tokenOptionsButton = build_override_token_options_button(sidebarPanel, listItem, placedToken, playerCustomization.tokenOptions, function(name, value) {
             if (value === true || value === false) {
-                playerOptions[name] = value;
+                playerCustomization.setTokenOption(name, value);
             } else {
-                delete playerOptions[name];
+                playerCustomization.removeTokenOption(name);
             }
         }, function () {
-            set_player_token_customizations(listItem.sheet, playerOptions);
-            redraw_settings_panel_token_examples(playerOptions);
+            persist_token_customization(playerCustomization);
+            redraw_settings_panel_token_examples(playerCustomization.tokenOptions);
             decorate_modal_images(sidebarPanel, listItem, placedToken);
         });
         inputWrapper.append(tokenOptionsButton);
@@ -1991,23 +1993,13 @@ function register_custom_token_image_context_menu() {
                         did_change_mytokens_items();
                     } else if (listItem?.isTypeMonster()) {
                         let monsterId = listItem.monsterData.id;
-                        let customImages = get_custom_monster_images(monsterId);
-                        let imageIndex = customImages.findIndex(image => image === imgSrc);
-                        if (imageIndex >= 0) {
-                            remove_custom_monster_image(monsterId, imageIndex);
-                            if (get_custom_monster_images(monsterId).length === 0) {
-                                redraw_token_images_in_modal(window.current_sidebar_modal, listItem, placedToken);
-                            }
-                        }
+                        remove_custom_monster_image(monsterId, imgSrc);
+                        redraw_token_images_in_modal(window.current_sidebar_modal, listItem, placedToken);
                     } else if (listItem?.isTypePC()) {
                         let playerId = listItem.sheet;
-                        let customImages = get_player_image_mappings(playerId);
-                        let imageIndex = customImages.findIndex(image => image === imgSrc);
-                        if (imageIndex >= 0) {
-                            remove_player_image_mapping(playerId, imageIndex);
-                            if (get_player_image_mappings(playerId).length === 0) {
-                                redraw_token_images_in_modal(window.current_sidebar_modal, listItem, placedToken);
-                            }
+                        remove_player_image_mapping(playerId, imgSrc);
+                        if (get_player_image_mappings(playerId).length === 0) {
+                            redraw_token_images_in_modal(window.current_sidebar_modal, listItem, placedToken);
                         }
                     } else {
                         alert("An unexpected error occurred");
@@ -2063,7 +2055,7 @@ function build_remove_all_images_button(sidebarPanel, listItem, placedToken) {
 function find_token_options_for_list_item(listItem) {
     switch (listItem.type) {
         case SidebarListItem.TypeMyToken: return find_my_token(listItem.fullPath());
-        case SidebarListItem.TypePC: return get_player_token_customizations(listItem.sheet);
+        case SidebarListItem.TypePC: return get_player_token_customizations(listItem.sheet).tokenOptions;
         case SidebarListItem.TypeMonster: return {}; // TODO: allow overriding monster token options
         default: return {};
     }
@@ -2268,19 +2260,192 @@ function move_mytokens_folder(listItem, folderPath) {
     }
 }
 
-// these are potentially what the cloud data will look like
+function migrate_token_customizations() {
+    load_custom_monster_image_mapping();
+    if (window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate === true) {
+        console.log("migrate_token_customizations has already completed");
+        return;
+    }
+    try {
+        let newCustomizations = [];
+
+        console.log("migrate_token_customizations starting to migrate player customizations");
+        // converting from a map with the id as the key to a list of objects with the id inside the object
+        let oldCustomizations = read_player_token_customizations();
+        for (let playerId in oldCustomizations) {
+            if (typeof playerId === "string" && playerId.length > 0) {
+                const newCustomization = TokenCustomization.PC(playerId, oldCustomizations[playerId]);
+                newCustomizations.push(newCustomization);
+                oldCustomizations[playerId].didMigrate = true;
+                console.debug("migrate_token_customizations migrated", oldCustomizations[playerId], "to", newCustomization);
+            } else {
+                console.debug("migrate_token_customizations did not migrate", oldCustomizations[playerId]);
+            }
+        }
+        console.log("migrate_token_customizations finished migrating player customizations");
+
+        if (window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate !== true) {
+            console.log("migrate_token_customizations starting to migrate monster customizations");
+            for(let monsterIdNumber in window.CUSTOM_TOKEN_IMAGE_MAP) {
+                const images = window.CUSTOM_TOKEN_IMAGE_MAP[monsterIdNumber];
+                const monsterId = `${monsterIdNumber}`; // monster ids are numbers, but we want it to be a string to be consistent with other ids
+                const newCustomization = TokenCustomization.Monster(monsterId, { alternativeImages: images });
+                newCustomizations.push(newCustomization);
+                console.debug("migrate_token_customizations migrated", monsterIdNumber, images, "to", newCustomization);
+            }
+            console.log("migrate_token_customizations finished migrating monster customizations");
+        }
+
+        persist_all_token_customizations(newCustomizations, function (success, errorType) {
+            if (success === true) {
+                // TODO: remove them entirely at some point
+                write_player_token_customizations(oldCustomizations);
+                window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate = true;
+                save_custom_monster_image_mapping();
+                console.log("migrate_token_customizations successfully persisted migrated customizations", newCustomizations);
+            } else {
+                console.error("migrate_token_customizations failed to persist new customizations", newCustomizations, errorType);
+            }
+        });
+
+    } catch (error) {
+        console.error("migrate_token_customizations failed", error);
+    }
+}
+
+function rollback_token_customizations_migration() {
+    localStorage.setItem("TokenCustomizations", JSON.stringify([]));
+    let playerCustomizations = read_player_token_customizations();
+    for (let playerId in playerCustomizations) {
+        playerCustomizations[playerId].didMigrate = false;
+    }
+    write_player_token_customizations(playerCustomizations);
+    window.CUSTOM_TOKEN_IMAGE_MAP.didMigrate = false;
+    save_custom_monster_image_mapping();
+}
+
+function persist_all_token_customizations(customizations, callback) {
+    console.log("persist_all_token_customizations starting");
+    // TODO: send to cloud instead of storing locally
+    localStorage.setItem("TokenCustomizations", JSON.stringify(customizations));
+    callback(true);
+
+    return; // TODO: remove everything above, and just do this instead
+
+    let http_api_gw="https://services.abovevtt.net";
+    let searchParams = new URLSearchParams(window.location.search);
+    if(searchParams.has("dev")){
+        http_api_gw="https://jiv5p31gj3.execute-api.eu-west-1.amazonaws.com";
+    }
+
+    window.ajaxQueue.addRequest({
+        url: `${http_api_gw}/services?action=setTokenCustomizations&userId=todo`, // TODO: figure this out
+        success: function (response) {
+            console.warn(`persist_all_token_customizations succeeded`, response);
+            callback(true);
+        },
+        error: function (errorMessage) {
+            console.warn(`persist_all_token_customizations failed`, errorMessage);
+            callback(false, errorMessage?.responseJSON?.type);
+        }
+    })
+}
+
+function persist_token_customization(customization, callback) {
+    if (typeof callback !== 'function') {
+        callback = function(){};
+    }
+    try {
+        if (
+            customization === undefined
+            || typeof customization.id !== "string" || customization.id.length === 0
+            || !TokenCustomization.validTypes.includes(customization.tokenType)
+            || !customization.tokenOptions
+        ) {
+            console.warn("Not persisting invalid customization", customization);
+            callback(false, "Invalid Customization");
+            return;
+        }
+
+        let existingIndex = window.TOKEN_CUSTOMIZATIONS.findIndex(c => c.tokenType === customization.tokenType && c.id === customization.id);
+        if (existingIndex) {
+            window.TOKEN_CUSTOMIZATIONS[existingIndex] = customization;
+        } else {
+            window.TOKEN_CUSTOMIZATIONS.push(customization);
+        }
+
+        window.persist_all_token_customizations(window.TOKEN_CUSTOMIZATIONS);
+
+
+    } catch (error) {
+        console.error("failed to persist customization", customization);
+        callback(false);
+    }
+}
+
+function fetch_token_customizations(callback) {
+    if (typeof callback !== 'function') {
+        callback = function(){};
+    }
+    try {
+        console.log("persist_token_customizations starting");
+        // TODO: fetch from the cloud instead of storing locally
+        let customMappingData = localStorage.getItem('TokenCustomizations');
+        let parsedCustomizations = [];
+        if (customMappingData !== undefined && customMappingData != null) {
+            $.parseJSON(customMappingData).forEach(obj => {
+                try {
+                    parsedCustomizations.push(TokenCustomization.fromJson(obj));
+                } catch (error) {
+                    // this one failed, but keep trying to parse the others
+                    console.error("persist_token_customizations failed to parse customization object", obj);
+                }
+            });
+        }
+        window.TOKEN_CUSTOMIZATIONS = parsedCustomizations;
+        callback(window.TOKEN_CUSTOMIZATIONS);
+    } catch (error) {
+        console.error("persist_token_customizations failed");
+        callback(false);
+    }
+
+    return; // TODO: remove everything above, and just do this instead
+
+    let http_api_gw="https://services.abovevtt.net";
+    let searchParams = new URLSearchParams(window.location.search);
+    if(searchParams.has("dev")){
+        http_api_gw="https://jiv5p31gj3.execute-api.eu-west-1.amazonaws.com";
+    }
+
+    window.ajaxQueue.addRequest({
+        url: `${http_api_gw}/services?action=getTokenCustomizations&userId=todo`, // TODO: figure this out
+        success: function (response) {
+            console.warn(`persist_token_customizations succeeded`, response);
+            callback(response); // TODO: grabe the actual list of objects from the response
+        },
+        error: function (errorMessage) {
+            console.warn(`persist_token_customizations failed`, errorMessage);
+            callback(false, errorMessage?.responseJSON?.type);
+        }
+    });
+}
+
+
+// these are what the cloud data will look like
 // const tokenCustomizationExamples = [
 //     {
 //         id: "/userid/characterId",
 //         type: "pc",
-//         alternativeImages: [],
-//         tokenOptions: {}
+//         tokenOptions: {
+//           alternativeImages: [],
+//           square: true,
+//           ...
+//         }
 //     },
 //     {
 //         id: "17001",
 //         type: "monster",
-//         alternativeImages: [],
-//         tokenOptions: {}
+//         tokenOptions: { ... }
 //     },
 //     // probably don't need to do any of the below, but we could
 //     {
@@ -2321,4 +2486,130 @@ function move_mytokens_folder(listItem, folderPath) {
 //         tokenOptions: {}
 //     }
 // ];
+
+class TokenCustomization {
+
+    /**
+     * @param playerSheet {string} the id of the DDB character
+     * @param tokenOptions {object} the overrides for token.options
+     * @returns {TokenCustomization} the token customization for the player
+     * @constructor
+     */
+    static PC(playerSheet, tokenOptions) {
+        return new TokenCustomization(playerSheet, SidebarListItem.TypePC, tokenOptions);
+    }
+
+    /**
+     * @param monsterId {number|string} the id of the DDB monster
+     * @param tokenOptions {object} the overrides for token.options
+     * @returns {TokenCustomization} the token customization for the monster
+     * @constructor
+     */
+    static Monster(monsterId, tokenOptions) {
+        return new TokenCustomization(`${monsterId}`, SidebarListItem.TypeMonster, tokenOptions);
+    }
+
+    /**
+     * @param obj {object} the raw JSON object with the same structure as a TokenCustomization object
+     * @returns {TokenCustomization} a typed object instead of the raw JSON object that was given
+     */
+    static fromJson(obj) {
+        return new TokenCustomization(obj.id, obj.tokenType, obj.tokenOptions);
+    }
+
+    static validTypes = [SidebarListItem.TypePC, SidebarListItem.TypeMonster];
+    // never call this directly! use the static functions above
+    constructor(id, tokenType, tokenOptions) {
+        if (!TokenCustomization.validTypes.includes(tokenType)) {
+            throw `Invalid Type ${tokenType}`;
+        }
+        if (typeof id !== "string" || id.length === 0) {
+            throw `Invalid id ${id}`;
+        }
+        this.id = id;
+        this.tokenType = tokenType;
+        if (typeof tokenOptions === "object") {
+            this.tokenOptions = tokenOptions;
+        } else {
+            this.tokenOptions = {};
+        }
+    }
+
+    setTokenOption(key, value) {
+        this.tokenOptions[key] = value;
+    }
+    removeTokenOption(key) {
+        delete this.tokenOptions[key];
+    }
+
+    addAlternativeImage(imageUrl) {
+        if (imageUrl.startsWith("data:")) {
+            return;
+        }
+        if (this.tokenOptions.alternativeImages === undefined) {
+            this.tokenOptions.alternativeImages = [];
+        }
+        const parsed = parse_img(imageUrl);
+        if (!this.tokenOptions.includes(parsed)) {
+            this.tokenOptions.push(parsed);
+        }
+    }
+    removeAlternativeImage(imageUrl) {
+        if (this.tokenOptions.alternativeImages === undefined) {
+            return;
+        }
+        let index = this.tokenOptions.alternativeImages.findIndex(i => i === imageUrl);
+        if (typeof index === "number" && index >= 0) {
+            this.tokenOptions.alternativeImages.splice(index, 1);
+        }
+        const parsed = parse_img(imageUrl);
+        let parsedIndex = this.tokenOptions.alternativeImages.findIndex(i => i === parsed);
+        if (typeof parsedIndex === "number" && parsedIndex >= 0) {
+            this.tokenOptions.alternativeImages.splice(parsedIndex, 1);
+        }
+    }
+    removeAllAlternativeImages() {
+        this.tokenOptions.alternativeImages = [];
+    }
+    randomImage() {
+        if (this.tokenOptions.alternativeImages && this.tokenOptions.alternativeImages.length > 0) {
+            let randomIndex = getRandomInt(0, this.tokenOptions.alternativeImages.length);
+            return this.tokenOptions.alternativeImages[randomIndex];
+        }
+        return undefined;
+    }
+}
+
+/**
+ * @param monsterId {number|string} the id of the DDB monster
+ * @returns {TokenCustomization|undefined} a token customization for the monster or undefined if not found
+ */
+function find_monster_token_customization(monsterId) {
+    return window.TOKEN_CUSTOMIZATIONS.find(c => c.tokenType === SidebarListItem.TypeMonster && c.id === `${monsterId}`);
+}
+
+/**
+ * @param monsterId {number|string} the id of the DDB monster
+ * @returns {TokenCustomization} a token customization for the monster. If it doesn't already exist, a new one will be created and returned
+ */
+function get_monster_token_customization(monsterId) {
+    return find_monster_token_customization(monsterId) || TokenCustomization.Monster(monsterId, {});
+}
+
+
+/**
+ * @param playerSheet {string} the id of the DDB character
+ * @returns {TokenCustomization|undefined} a token customization for the monster or undefined if not found
+ */
+function find_player_token_customization(playerSheet) {
+    return window.TOKEN_CUSTOMIZATIONS.find(c => c.tokenType === SidebarListItem.TypePC && c.id === playerSheet);
+}
+
+/**
+ * @param playerSheet {string} the id of the DDB character
+ * @returns {TokenCustomization} a token customization for the player. If it doesn't already exist, a new one will be created and returned
+ */
+function get_player_token_customizations(playerSheet) {
+    return find_player_token_customization(playerSheet) || TokenCustomization.PC(playerSheet, {});
+}
 

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1229,39 +1229,6 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
         // MyToken footer form
         let myToken = find_my_token(listItem.fullPath());
 
-        const buildOptionSelect = function (name, disabledLabel, enabledLabel) {
-            let inputElement = $(`
-            <select name="${name}">
-                <option value="default">Default</option>
-                <option value="disabled">${disabledLabel}</option>
-                <option value="enabled">${enabledLabel}</option>
-            </select>
-        `);
-
-            // explicitly look for true/false because the default value is undefined
-            let configuredValue = myToken[name];
-            if (configuredValue === true) {
-                inputElement.val("enabled");
-            } else if (configuredValue === false) {
-                inputElement.val("disabled");
-            } else {
-                inputElement.val("default");
-            }
-            inputElement.change(function (event) {
-                console.log("update", event.target.name, "to", event.target.value);
-                if (event.target.value === "enabled") {
-                    myToken[name] = true;
-                } else if (event.target.value === "disabled") {
-                    myToken[name] = false;
-                } else {
-                    delete myToken[name];
-                }
-                persist_my_tokens();
-                decorate_modal_images(sidebarPanel, listItem, placedToken);
-            });
-            return inputElement;
-        };
-
         // token name
         inputWrapper.append($(`<div class="token-image-modal-footer-title" style="width:100%;padding-left:0px">Token Name</div>`));
         let nameInput = $(`<input data-previous-name="${name}" title="token name" placeholder="my token name" name="addCustomName" type="text" style="width:100%" value="${name === undefined ? '' : name}" />`);
@@ -1304,8 +1271,9 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
                 });
                 optionsContainer.prepend(`<div class="sidebar-panel-header-explanation">Every time you place this token on the scene, these settings will be used. Setting the value to "Default" will use the global settings which are found in the settings tab.</div>`);
                 flyout.append(optionsContainer);
-                flyout.css("left", sidebarPanel.container[0].getBoundingClientRect().left - flyout.width());
+                position_flyout_left_of(sidebarPanel.container, flyout);
                 redraw_settings_panel_token_examples(myToken);
+                decorate_modal_images(sidebarPanel, listItem, placedToken);
             });
         });
         inputWrapper.append(tokenOptionsButton);

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -2062,7 +2062,7 @@ function find_token_options_for_list_item(listItem) {
     } else if (listItem.isTypeBuiltinToken()) {
         return find_builtin_token(listItem.fullPath());
     } else {
-        return find_token_customization(listItem.type, listItem.sheet)?.tokenOptions || {};
+        return find_token_customization(listItem.type, listItem.backingId())?.tokenOptions || {};
     }
 }
 
@@ -2330,6 +2330,9 @@ function rollback_token_customizations_migration() {
 }
 
 function persist_all_token_customizations(customizations, callback) {
+    if (typeof callback !== 'function') {
+        callback = function(){};
+    }
     console.log("persist_all_token_customizations starting");
     // TODO: send to cloud instead of storing locally
     localStorage.setItem("TokenCustomizations", JSON.stringify(customizations));
@@ -2381,9 +2384,8 @@ function persist_token_customization(customization, callback) {
 
         window.persist_all_token_customizations(window.TOKEN_CUSTOMIZATIONS);
 
-
     } catch (error) {
-        console.error("failed to persist customization", customization);
+        console.error("failed to persist customization", customization, error);
         callback(false);
     }
 }
@@ -2549,6 +2551,7 @@ class TokenCustomization {
     }
 
     setTokenOption(key, value) {
+        console.debug("setTokenOption", key, value);
         if (value === undefined) {
             delete this.tokenOptions[key];
         } else if (value === true || value === "true") {
@@ -2574,8 +2577,8 @@ class TokenCustomization {
             this.tokenOptions.alternativeImages = [];
         }
         const parsed = parse_img(imageUrl);
-        if (!this.tokenOptions.includes(parsed)) {
-            this.tokenOptions.push(parsed);
+        if (!this.tokenOptions.alternativeImages.includes(parsed)) {
+            this.tokenOptions.alternativeImages.push(parsed);
         }
     }
     removeAlternativeImage(imageUrl) {

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -963,7 +963,7 @@ function create_mytoken_folder_inside(listItem) {
             expand_all_folders_up_to_item(newListItem);
         } else {
             console.error("create_mytoken_folder_inside failed to create a new folder", errorType);
-            showGenericAlert();
+            showDebuggingAlert();
         }
     });
 }
@@ -980,14 +980,14 @@ function delete_mytokens_folder_and_everything_in_it(listItem) {
                     console.log("delete_mytokens_folder_and_everything_in_it successfully deleted the folder with id", listItem.id);
                 } else {
                     console.error("delete_mytokens_folder_and_everything_in_it failed delete the folder with id", listItem.id, deletedFolderErrorType);
-                    showGenericAlert();
+                    showDebuggingAlert();
                 }
             });
         } else {
             did_change_mytokens_items();
             expand_all_folders_up_to_item(listItem);
             console.error("delete_mytokens_within_folder failed to delete token customizations", deletedChildrenErrorType);
-            showGenericAlert();
+            showDebuggingAlert();
         }
     });
 }
@@ -1014,7 +1014,7 @@ function move_mytokens_to_parent_folder_and_delete_folder(listItem, callback) {
             console.log("move_mytokens_to_parent_folder_and_delete_folder successfully moved all children up one level and deleted folder with id", listItem.id);
         } else {
             console.error("move_mytokens_to_parent_folder_and_delete_folder failed to move all items out of", listItem.id, errorType);
-            showGenericAlert();
+            showDebuggingAlert();
         }
         callback(didSucceed, errorType);
     });
@@ -1056,7 +1056,7 @@ function create_token_inside(listItem) {
             display_token_configuration_modal(newItem);
         } else {
             console.error("Failed to create My Token", customization, error);
-            showGenericAlert();
+            showDebuggingAlert();
         }
     });
 }
@@ -1077,10 +1077,12 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
             return;
     }
 
-    let customization = find_token_customization(listItem.type, listItem.id);
-    if (customization === undefined) {
-        console.warn("display_token_configuration_modal failed to find a customization object matching listItem:", listItem);
-        alert("Failed to find a matching token customization object.");
+    let customization;
+    try {
+        customization = find_or_create_token_customization(listItem.type, listItem.id, RootFolder.Monsters.id);
+    } catch (error) {
+        console.error("display_token_configuration_modal failed to create a customization object for listItem:", listItem, error);
+        showDebuggingAlert("Failed to create a token customization object.");
         return;
     }
 
@@ -1796,7 +1798,7 @@ function register_custom_token_image_context_menu() {
                             let customization = find_token_customization(listItem.type, listItem.id);
                             if (!customization) {
                                 console.error("register_custom_token_image_context_menu Remove failed to find a token customization object matching listItem: ", listItem);
-                                showGenericAlert();
+                                showDebuggingAlert();
                                 return;
                             }
                             customization.removeAlternativeImage(imgSrc);
@@ -1804,7 +1806,7 @@ function register_custom_token_image_context_menu() {
                             redraw_token_images_in_modal(window.current_sidebar_modal, listItem, placedToken);
                         } else {
                             console.error("register_custom_token_image_context_menu Remove attempted to remove a custom image with an invalid type. listItem:", listItem);
-                            showGenericAlert();
+                            showDebuggingAlert();
                             return;
                         }
                         selectedItem.remove();
@@ -1836,7 +1838,7 @@ function build_remove_all_images_button(sidebarPanel, listItem, placedToken) {
         }
         if (!customization) {
             console.error("build_remove_all_images_button failed to find token customization for listItem:", listItem, ", placedToken:", placedToken);
-            showGenericAlert();
+            showDebuggingAlert();
             return;
         }
         if (window.confirm(`Are you sure you want to remove all custom images for ${tokenName}?\nThis will reset the token images back to the default`)) {

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -655,23 +655,15 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
         return;
     }
 
-    let options = {
-        name: listItem.name,
-        listItemPath: listItem.fullPath(),
-        hidden: hidden,
-        imgsrc: random_image_for_item(listItem, specificImage)
-    };
-
+    // set up whatever you need to. We'll override a few things after
+    let options = {};
     switch (listItem.type) {
         case SidebarListItem.TypeFolder:
             console.log("TODO: place all tokens in folder?", listItem);
             break;
         case SidebarListItem.TypeMyToken:
             let myToken = find_my_token(listItem.fullPath());
-            options.square = myToken.square;
-            options.disableborder = myToken.disableborder;
-            options.legacyaspectratio = myToken.legacyaspectratio;
-            options.disablestat = true;
+            options = {...myToken};
             let tokenSizeSetting = myToken.tokenSize;
             let tokenSize = parseInt(tokenSizeSetting);
             if (tokenSizeSetting === undefined || typeof tokenSizeSetting !== 'number') {
@@ -721,10 +713,15 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
         case SidebarListItem.TypeBuiltinToken:
             let builtinToken = builtInTokens.find(t => t.name === listItem.name);
             console.log("create_and_place_token SidebarListItem.TypeBuiltinToken options before", options, builtinToken);
-            options = {...options, ...builtinToken}
+            options = {...builtinToken}
             options.disablestat = true;
             break;
     }
+
+    options.name = listItem.name;
+    options.listItemPath = listItem.fullPath();
+    options.hidden = hidden;
+    options.imgsrc = random_image_for_item(listItem, specificImage);
 
     console.log("create_and_place_token about to place token with options", options);
 
@@ -1290,22 +1287,29 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
             persist_my_tokens();
         });
         inputWrapper.append(tokenSizeInput);
-        inputWrapper.append(`<div class="sidebar-panel-header-explanation" style="padding-bottom:6px;">The following will override global settings for this token. Global settings can be changed in the settings tab.</div>`)
 
-        // token type
-        let tokenTypeInput = buildOptionSelect("square", "Round", "Square");
-        let tokenTypeInputWrapper = build_select_input("Token Shape", tokenTypeInput);
-        inputWrapper.append(tokenTypeInputWrapper);        // adds class token-round
-
-        // token border
-        let hideBorderInput = buildOptionSelect("disableborder", "Border", "No Border");
-        let hideBorderInputWrapper = build_select_input("Border Visibility", hideBorderInput);
-        inputWrapper.append(hideBorderInputWrapper); // sets border-width: 4
-
-        // token aspect ratio
-        let aspectRatioInput = buildOptionSelect("legacyaspectratio", "Maintain", "Stretch")
-        let aspectRatioInputWrapper = build_select_input("Aspect Ratio", aspectRatioInput);
-        inputWrapper.append(aspectRatioInputWrapper);     // adds class preserve-aspect-ratio
+        let tokenOptionsButton = $(`<button class="sidebar-panel-footer-button" style="margin: 10px 0px 10px 0px;">Override Token Options</button>`);
+        tokenOptionsButton.on("click", function (clickEvent) {
+            build_and_display_sidebar_flyout(clickEvent.clientY, function (flyout) {
+                let optionsContainer = build_sidebar_token_options_flyout(token_setting_options, myToken, TOKEN_OPTIONS_INPUT_TYPE_SELECT, function(name, newValue) {
+                    if (newValue === true || newValue === false) {
+                        myToken[name] = newValue;
+                    } else {
+                        delete myToken[name];
+                    }
+                }, function () {
+                    persist_my_tokens();
+                    redraw_settings_panel_token_examples(myToken);
+                    decorate_modal_images(sidebarPanel, listItem, placedToken);
+                });
+                optionsContainer.prepend(`<div class="sidebar-panel-header-explanation">Every time you place this token on the scene, these settings will be used. Setting the value to "Default" will use the global settings which are found in the settings tab.</div>`);
+                flyout.append(optionsContainer);
+                flyout.css("left", sidebarPanel.container[0].getBoundingClientRect().left - flyout.width());
+                redraw_settings_panel_token_examples(myToken);
+            });
+        });
+        inputWrapper.append(tokenOptionsButton);
+        inputWrapper.append(`<br />`);
 
         // submit form button
         let saveButton = $(`<button class="sidebar-panel-footer-button" style="width:100%;padding:8px;margin-top:8px;margin-left:0px;">Save Token</button>`);
@@ -1403,7 +1407,7 @@ function redraw_token_images_in_modal(sidebarPanel, listItem, placedToken) {
 
     const buildTokenDiv = function(imageUrl) {
         let parsedImage = parse_img(imageUrl);
-        let tokenDiv = build_alternative_image_for_modal(parsedImage, placedToken);
+        let tokenDiv = build_alternative_image_for_modal(parsedImage, find_token_options_for_list_item(listItem), placedToken);
         if (placedToken?.isMonster()) {
             tokenDiv.attr("data-monster", placedToken.options.monster);
         }
@@ -1435,7 +1439,6 @@ function redraw_token_images_in_modal(sidebarPanel, listItem, placedToken) {
         modalBody.append(tokenDiv);
     }
 
-    decorate_modal_images(sidebarPanel, listItem, placedToken);
     if (alternative_images_for_item(listItem).length === 0) {
         sidebarPanel.footer.find(".token-image-modal-url-label-add-wrapper .token-image-modal-url-label-wrapper .token-image-modal-footer-title").text("Replace The Default Image");
     } else {
@@ -1449,13 +1452,16 @@ function redraw_token_images_in_modal(sidebarPanel, listItem, placedToken) {
  * @param placedToken {Token} the Token object that as been placed on the scene; else undefined
  * @returns {*|jQuery|HTMLElement} the HTML that you can add to a sidebarPanel modal
  */
-function build_alternative_image_for_modal(image, placedToken) {
-    let tokenDiv = $(`
-		    <div class="custom-token-image-item">
-			    <div class="token-image-sizing-dummy"></div>
-			    <img alt="token-img" class="token-image token-round" src="${image}" />
-	    	</div>
-    	`);
+function build_alternative_image_for_modal(image, options, placedToken) {
+    let mergedOptions = {};
+    if (options !== undefined) {
+        mergedOptions = {...mergedOptions, ...options};
+    }
+    if (placedToken !== undefined) {
+        mergedOptions = {...mergedOptions, ...placedToken.options};
+    }
+    mergedOptions.imgsrc = image;
+    let tokenDiv = build_example_token(mergedOptions);
     if (placedToken !== undefined) {
         // the user is changing their token image, allow them to simply click an image
         // we don't want to allow drag and drop from this modal
@@ -1466,6 +1472,7 @@ function build_alternative_image_for_modal(image, placedToken) {
             placedToken.place_sync_persist();
         });
     }
+    tokenDiv.addClass("custom-token-image-item");
     return tokenDiv;
 }
 
@@ -1476,7 +1483,6 @@ function build_alternative_image_for_modal(image, placedToken) {
  * @param placedToken {Token|undefined} the token on the scene
  */
 function decorate_modal_images(sidebarPanel, listItem, placedToken) {
-
     if (listItem === undefined && placedToken === undefined) {
         console.warn("decorate_modal_images was called without a listItem or a placedToken");
         return;
@@ -1488,47 +1494,12 @@ function decorate_modal_images(sidebarPanel, listItem, placedToken) {
         myToken = find_my_token(listItem.fullPath());
     }
 
-    let items = sidebarPanel.body.find(".custom-token-image-item");
-
-    const getSettingValue = function(settingName) {
-        if (myToken !== undefined && myToken[settingName] !== undefined) {
-            return myToken[settingName];
-        } else if (placedToken !== undefined) {
-            return placedToken.options[settingName];
-        } else {
-            return window.TOKEN_SETTINGS[settingName];
-        }
+    let items = sidebarPanel.body.find(".example-token");
+    for (let i = 0; i < items.length; i++) {
+        let item = $(items[i]);
+        let imgsrc = item.find("img.token-image").attr("src");
+        item.replaceWith(build_alternative_image_for_modal(imgsrc, myToken, placedToken));
     }
-
-    let squareSetting = getSettingValue("square");
-    if (squareSetting === true) {
-        items.find("img").removeClass("token-round");
-    } else {
-        items.find("img").addClass("token-round");
-    }
-
-    let borderSetting = getSettingValue("disableborder");
-    if (borderSetting === true) {
-        items.find("img").css("border", "0px solid #000")
-    } else {
-        items.find("img").css("border", "4px solid #000")
-    }
-
-    let legacyaspectratio = getSettingValue("legacyaspectratio");
-    if (legacyaspectratio === true) {
-        items.find("img").removeClass("preserve-aspect-ratio");
-    } else {
-        items.find("img").addClass("preserve-aspect-ratio");
-    }
-
-    let tokenSize = token_size_for_item(listItem);
-    if (tokenSize === undefined && placedToken !== undefined) {
-        placedToken.gridSize();
-    }
-    if (tokenSize === undefined) {
-        tokenSize = 1;
-    }
-    items.attr("data-token-size", tokenSize);
 }
 
 /**
@@ -2072,6 +2043,15 @@ function build_remove_all_images_button(sidebarPanel, listItem, placedToken) {
     return removeAllButton;
 }
 
+function find_token_options_for_list_item(listItem) {
+    switch (listItem.type) {
+        case SidebarListItem.TypeMyToken: return find_my_token(listItem.fullPath());
+        case SidebarListItem.TypePC: return get_player_token_customizations(listItem.sheet);
+        case SidebarListItem.TypeMonster: return {}; // TODO: allow overriding monster token options
+        default: return {};
+    }
+}
+
 function display_change_image_modal(placedToken) {
     if (placedToken === undefined) {
         console.warn("Attempted to call display_change_image_modal without a token");
@@ -2143,11 +2123,10 @@ function display_change_image_modal(placedToken) {
             myToken.alternativeImages.push(parse_img(imageUrl));
             did_change_mytokens_items();
         }
-        let tokenDiv = build_alternative_image_for_modal(imageUrl, placedToken);
+        let tokenDiv = build_alternative_image_for_modal(imageUrl, find_token_options_for_list_item(listItem), placedToken);
         modalBody.append(tokenDiv);
         footerLabel.text(determineLabelText())
         removeAllButton.show();
-        decorate_modal_images(sidebarPanel, listItem, placedToken);
     };
     if (alternative_images_for_item(listItem).length === 0) {
         removeAllButton.hide();

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -62,7 +62,7 @@ function migrate_to_my_tokens() {
         }
     }
 
-    migrateFolderAtPath(RootFolderPath.Root);
+    migrateFolderAtPath(RootFolder.Root.path);
     tokendata.didMigrateToMyToken = true;
     persist_my_tokens();
     persist_customtokens();
@@ -92,7 +92,7 @@ function rollback_from_my_tokens() {
             rollbackFolderAtPath(nextFolderPath);
         }
     };
-    rollbackFolderAtPath(RootFolderPath.Root);
+    rollbackFolderAtPath(RootFolder.Root.path);
     persist_customtokens();
     console.groupEnd();
 }
@@ -116,13 +116,13 @@ function list_item_from_monster_id(monsterId) {
 function list_item_from_player_id(playerId) {
     let pc = window.pcs.find(p => p.sheet = playerId);
     if (pc === undefined) return undefined;
-    let fullPath = sanitize_folder_path(`${RootFolderPath.Players}/${pc.name}`);
+    let fullPath = sanitize_folder_path(`${RootFolder.Players.path}/${pc.name}`);
     return find_sidebar_list_item_from_path(fullPath);
 }
 
 function list_item_from_token(placedToken) {
     let listItemPath = placedToken.options.listItemPath;
-    if (listItemPath !== undefined && listRootFolderPath.length > 0) {
+    if (listItemPath !== undefined && listItemPath.length > 0) {
         // this token was placed after we unified tokens
         return find_sidebar_list_item_from_path(listItemPath);
     }
@@ -137,11 +137,11 @@ function list_item_from_token(placedToken) {
         let tokenDataPath = placedToken.options.tokendatapath !== undefined ? placedToken.options.tokendatapath : "";
         let tokenDataName = placedToken.options.tokendataname !== undefined ? placedToken.options.tokendataname : placedToken.options.name;
         if (tokenDataPath.startsWith("/AboveVTT BUILTIN")) {
-            let convertedPath = tokenDataPath.replace("/AboveVTT BUILTIN", RootFolderPath.AboveVTT);
+            let convertedPath = tokenDataPath.replace("/AboveVTT BUILTIN", RootFolder.AboveVTT.path);
             let fullPath = sanitize_folder_path(`${convertedPath}/${tokenDataName}`);
             return find_sidebar_list_item_from_path(fullPath);
         } else {
-            let fullPath = sanitize_folder_path(`${RootFolderPath.MyTokens}/${tokenDataPath}/${tokenDataName}`);
+            let fullPath = sanitize_folder_path(`${RootFolder.MyTokens.path}/${tokenDataPath}/${tokenDataName}`);
             return find_sidebar_list_item_from_path(fullPath);
         }
     }
@@ -153,13 +153,13 @@ function list_item_from_token(placedToken) {
  * @returns {undefined|*} the "My Token" object if found; else undefined
  */
 function find_my_token(fullPath) {
-    if (!fullPath.startsWith(RootFolderPath.MyTokens)) {
-        console.warn("find_my_token was called with the wrong token type.", fullPath, "should start with", RootFolderPath.MyTokens);
+    if (!fullPath.startsWith(RootFolder.MyTokens.path)) {
+        console.warn("find_my_token was called with the wrong token type.", fullPath, "should start with", RootFolder.MyTokens.path);
         return undefined;
     }
     console.groupCollapsed("find_my_token");
     let found = mytokens.find(t => {
-        let dirtyPath = `${RootFolderPath.MyTokens}${t.folderPath}/${t.name}`;
+        let dirtyPath = `${RootFolder.MyTokens.path}${t.folderPath}/${t.name}`;
         let fullTokenPath = sanitize_folder_path(dirtyPath);
         console.debug("looking for: ", fullPath, fullTokenPath, fullTokenPath === fullPath, t);
         return fullTokenPath === fullPath;
@@ -175,13 +175,13 @@ function find_my_token(fullPath) {
  * @returns {undefined|*} the Folder object if found; else undefined
  */
 function find_my_token_folder(fullPath) {
-    if (!fullPath.startsWith(RootFolderPath.MyTokens)) {
-        console.warn("find_my_token was called with the wrong token type.", fullPath, "should start with", RootFolderPath.MyTokens);
+    if (!fullPath.startsWith(RootFolder.MyTokens.path)) {
+        console.warn("find_my_token was called with the wrong token type.", fullPath, "should start with", RootFolder.MyTokens.path);
         return undefined;
     }
     console.groupCollapsed("find_my_token_folder");
     let found = mytokensfolders.find(f => {
-        let dirtyPath = `${RootFolderPath.MyTokens}${f.folderPath}/${f.name}`;
+        let dirtyPath = `${RootFolder.MyTokens.path}${f.folderPath}/${f.name}`;
         let fullFolderPath = sanitize_folder_path(dirtyPath);
         console.debug("looking for: ", fullPath, dirtyPath, fullFolderPath, fullFolderPath === fullPath, f);
         return fullFolderPath === fullPath;
@@ -197,13 +197,13 @@ function find_my_token_folder(fullPath) {
  * @returns {undefined|*} the "Builtin Token" object if found; else undefined
  */
 function find_builtin_token(fullPath) {
-    if (!fullPath.startsWith(RootFolderPath.AboveVTT)) {
-        console.warn("find_builtin_token was called with the wrong token type.", fullPath, "should start with", RootFolderPath.AboveVTT);
+    if (!fullPath.startsWith(RootFolder.AboveVTT.path)) {
+        console.warn("find_builtin_token was called with the wrong token type.", fullPath, "should start with", RootFolder.AboveVTT.path);
         return undefined;
     }
     console.groupCollapsed("find_builtin_token");
     let found = builtInTokens.find(t => {
-        let dirtyPath = `${RootFolderPath.AboveVTT}${t.folderPath}/${t.name}`;
+        let dirtyPath = `${RootFolder.AboveVTT.path}${t.folderPath}/${t.name}`;
         let fullTokenPath = sanitize_folder_path(dirtyPath);
         console.debug("looking for: ", fullPath, dirtyPath, fullTokenPath, fullTokenPath === fullPath, t);
         return fullTokenPath === fullPath;
@@ -215,13 +215,13 @@ function find_builtin_token(fullPath) {
 
 function backfill_mytoken_folders() {
     mytokens.forEach(myToken => {
-        if (myToken.folderPath !== RootFolderPath.Root) {
+        if (myToken.folderPath !== RootFolder.Root.path) {
             // we split the path and backfill empty every folder along the way if needed. This is really important for folders that hold subfolders, but not items
             let parts = myToken.folderPath.split("/");
             let backfillPath = "";
             parts.forEach(part => {
                 let fullBackfillPath = sanitize_folder_path(`${backfillPath}/${part}`);
-                if (fullBackfillPath !== RootFolderPath.Root && !mytokensfolders.find(fi => sanitize_folder_path(`${fi.folderPath}/${fi.name}`) === fullBackfillPath)) {
+                if (fullBackfillPath !== RootFolder.Root.path && !mytokensfolders.find(fi => sanitize_folder_path(`${fi.folderPath}/${fi.name}`) === fullBackfillPath)) {
                     // we don't have this folder yet so add it
                     let newFolder = { folderPath: sanitize_folder_path(backfillPath), name: part, collapsed: true };
                     console.log("adding folder", newFolder);
@@ -265,7 +265,7 @@ function rebuild_token_items_list() {
 
     // AboveVTT Tokens
     let allBuiltinPaths = builtInTokens
-        .filter(item => item.folderPath !== RootFolderPath.Root && item.folderPath !== "" && item.folderPath !== undefined)
+        .filter(item => item.folderPath !== RootFolder.Root.path && item.folderPath !== "" && item.folderPath !== undefined)
         .map(item => item.folderPath);
     let builtinPaths = [...new Set(allBuiltinPaths)];
     for (let i = 0; i < builtinPaths.length; i++) {
@@ -273,13 +273,13 @@ function rebuild_token_items_list() {
         let pathComponents = path.split("/");
         let folderName = pathComponents.pop();
         let folderPath = pathComponents.join("/");
-        let builtinFolderPath = sanitize_folder_path(`${RootFolderPath.AboveVTT}/${folderPath}`);
+        let builtinFolderPath = sanitize_folder_path(`${RootFolder.AboveVTT.path}/${folderPath}`);
         tokenItems.push(
             SidebarListItem.Folder(path_to_html_id(builtinFolderPath, folderName),
                 builtinFolderPath,
                 folderName,
                 true,
-            builtinFolderPath === RootFolderPath.AboveVTT ? RootFolderId.BuiltinTokens : path_to_html_id(builtinFolderPath)
+            builtinFolderPath === RootFolder.AboveVTT.path ? RootFolder.AboveVTT.id : path_to_html_id(builtinFolderPath)
             )
         );
     }
@@ -318,7 +318,7 @@ function filter_token_list(searchTerm) {
         allFolders.removeClass("collapsed"); // auto expand all folders
         for (let i = 0; i < allFolders.length; i++) {
             let currentFolder = $(allFolders[i]);
-            if (matches_full_path(currentFolder, RootFolderPath.Monsters)) {
+            if (matches_full_path(currentFolder, RootFolder.Monsters.path)) {
                 // we always want the monsters folder to be open when searching
                 continue;
             }
@@ -353,7 +353,7 @@ function inject_monster_tokens(searchTerm, skip) {
             listItems.push(item);
         }
         console.log("search_monsters converted", listItems);
-        let monsterFolder = find_html_row_from_path(RootFolderPath.Monsters, tokensPanel.body);
+        let monsterFolder = find_html_row_from_path(RootFolder.Monsters.path, tokensPanel.body);
         inject_monster_list_items(listItems);
         if (searchTerm.length > 0) {
             monsterFolder.removeClass("collapsed");
@@ -374,7 +374,7 @@ function inject_monster_tokens(searchTerm, skip) {
 }
 
 function inject_monster_list_items(listItems) {
-    let monsterFolder = find_html_row_from_path(RootFolderPath.Monsters, tokensPanel.body);
+    let monsterFolder = find_html_row_from_path(RootFolder.Monsters.path, tokensPanel.body);
     if (monsterFolder === undefined || monsterFolder.length === 0) {
         console.warn("inject_monster_list_items failed to find the monsters folder");
         return;
@@ -394,11 +394,11 @@ function init_tokens_panel() {
     console.log("init_tokens_panel");
 
     tokens_rootfolders = [
-        SidebarListItem.Folder(RootFolderId.Players, RootFolderPath.Root, SidebarListItem.NamePlayers, false, path_to_html_id(RootFolderPath.Root)),
-        SidebarListItem.Folder(RootFolderId.Monsters, RootFolderPath.Root, SidebarListItem.NameMonsters, false, path_to_html_id(RootFolderPath.Root)),
-        SidebarListItem.Folder(RootFolderId.MyTokens, RootFolderPath.Root, SidebarListItem.NameMyTokens, false, path_to_html_id(RootFolderPath.Root)),
-        SidebarListItem.Folder(RootFolderId.BuiltinTokens, RootFolderPath.Root, SidebarListItem.NameAboveVTT, false, path_to_html_id(RootFolderPath.Root)),
-        SidebarListItem.Folder(RootFolderId.Encounter, RootFolderPath.Root, SidebarListItem.NameEncounters, false, path_to_html_id(RootFolderPath.Root))
+        SidebarListItem.Folder(RootFolder.Players.id, RootFolder.Root.path, RootFolder.Players.name, false, path_to_html_id(RootFolder.Root.path)),
+        SidebarListItem.Folder(RootFolder.Monsters.id, RootFolder.Root.path, RootFolder.Monsters.name, false, path_to_html_id(RootFolder.Root.path)),
+        SidebarListItem.Folder(RootFolder.MyTokens.id, RootFolder.Root.path, RootFolder.MyTokens.name, false, path_to_html_id(RootFolder.Root.path)),
+        SidebarListItem.Folder(RootFolder.AboveVTT.id, RootFolder.Root.path, RootFolder.AboveVTT.name, false, path_to_html_id(RootFolder.Root.path)),
+        SidebarListItem.Folder(RootFolder.Encounters.id, RootFolder.Root.path, RootFolder.Encounters.name, false, path_to_html_id(RootFolder.Root.path))
     ];
 
     if(localStorage.getItem('MyTokens') != null){
@@ -624,7 +624,7 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
         if (listItem.isTypeFolder()) {
             let fullPath = listItem.fullPath();
             // find and place all items in this folder... but not subfolders
-            tokensToPlace = (listItem.fullPath().startsWith(RootFolderPath.Monsters) ? window.monsterListItems : window.tokenListItems)
+            tokensToPlace = (listItem.fullPath().startsWith(RootFolder.Monsters.path) ? window.monsterListItems : window.tokenListItems)
                 .filter(item => !item.isTypeFolder()) // if we ever want to add everything at every subfolder depth, remove this line
                 .filter(item => item.folderPath === fullPath);
         } else if (listItem.isTypeEncounter()) {
@@ -669,6 +669,12 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
     // set up whatever you need to. We'll override a few things after
     let options = {...window.TOKEN_SETTINGS};
     options.name = listItem.name;
+
+
+    // TODO: handle parent folder options!!!
+
+
+
 
     switch (listItem.type) {
         case ItemType.Folder:
@@ -797,7 +803,7 @@ function alternative_images_for_item(listItem) {
             alternativeImages = get_custom_monster_images(listItem.monsterData.id);
             break;
         case ItemType.BuiltinToken:
-            alternativeImages = builtInTokens.find(bt => listItem.fullPath() === sanitize_folder_path(`${RootFolderPath.AboveVTT}${bt.folderPath}/${bt.name}`) )?.alternativeImages;
+            alternativeImages = builtInTokens.find(bt => listItem.fullPath() === sanitize_folder_path(`${RootFolder.AboveVTT.path}${bt.folderPath}/${bt.name}`) )?.alternativeImages;
             break;
     }
 
@@ -985,12 +991,12 @@ function my_token_path_exists(folderPath) {
  * @param listItem {SidebarListItem} The folder to create a new folder within
  */
 function create_mytoken_folder_inside(listItem) {
-    if (!listItem.isTypeFolder() || !listItem.fullPath().startsWith(RootFolderPath.MyTokens)) {
+    if (!listItem.isTypeFolder() || !listItem.fullPath().startsWith(RootFolder.MyTokens.path)) {
         console.warn("create_mytoken_folder_inside called with an incorrect item type", listItem);
         return;
     }
 
-    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.MyTokens, ""));
+    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.MyTokens.path, ""));
     let newFolderName = "New Folder";
     let newFolderCount = mytokensfolders.filter(f => f.folderPath === adjustedPath && f.name.startsWith(newFolderName)).length;
     console.log("newFolderCount", newFolderCount);
@@ -999,7 +1005,7 @@ function create_mytoken_folder_inside(listItem) {
     }
     let newFolder = { folderPath: adjustedPath, name: newFolderName, collapsed: true };
     mytokensfolders.push(newFolder);
-    let newFolderFullPath = sanitize_folder_path(`${RootFolderPath.MyTokens}${newFolder.folderPath}/${newFolder.name}`);
+    let newFolderFullPath = sanitize_folder_path(`${RootFolder.MyTokens.path}${newFolder.folderPath}/${newFolder.name}`);
     did_change_mytokens_items();
     expand_all_folders_up_to(newFolderFullPath, tokensPanel.body);
     let newListItem = window.tokenListItems.find(i => i.fullPath() === newFolderFullPath);
@@ -1014,7 +1020,7 @@ function create_mytoken_folder_inside(listItem) {
  * @returns {string|undefined} the path of the newly created folder; undefined if the folder could not be created.
  */
 function rename_mytoken_folder(item, newName, alertUser = true) {
-    if (!item.isTypeFolder() || !item.folderPath.startsWith(RootFolderPath.MyTokens)) {
+    if (!item.isTypeFolder() || !item.folderPath.startsWith(RootFolder.MyTokens.path)) {
         console.warn("rename_folder called with an incorrect item type", item);
         if (alertUser !== false) {
             alert("An unexpected error occurred");
@@ -1031,8 +1037,8 @@ function rename_mytoken_folder(item, newName, alertUser = true) {
         return;
     }
 
-    let fromFullPath = sanitize_folder_path(item.fullPath().replace(RootFolderPath.MyTokens, ""));
-    let fromFolderPath = sanitize_folder_path(item.folderPath.replace(RootFolderPath.MyTokens, ""));
+    let fromFullPath = sanitize_folder_path(item.fullPath().replace(RootFolder.MyTokens.path, ""));
+    let fromFolderPath = sanitize_folder_path(item.folderPath.replace(RootFolder.MyTokens.path, ""));
     let toFullPath = sanitize_folder_path(`${fromFolderPath}/${newName}`);
     if (my_token_path_exists(toFullPath)) {
         console.warn(`Attempted to rename folder to ${newName}, which would be have a path: ${toFullPath} but a folder with that path already exists`);
@@ -1077,7 +1083,7 @@ function rename_mytoken_folder(item, newName, alertUser = true) {
 
 function delete_mytokens_within_folder(listItem) {
     console.groupCollapsed(`delete_mytokens_within_folder`);
-    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.MyTokens, ""));
+    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.MyTokens.path, ""));
 
     console.log("about to delete all tokens within", adjustedPath);
     console.debug("before deleting from mytokens", mytokens);
@@ -1095,8 +1101,8 @@ function delete_mytokens_within_folder(listItem) {
 function move_mytokens_to_parent_folder(listItem) {
     // this is different from move_mytokens_folder in that it moved everything out of listItem
     console.groupCollapsed(`move_mytokens_to_parent_folder`);
-    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.MyTokens, ""));
-    let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(RootFolderPath.MyTokens, ""));
+    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.MyTokens.path, ""));
+    let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(RootFolder.MyTokens.path, ""));
 
     console.debug("before moving mytokens", mytokens);
     mytokens.forEach(token => {
@@ -1128,7 +1134,7 @@ function move_mytokens_to_parent_folder(listItem) {
 
 function delete_mytokens_folder(listItem) {
     console.log("delete_mytokens_folder", listItem);
-    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.MyTokens, ""));
+    let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.MyTokens.path, ""));
     console.debug("before deleting from mytokensfolders", mytokensfolders);
     mytokensfolders = mytokensfolders.filter(folder => sanitize_folder_path(`${folder.folderPath}/${folder.name}`) !== adjustedPath);
     console.debug("after deleting from mytokensfolders", mytokensfolders);
@@ -1139,12 +1145,12 @@ function delete_mytokens_folder(listItem) {
  * @param listItem {SidebarListItem} the folder item to create a token in
  */
 function create_token_inside(listItem) {
-    if (!listItem.isTypeFolder() || !listItem.fullPath().startsWith(RootFolderPath.MyTokens)) {
+    if (!listItem.isTypeFolder() || !listItem.fullPath().startsWith(RootFolder.MyTokens.path)) {
         console.warn("create_token_inside called with an incorrect item type", listItem);
         return;
     }
 
-    let folderPath = listItem.fullPath().replace(RootFolderPath.MyTokens, "");
+    let folderPath = listItem.fullPath().replace(RootFolder.MyTokens.path, "");
     let newTokenName = "New Token";
     let newTokenCount = mytokens.filter(t => t.folderPath === folderPath && t.name.startsWith(newTokenName)).length;
     console.log("newTokenCount", newTokenCount);
@@ -1400,13 +1406,13 @@ function build_override_token_options_button(sidebarPanel, listItem, placedToken
  */
 function rename_my_token(myToken, newName, alertUser) {
     let newPath = sanitize_folder_path(`${myToken.folderPath}/${newName}`);
-    let newFullPath = sanitize_folder_path(`${RootFolderPath.MyTokens}${newPath}`);
+    let newFullPath = sanitize_folder_path(`${RootFolder.MyTokens.path}${newPath}`);
     let existing = find_my_token(newFullPath);
     if (existing !== undefined) {
         if (alertUser !== false) {
             alert(`A Token with the name "${newName}" already exists at "${newFullPath}"`);
         }
-        console.warn(`A Token with the name ${newName} already exists in the folder "${RootFolderPath.MyTokens}${myToken.folderPath}"`);
+        console.warn(`A Token with the name ${newName} already exists in the folder "${RootFolder.MyTokens.path}${myToken.folderPath}"`);
         return false;
     }
     myToken.name = newName;
@@ -1589,7 +1595,7 @@ function persist_token_folders_remembered_state() {
     if (window.tokenListItems === undefined) return;
     let rememberedFolderState = {};
     let foldersToRemember = window.tokenListItems
-        .filter(item => item.isTypeFolder() && item.fullPath().startsWith(RootFolderPath.AboveVTT))
+        .filter(item => item.isTypeFolder() && item.fullPath().startsWith(RootFolder.AboveVTT.path))
         .concat(tokens_rootfolders);
     foldersToRemember.forEach(f => {
         rememberedFolderState[f.fullPath()] = f.collapsed
@@ -2236,24 +2242,24 @@ function move_mytoken_to_folder(listItem, folderPath) {
         console.warn("move_mytoken_to_folder could not find myToken for listItem", listItem);
         return;
     }
-    myToken.folderPath = sanitize_folder_path(folderPath.replace(RootFolderPath.MyTokens, ""));
+    myToken.folderPath = sanitize_folder_path(folderPath.replace(RootFolder.MyTokens.path, ""));
 }
 
 function move_mytokens_folder(listItem, folderPath) {
     // this is different from move_mytokens_to_parent_folder in that it moves the listItem keeping everything within the folder intact
-    if (listItem.isTypeFolder() && listItem.folderPath.startsWith(RootFolderPath.MyTokens)) {
+    if (listItem.isTypeFolder() && listItem.folderPath.startsWith(RootFolder.MyTokens.path)) {
         console.groupCollapsed("move_mytokens_folder");
 
-        let fromPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.MyTokens, ""));
+        let fromPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.MyTokens.path, ""));
 
         let folderObject = find_my_token_folder(listItem.fullPath());
-        let newFolderPath = sanitize_folder_path(folderPath.replace(RootFolderPath.MyTokens, ""));
+        let newFolderPath = sanitize_folder_path(folderPath.replace(RootFolder.MyTokens.path, ""));
         if (folderObject) {
             folderObject.folderPath = newFolderPath;
         }
         listItem.folderPath = newFolderPath;
 
-        let toPath = sanitize_folder_path(listItem.fullPath().replace(RootFolderPath.MyTokens, ""));
+        let toPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.MyTokens.path, ""));
 
         console.debug("before moving mytokens", mytokens);
         mytokens.forEach(token => {

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1256,6 +1256,15 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
         });
         inputWrapper.append(tokenSizeInput);
 
+        // image scale
+        let imageScaleWrapper = build_token_image_scale_input(myToken.imageSize, function (imageSize) {
+            myToken.imageSize = imageSize;
+            persist_my_tokens();
+            decorate_modal_images(sidebarPanel, listItem, placedToken);
+        });
+        inputWrapper.append(imageScaleWrapper);
+
+        // override options
         let tokenOptionsButton = build_override_token_options_button(sidebarPanel, listItem, placedToken, myToken, function(name, value) {
             if (value === true || value === false) {
                 myToken[name] = value;
@@ -1300,7 +1309,25 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
         });
         inputWrapper.append(saveButton);
     } else if (listItem.isTypePC()) {
+
         let playerOptions = get_player_token_customizations(listItem.sheet);
+
+        // token size
+        let tokenSizeInput = build_token_size_input(tokenSize, function (newSize) {
+            playerOptions.tokenSize = newSize;
+            set_player_token_customizations(listItem.sheet, playerOptions);
+            decorate_modal_images(sidebarPanel, listItem, placedToken);
+        });
+        inputWrapper.append(tokenSizeInput);
+
+        // image scale
+        let imageScaleWrapper = build_token_image_scale_input(playerOptions.imageSize, function (imageSize) {
+            playerOptions.imageSize = imageSize;
+            set_player_token_customizations(listItem.sheet, playerOptions);
+            decorate_modal_images(sidebarPanel, listItem, placedToken);
+        });
+        inputWrapper.append(imageScaleWrapper);
+
         let tokenOptionsButton = build_override_token_options_button(sidebarPanel, listItem, placedToken, playerOptions, function(name, value) {
             if (value === true || value === false) {
                 playerOptions[name] = value;

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1368,7 +1368,6 @@ function persist_folders_remembered_state() {
 
 function update_token_folders_remembered_state() {
     if (!window.tokenListItems || !window.sceneListFolders) {
-        console.debug("update_token_folders_remembered_state not even trying", !window.tokenListItems, !window.sceneListFolders);
         return; // still starting up
     }
 
@@ -1377,20 +1376,14 @@ function update_token_folders_remembered_state() {
         .concat(tokens_rootfolders)
         .concat(window.sceneListFolders);
 
-    console.debug("update_token_folders_remembered_state item count", items.length);
-
     if(localStorage.getItem('FolderRememberedState') != null) {
         let rememberedStates = JSON.parse(localStorage.getItem('FolderRememberedState'));
         items.forEach(item => {
             let state = rememberedStates[item.id];
-            console.debug("update_token_folders_remembered_state before", state, item);
             if (state === true || state === false) {
                 item.collapsed = state;
             }
-            console.debug("update_token_folders_remembered_state after", state, item);
         });
-    } else {
-        console.debug("update_token_folders_remembered_state nope");
     }
 }
 

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -268,16 +268,12 @@ function rebuild_token_items_list() {
         .filter(item => item.folderPath !== RootFolderPath.Root && item.folderPath !== "" && item.folderPath !== undefined)
         .map(item => item.folderPath);
     let builtinPaths = [...new Set(allBuiltinPaths)];
-    console.log("heyyy builtinPaths", builtinPaths)
     for (let i = 0; i < builtinPaths.length; i++) {
         let path = builtinPaths[i];
         let pathComponents = path.split("/");
         let folderName = pathComponents.pop();
         let folderPath = pathComponents.join("/");
         let builtinFolderPath = sanitize_folder_path(`${RootFolderPath.AboveVTT}/${folderPath}`);
-        console.log("heyyy builtinFolderPath", builtinFolderPath);
-        console.log("heyyy path_to_html_id(builtinFolderPath, folderName)", path_to_html_id(builtinFolderPath, folderName));
-        console.log("heyyy path_to_html_id(builtinFolderPath)", path_to_html_id(builtinFolderPath));
         tokenItems.push(
             SidebarListItem.Folder(path_to_html_id(builtinFolderPath, folderName),
                 builtinFolderPath,
@@ -680,7 +676,7 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
             break;
         case ItemType.MyToken:
             options = {...options, ...find_token_options_for_list_item(listItem)};
-            let tokenSizeSetting = myToken.tokenSize;
+            let tokenSizeSetting = options.tokenSize;
             let tokenSize = parseInt(tokenSizeSetting);
             if (tokenSizeSetting === undefined || typeof tokenSizeSetting !== 'number') {
                 tokenSize = 1;
@@ -767,8 +763,8 @@ function token_size_for_item(listItem) {
         case ItemType.Folder:
             return 1;
         case ItemType.MyToken:
-            let myToken = find_my_token(listItem.fullPath());
-            let tokenSizeSetting = myToken.tokenSize;
+            let options = find_token_options_for_list_item(listItem);
+            let tokenSizeSetting = options.tokenSize;
             let tokenSize = parseInt(tokenSizeSetting);
             if (tokenSizeSetting === undefined || typeof tokenSizeSetting !== 'number') {
                 tokenSize = 1; // TODO: handle custom sizes
@@ -1337,7 +1333,7 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
 
         let customization;
         try {
-             customization = find_or_create_token_customization(listItem.type, listItem.id);
+             customization = find_or_create_token_customization(listItem.type, listItem.id, listItem.parentId);
         } catch (error) {
             console.error("Failed to find_or_create TokenCustomization object from listItem", listItem);
             return;
@@ -2083,10 +2079,7 @@ function build_remove_all_images_button(sidebarPanel, listItem, placedToken) {
 }
 
 function find_token_options_for_list_item(listItem) {
-    if (listItem.isTypeMyToken()) {
-        // TODO: soon to use find_token_customization as well
-        return find_my_token(listItem.fullPath());
-    } else if (listItem.isTypeBuiltinToken()) {
+    if (listItem.isTypeBuiltinToken()) {
         return find_builtin_token(listItem.fullPath());
     } else {
         return find_token_customization(listItem.type, listItem.id)?.tokenOptions || {};

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2280,10 +2280,12 @@ h5.token-image-modal-footer-title:after {
     margin: 0px 4px 0px 4px;
     width: auto;
 }
+.example-token,
 .custom-token-image-item {
     float: left; 
     width: 33%;
     position: relative;
+    opacity: 1;
 }
 .custom-token-image-item.ui-draggable-dragging {
     width: auto;
@@ -2366,6 +2368,11 @@ h5.token-image-modal-footer-title:after {
     height: 400px;
     object-fit: cover;
     display: block;
+}
+.sidebar-token-options-flyout-container {
+    width: 320px;
+    padding: 5px;
+    background-color: rgb(235, 241, 245);
 }
 #scenes-panel .sidebar-list-item-row.scene-item .scene-item-footer {
     display: flex;
@@ -3203,11 +3210,6 @@ button.avtt-roll-button {
 }
 .context-menu-list li{
     background: none;
-}
-
-.token-image-modal-footer-title,
-.token-image-modal-footer-select-wrapper{
-    min-width: fit-content;
 }
 
 .menu-outer-aura h3,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2188,6 +2188,13 @@ div.token-image-modal-footer-title {
     font-size: 13px;
     /*width: 100%;*/
 }
+h1.token-image-modal-footer-title,
+h2.token-image-modal-footer-title,
+h3.token-image-modal-footer-title,
+h4.token-image-modal-footer-title,
+h5.token-image-modal-footer-title {
+    display: block;
+}
 h1.token-image-modal-footer-title:after,
 h2.token-image-modal-footer-title:after,
 h3.token-image-modal-footer-title:after,
@@ -2349,11 +2356,9 @@ h5.token-image-modal-footer-title:after {
 }
 .sidebar-flyout {
     position: fixed;
-    right: 350px;
-    z-index: 1000;
-    border: 1px solid #d8e1e8;
+    z-index: 100000;
     box-shadow: 1px 1px 10px black, -1px -1px 10px black;
-    border-radius: 15px;
+    border-radius: 5px;
     overflow: hidden;
 }
 .list-item-image-flyout {
@@ -2772,6 +2777,17 @@ h5.token-image-modal-footer-title:after {
     outline: 2px solid #000;
 }
 
+.sidebar-hover-text-flyout {
+    display: block;
+    max-width: 400px;
+    padding: 0px 10px;
+    background-color: rgba(28,29,30,0.8);
+    color: #fff;
+    font-family: 'Roboto', sans-serif;
+    font-weight: 300;
+    font-size: 14px;
+    text-transform: none;
+}
 .sidebar-hovertext:before {
     content: attr(data-hover);
     font-family: 'Roboto', sans-serif;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2224,7 +2224,8 @@ h5.token-image-modal-footer-title:after {
     margin: 0px 4px 0px 4px;
 }
 .token-image-modal-footer-select-wrapper select {
-    min-width: 30%;
+    min-width: 35%;
+    max-width: 35%;
 }
 .footer-input-wrapper {
     width: 100%;
@@ -2370,7 +2371,7 @@ h5.token-image-modal-footer-title:after {
     display: block;
 }
 .sidebar-token-options-flyout-container {
-    width: 320px;
+    width: 400px;
     padding: 5px;
     background-color: rgb(235, 241, 245);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -79,6 +79,7 @@
 		"ScenesHandler.js",
 		"ScenesPanel.js",
 		"TokensPanel.js",
+		"TokenCustomization.js",
 		"built-in-tokens.js",
 		"mousetrap.1.6.5.min.js",
 		"KeypressHandler.js",


### PR DESCRIPTION
# Public Release Notes
Token Updates by @Azmoria#7532, @mikedave#6365, and new developer @H2owsome#0852 🚀 🥳 
- Added Token "styles" that override token settings based on the style you choose. Styles include:
    - "Circle" (Great for portrait tokens)
    - "Square" (Great for portrait tokens)
    - "Virtual Mini w/ Round Base" (Great for top-down tokens)
    - "Virtual Mini w/ Square Base" (Great for top-down tokens)
    - "No Constraint" (most customizable)
- Monster HP can now be set to average, max, or rolled.
- All token options can now be overridden on a per-token basis as well as a per-folder basis.
    - You can override token options on players, monsters, custom tokens, and any folder within the My Tokens folder!
    - Token option overrides are hierarchical, meaning:
        1. Changing token options in the settings tab applies to all tokens
        2. Changing token options on a folder applies to all tokens within that folder
        3. Changing token options on a token applies to only that token
    - When you place a token on a scene, the options get applied in that order.
- D&D Beyond Portraits can now be used as tokens! Find them in a new folder within the Tokens Panel.

# Technical Release Notes
- Token options have moved to sidebar flyouts, and reuse the same builder functions
- MyToken objects have been migrated to a new TokenCustomization object. 
- PC and Monster customizations have also been migrated to the new TokenCustomization object.
- We are (very nearly) ready to migrate all TokenCustomization objects to the cloud. We still need the cloud work.
- SidebarListItems are now addressed by id instead of path. 
    - This is a much cleaner implementation, more performant, less brittle, and avoids naming collisions (scene folders still need to be unique, but scene names and scene folder names can be the same).


# Demos

## Token Style
Here are all the styles in order of circle, square, virtual mini round, virtual mini square, no constraint.
<img width="1176" alt="Screen Shot 2022-06-17 at 7 44 19 AM" src="https://user-images.githubusercontent.com/584771/174300771-cd3b8945-15eb-47f0-900c-aa131656caed.png">

## Monster HP
The default is "average" which is what we always used to do. Here are 4 tokens that were placed using the "roll" setting.
<img width="878" alt="Screen Shot 2022-06-17 at 7 49 40 AM" src="https://user-images.githubusercontent.com/584771/174301692-744e5a6c-77c5-45af-bbbc-c5abe8c0b208.png">


## Settings Panel Organization
The global token options are now in a flyout to make it consistent with other parts of the app. This also helps to clean up the settings panel a bit.
<img width="773" alt="Screen Shot 2022-06-17 at 6 50 16 AM" src="https://user-images.githubusercontent.com/584771/174292863-18714103-eb8e-44aa-9bf8-2023c28a5510.png">



## Token Customization
Player tokens, monster tokens, My Tokens, and My Tokens folders can now override any of the options that exist in the global settings. These have always been available as global settings and on placed tokens so it makes sense to allow them on token definitions as well. In addition to the options menu flyout, I've also included the image scale option here which will greatly ease the setup time for DMs that use images that need to be scaled slightly. 
At this level, the options are all drop downs instead of toggles because they we need to offer a way to force the value to true or false while also allowing to not force any setting. So the options become [true, false, not overridden].
<img width="754" alt="Screen Shot 2022-06-17 at 6 51 44 AM" src="https://user-images.githubusercontent.com/584771/174293016-ab9eb39f-ed6a-4c5f-b739-1f0001eb3080.png">

## D&D Beyond Portraits
On the left, you can see the list of races that DDB provides portraits for. On the right are all the Human portraits (which can be accessed by clicking the gear like any other token)
![ddbPortraits](https://user-images.githubusercontent.com/584771/174302656-97f038f6-4393-4a15-aac3-55c8cf06a327.png)

## Hover Text Flyouts
Instead of showing the hover text over the top of the sidebar, they are now displayed in a "flyout" to the left of the sidebar.
<img width="726" alt="Screen_Shot_2022-06-05_at_9 55 41_AM" src="https://user-images.githubusercontent.com/584771/172059479-fb2a5fcd-06e4-41fc-a5df-0f537a5544e6.png">



# Other things to note
### Token Options as a toggle vs select list
1. Global options are a toggle because these are not overriding anything. They are either on or off.
2. On a token definition (My Token, PC, etc.) have select lists because they can override the global settings by setting them to on or off, but we also want to allow them to use the global settings. So the options become "on", "off", or "whatever the global setting is". 
3. Placed tokens are toggles because they are either on or off. Once a token has been placed, those settings have been applied to the token and are essentially "locked" in place. We could change these to select list and just reference other overrides/global, but we don't do that now, and I'm not sure that we should. It would allow changing all placed tokens from square to circle by changing the global setting, but only if you didn't override it anywhere... I think that would feel confusing and disjointed.

