### PR TITLE
Constrain tokens to map #469

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1236,12 +1236,14 @@ class MessageBroker {
 
 		load_scenemap(data.map, data.is_video, data.width, data.height, function() {
 			console.group("load_scenemap callback")
-			var owidth = $("#scene_map").width();
-			var oheight = $("#scene_map").height();
-			if (window.CURRENT_SCENE_DATA.scale_factor) {
-				$("#scene_map").width(owidth * window.CURRENT_SCENE_DATA.scale_factor);
-				$("#scene_map").height(oheight * window.CURRENT_SCENE_DATA.scale_factor);
-			}
+			const scaleFactor = window.CURRENT_SCENE_DATA.scale_factor || 1;
+			// Store current scene width and height
+			window.CURRENT_SCENE_DATA.width = $("#scene_map").width() * scaleFactor;
+			window.CURRENT_SCENE_DATA.height = $("#scene_map").height() * scaleFactor;
+			// Scale map according to scaleFactor
+			$("#scene_map").width(window.CURRENT_SCENE_DATA.width);
+			$("#scene_map").height(window.CURRENT_SCENE_DATA.height);
+			
 			reset_canvas();
 			redraw_fog();
 			redraw_drawings();

--- a/Token.js
+++ b/Token.js
@@ -259,7 +259,6 @@ class Token {
 		// Sets how far tokens are allowed to move outside of the scene
 		const movePadding = this.options.size * this.SCENE_MOVE_GRID_PADDING_MULTIPLIER;
 		// Stop movement if new position is outside of the scene
-		console.warn(this.sceneBoundaries.left - movePadding);
 		if (
 			top  < (this.sceneBoundaries.top - movePadding)    || 
 			top  > (this.sceneBoundaries.bottom + movePadding) ||
@@ -1199,6 +1198,9 @@ class Token {
 				x: 0,
 				y: 0
 			};
+
+			const movePaddingWhileDragging = self.options.size * self.SCENE_MOVE_GRID_PADDING_MULTIPLIER;
+
 			tok.draggable({
 				scroll: false,
 				stop:
@@ -1389,6 +1391,11 @@ class Token {
 					remove_selected_token_bounding_box();
 				},
 
+				/**
+				 * Dragging a token.
+				 * @param {Event} event mouse event
+				 * @param {Object} ui UI-object
+				 */
 				drag: function(event, ui) {
 					event.stopPropagation()
 					var zoom = window.ZOOM;
@@ -1399,6 +1406,11 @@ class Token {
 
 					// this was copied the place function in this file. We should make this a single function to be used in other places
 					let tokenPosition = snap_point_to_grid(tokenX + (window.CURRENT_SCENE_DATA.hpps / 2), tokenY + (window.CURRENT_SCENE_DATA.vpps / 2));
+
+					// Constrain token within scene
+					tokenPosition.x = clamp(tokenPosition.x, self.sceneBoundaries.left - movePaddingWhileDragging, self.sceneBoundaries.right + movePaddingWhileDragging);
+					tokenPosition.y = clamp(tokenPosition.y, self.sceneBoundaries.top - movePaddingWhileDragging, self.sceneBoundaries.bottom + movePaddingWhileDragging);
+
 					ui.position = {
 						left: tokenPosition.x,
 						top: tokenPosition.y


### PR DESCRIPTION
Fixes #469 

Performance on the `Token#drag` method is mediocre, since the token is still moved to the maximum allowed position with each fired event.

I fear that stuff may break if we return out of the `Token#drag` method when we are outside of the scene.

For configuration, I added `Token#SCENE_MOVE_GRID_PADDING_MULTIPLIER` which defines how many grid fields a token can be moved outside of the scene.