### PR TITLE
fix ruler fadeout not clearing temp canvas

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -331,47 +331,7 @@ class WaypointManagerClass {
 	 * redraws the waypoints using various levels of opacity until completely clear
 	 * then removes all waypoints and resets canvas opacity
 	 */
-	 fadeoutMeasuring(){
-		let alpha = 1.0
-		const self = this
-		// only ever allow a single fadeout to occur
-		// this stops weird flashing behaviour with interacting
-		// interval function calls
-		if (this.timerId){
-			return
-		}
-		this.timerId = setInterval(function(){ fadeout() }, 100);
-
-		function fadeout(){
-			self.ctx.clearRect(0,0, self.canvas.width, self.canvas.height);
-			self.ctx.globalAlpha = alpha;
-			self.draw(false)
-			alpha = alpha - 0.2;
-			if (alpha <= 0.0){
-				self.cancelFadeout()
-				self.clearWaypoints();
-				clear_temp_canvas()
-			}
-		}
-	}
-
-	/**
-	 * 
-	 */
-	cancelFadeout(){
-		if (this.timerId !== undefined){
-			clearInterval(this.timerId);
-			this.ctx.globalAlpha = 1.0
-			this.timerId = undefined
-
-		}	
-	}
-
-	/**
-	 * redraws the waypoints using various levels of opacity until completely clear
-	 * then removes all waypoints and resets canvas opacity
-	 */
-	fadeoutMeasuring(){
+	fadeoutMeasuring() {
 		let alpha = 1.0
 		const self = this
 		// only ever allow a single fadeout to occur
@@ -387,9 +347,10 @@ class WaypointManagerClass {
 			self.ctx.globalAlpha = alpha;
 			self.draw(false)
 			alpha = alpha - 0.08;
-			if (alpha <= 0.0){
+			if (alpha <= 0.0) {
 				self.cancelFadeout()
 				self.clearWaypoints();
+				clear_temp_canvas();
 			}
 		}
 	}


### PR DESCRIPTION
Somewhere along the way, these functions were duplicated, and each were updated in different ways. This cleans that up