### PR TITLE
Persist scene list filter through did_update_scenes()

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1575,7 +1575,7 @@ function did_update_scenes() {
 
 	// Filters scene list by search input if scenes-panel is active
 	const sceneSearchInput = $("#scenes-panel.selected-tab input[name='scene-search']");
-	const sceneSearchTerm = sceneSearchInput ? sceneSearchInput.val() : '';
+	const sceneSearchTerm = (sceneSearchInput.length > 0) ? sceneSearchInput.val() : '';
 	redraw_scene_list(sceneSearchTerm);
 }
 

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1517,7 +1517,7 @@ function init_scenes_panel() {
 	scenesPanel.updateHeader("Scenes");
 	add_expand_collapse_buttons_to_header(scenesPanel);
 
-	let searchInput = $(`<input name="scene-search" type="text" style="width:96%;margin:2%" placeholder="search scenes">`);
+	let searchInput = $(`<input name="scene-search" type="search" style="width:96%;margin:2%" placeholder="search scenes">`);
 	searchInput.off("input").on("input", mydebounce(() => {
 		let textValue = scenesPanel.header.find("input[name='scene-search']").val();
 		redraw_scene_list(textValue);
@@ -1567,9 +1567,16 @@ function init_scenes_panel() {
 	}, 5000); // do better than this... or don't, it probably doesn't matter
 }
 
+/**
+ * Updates and redraws the scene list in the sidebar
+ */
 function did_update_scenes() {
 	rebuild_scene_items_list();
-	redraw_scene_list("");
+
+	// Filters scene list by search input if scenes-panel is active
+	const sceneSearchInput = $("#scenes-panel.selected-tab input[name='scene-search']");
+	const sceneSearchTerm = sceneSearchInput ? sceneSearchInput.val() : '';
+	redraw_scene_list(sceneSearchTerm);
 }
 
 function rebuild_scene_items_list() {


### PR DESCRIPTION
It looks up the search value when the `did_update_scenes()` is called and filters the list if the scenes tab is active in the sidebar.

I also changed the input type to `search`, which will add a little 'x' to the right of the search box to clear the content.
This is a browser specific feature, but has over [97% browser support](https://caniuse.com/input-search).

This fixes https://discord.com/channels/815028457851191326/815028804103307354/988454588636078150