### PR TITLE
Add option to Group Tokens in Right-click menu

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -59,7 +59,7 @@ class WaypointManagerClass {
 			backgroundColor: "rgba(255, 255, 255, 0.7)"
 		}
 	}
-	
+
 	resetDefaultDrawStyle(){
 		this.drawStyle = {
 			lineWidth: Math.max(25 * Math.max((1 - window.ZOOM), 0), 5),
@@ -322,7 +322,7 @@ class WaypointManagerClass {
 		this.ctx.fillStyle = this.drawStyle.textColor
 		this.ctx.textBaseline = 'top';
 		this.ctx.fillText(text, textX, textY);
-		
+
 		this.drawBobble(snapPointXStart, snapPointYStart);
 		this.drawBobble(snapPointXEnd, snapPointYEnd);
 	}
@@ -356,7 +356,7 @@ class WaypointManagerClass {
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	cancelFadeout(){
 		if (this.timerId !== undefined){
@@ -364,7 +364,7 @@ class WaypointManagerClass {
 			this.ctx.globalAlpha = 1.0
 			this.timerId = undefined
 
-		}	
+		}
 	}
 
 	/**
@@ -381,7 +381,7 @@ class WaypointManagerClass {
 			return
 		}
 		this.timerId = setInterval(function(){ fadeout() }, 100);
-		
+
 		function fadeout(){
 			self.ctx.clearRect(0,0, self.canvas.width, self.canvas.height);
 			self.ctx.globalAlpha = alpha;
@@ -395,7 +395,7 @@ class WaypointManagerClass {
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	cancelFadeout(){
 		if (this.timerId !== undefined){
@@ -403,7 +403,7 @@ class WaypointManagerClass {
 			this.ctx.globalAlpha = 1.0
 			this.timerId = undefined
 
-		}	
+		}
 	}
 };
 
@@ -460,12 +460,12 @@ function do_check_token_visibility() {
 		var selector = "div[data-id='" + id + "']";
 		let auraSelector = ".aura-element[id='aura_" + auraSelectorId + "']";
 		if (pixeldata[3] == 255) {
-			
+
 			$(selector).hide();
 			if(window.TOKEN_OBJECTS[id].options.hideaurafog)
 			{
 					$(auraSelector).hide();
-			}			
+			}
 		}
 		else if (!window.TOKEN_OBJECTS[id].options.hidden) {
 			$(selector).show();
@@ -571,7 +571,7 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 	startX = Math.round(startX)
 	startY = Math.round(startY)
 	const incrementX = hpps || window.CURRENT_SCENE_DATA.hpps;
-	const incrementY = vpps || window.CURRENT_SCENE_DATA.vpps; 
+	const incrementY = vpps || window.CURRENT_SCENE_DATA.vpps;
 	gridContext.lineWidth = lineWidth || window.CURRENT_SCENE_DATA.grid_line_width;
 	gridContext.strokeStyle = color || window.CURRENT_SCENE_DATA.grid_color;
 	let isSubdivided = subdivide === "1" || window.CURRENT_SCENE_DATA.grid_subdivided === "1"
@@ -608,7 +608,7 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 }
 
 function draw_wizarding_box() {
-	
+
 	var gridCanvas = document.getElementById("grid_overlay");
 	var gridContext = gridCanvas.getContext("2d");
 	gridCanvas.width = $("#scene_map").width();
@@ -856,10 +856,10 @@ function get_event_cursor_position(event){
 }
 
 /**
- * Pulls information from menu's or buttons without menu's to set values used by 
+ * Pulls information from menu's or buttons without menu's to set values used by
  * drawing mousemove, mousedown, mousecontext events
- * @param {Event} e 
- * @returns 
+ * @param {Event} e
+ * @returns
  */
 function drawing_mousedown(e) {
 	// perform some cleanup of the canvas/objects
@@ -878,7 +878,7 @@ function drawing_mousedown(e) {
 	context.setLineDash([])
 	// get teh data from the menu's/buttons
 	const data = get_draw_data(e.data.clicked,  e.data.menu)
-	
+
 	// these are generic values used by most drawing functionality
 	window.LINEWIDTH = data.draw_line_width
 	window.DRAWTYPE = data.fill
@@ -903,7 +903,7 @@ function drawing_mousedown(e) {
 		context.setLineDash([10, 5])
 		if (e.which == 1) {
 			$("#temp_overlay").css('cursor', 'crosshair');
-		}		
+		}
 	}
 	// figure out what these 3 returns are supposed to be for.
 	if ($(".context-menu-list.context-menu-root ~ .context-menu-list.context-menu-root:visible, .body-rpgcharacter-sheet .context-menu-list.context-menu-root").length>0){
@@ -920,7 +920,7 @@ function drawing_mousedown(e) {
 	}
 	// end of wtf is this return block doing?
 	const [pointX, pointY] = get_event_cursor_position(e)
-	
+
 	if(window.DRAWSHAPE === "brush"){
 		window.BEGIN_MOUSEX = pointX
 		window.BEGIN_MOUSEY = pointY
@@ -963,7 +963,7 @@ function drawing_mousedown(e) {
 			window.DRAWTYPE === "filled" ? 1 : window.LINEWIDTH,
 		);
 		drawClosingArea(context, window.BEGIN_MOUSEX[0], window.BEGIN_MOUSEY[0]);
-		
+
 	}
 	else if (window.DRAWFUNCTION === "draw_text"){
 		window.BEGIN_MOUSEX = e.clientX;
@@ -984,12 +984,12 @@ function drawing_mousedown(e) {
 
 /**
  * Draws the respective shape from window.DRAWSHAPE onto the screen
- * 
- * @param {Event} e 
- * @returns 
+ *
+ * @param {Event} e
+ * @returns
  */
 function drawing_mousemove(e) {
-	
+
 	if (window.MOUSEMOVEWAIT) {
 		return;
 	}
@@ -1005,7 +1005,7 @@ function drawing_mousemove(e) {
 	const isFilled = window.DRAWTYPE === "filled"
 	const mouseMoveFps = Math.round((1000.0 / 16.0));
 
-	
+
 	window.MOUSEMOVEWAIT = true;
 	setTimeout(function() {
 		window.MOUSEMOVEWAIT = false;
@@ -1070,12 +1070,12 @@ function drawing_mousemove(e) {
 		}
 		else if (window.DRAWSHAPE == "cone") {
 			drawCone(context,
-				     window.BEGIN_MOUSEX, 
-					 window.BEGIN_MOUSEY, 
-					 mouseX, 
-					 mouseY, 
-					 window.DRAWCOLOR, 
-					 isFilled, 
+				     window.BEGIN_MOUSEX,
+					 window.BEGIN_MOUSEY,
+					 mouseX,
+					 mouseY,
+					 window.DRAWCOLOR,
+					 isFilled,
 					 window.LINEWIDTH);
 		}
 		else if (window.DRAWSHAPE == "line") {
@@ -1090,14 +1090,14 @@ function drawing_mousemove(e) {
 				}
 			}else{
 				drawLine(context,
-					window.BEGIN_MOUSEX, 
-					window.BEGIN_MOUSEY, 
-					mouseX, 
-					mouseY, 
-					window.DRAWCOLOR, 
+					window.BEGIN_MOUSEX,
+					window.BEGIN_MOUSEY,
+					mouseX,
+					mouseY,
+					window.DRAWCOLOR,
 					window.LINEWIDTH);
 			}
-			
+
 		}
 		else if (window.DRAWSHAPE == "brush"){
 			// Only add a new point every 75ms to keep the drawing size low
@@ -1142,8 +1142,8 @@ function drawing_mousemove(e) {
 /**
  * Drawing finished (most of the time) set the final shape into window.DRAWING/windo.REVEAL
  * then call redraw functions and sync functions
- * @param {Event} e 
- * @returns 
+ * @param {Event} e
+ * @returns
  */
 function drawing_mouseup(e) {
 	// ignore this if we're dragging a token
@@ -1161,9 +1161,9 @@ function drawing_mouseup(e) {
 	}
 	// ignore if right mouse buttons for the following
 	if((window.DRAWFUNCTION == "draw" ||
-		window.DRAWFUNCTION == "reveal" || 
-		window.DRAWFUNCTION == "hide" || 
-		window.DRAWFUNCTION == "draw_text" || 
+		window.DRAWFUNCTION == "reveal" ||
+		window.DRAWFUNCTION == "hide" ||
+		window.DRAWFUNCTION == "draw_text" ||
 		window.DRAWFUNCTION === "select") && e.which !== 1)
 	{
 		return;
@@ -1184,7 +1184,7 @@ function drawing_mouseup(e) {
 	if (window.DRAWFUNCTION === 'select') {
 		$("#temp_overlay").css('cursor', '');
 	}
-	
+
 	window.MOUSEDOWN = false;
 	const width = mouseX - window.BEGIN_MOUSEX;
 	const height = mouseY - window.BEGIN_MOUSEY;
@@ -1275,7 +1275,7 @@ function drawing_mouseup(e) {
 	else if (window.DRAWFUNCTION == "hide" || window.DRAWFUNCTION == "reveal"){
 		finalise_drawing_fog(mouseX, mouseY, width, height)
 	}
-	
+
 	else if (window.DRAWFUNCTION == "select") {
 		// FIND TOKENS INSIDE THE AREA
 		var c = 0;
@@ -1292,11 +1292,12 @@ function drawing_mouseup(e) {
 			if (window.DM || !curr.options.hidden) {
 				let tokenDiv = $("#tokens>div[data-id='" + curr.options.id + "']")
 				if(tokenDiv.css("pointer-events")!="none" && tokenDiv.css("display")!="none" && !tokenDiv.hasClass("ui-draggable-disabled")) {
-					curr.selected = true;
-					curr.place();
+					curr.get_grouped_tokens().forEach(token => {
+						token.selected = true;
+						token.place();
+					});
 				}
 			}
-			
 		}
 
 		window.MULTIPLE_TOKEN_SELECTED = (c > 1);
@@ -1308,7 +1309,7 @@ function drawing_mouseup(e) {
 	else if (window.DRAWFUNCTION == "measure") {
 		WaypointManager.fadeoutMeasuring()
 	}
-	
+
 }
 
 function drawing_contextmenu(e) {
@@ -1404,7 +1405,7 @@ function deselect_all_top_buttons(buttonSelectedClasses) {
 
 /**
  * Gets the relevant draw information from the button and menu provided
- * 
+ *
  * @param {$} button the selected button when the user clicks on the canvas
  * @param {$} menuSelector the open menu if it exists
  * @returns {Object} draw data, containing at least "shape" and "function", optionally "frommenu"
@@ -1488,11 +1489,11 @@ function handle_drawing_button_click() {
 			}
 			// toggle the button off...
 			if($(clicked).hasClass("menu-option")){
-				// but only toggled on or off if they're not a unique-with which must always have 
+				// but only toggled on or off if they're not a unique-with which must always have
 				// 1 option selected
 				if(!$(clicked).attr("data-unique-with")){
 					$(clicked).removeClass(`${buttonSelectedClasses}`)
-				}			
+				}
 			}
 		}else{
 			// unselect any matching unique-with buttons
@@ -1526,7 +1527,7 @@ function handle_drawing_button_click() {
 		target.on('mouseup',  data, drawing_mouseup);
 		target.on('mousemove', data, drawing_mousemove);
 		target.on('contextmenu', data, drawing_contextmenu);
-		
+
 	})
 	// during initialisation of VTT default to the select button
 	$('#select-button').click();
@@ -1545,7 +1546,7 @@ function drawCircle(ctx, centerX, centerY, radius, style, fill=true, lineWidth =
 		ctx.lineWidth = lineWidth;
 		ctx.stroke();
 	}
-	
+
 }
 
 function drawRect(ctx, startx, starty, width, height, style, fill=true, lineWidth = 6)
@@ -1564,7 +1565,7 @@ function drawRect(ctx, startx, starty, width, height, style, fill=true, lineWidt
 		ctx.rect(startx, starty, width, height);
 		ctx.stroke();
 	}
-	
+
 }
 
 function drawCone(ctx, startx, starty, endx, endy, style, fill=true, lineWidth = 6)
@@ -1586,7 +1587,7 @@ function drawCone(ctx, startx, starty, endx, endy, style, fill=true, lineWidth =
 		ctx.strokeStyle = style;
 		ctx.stroke();
 	}
-	
+
 }
 
 function drawLine(ctx, startx, starty, endx, endy, style, lineWidth = 6)
@@ -1663,7 +1664,7 @@ function drawPolygon (
 		ctx.strokeStyle = style;
 		ctx.stroke();
 	}
-	
+
 }
 
 function clear_temp_canvas(){
@@ -1708,7 +1709,7 @@ function savePolygon(e) {
 		redraw_drawings();
 	}
 	clear_temp_canvas()
-	
+
 	window.ScenesHandler.persist();
 
 	if(window.CLOUD){
@@ -1717,7 +1718,7 @@ function savePolygon(e) {
 		}
 		else{
 			sync_fog();
-		}			
+		}
 	}
 	else{
 		window.MB.sendMessage(
@@ -1785,24 +1786,24 @@ function drawClosingArea(ctx, pointX, pointY) {
 }
 
 function init_fog_menu(buttons){
-	
+
 
 
 	fog_menu = $("<div id='fog_menu' class='top_menu'></div>");
 	fog_menu.append("<div class='menu-subtitle' data-skip='true'>Reveal</div>");
 	fog_menu.append(
-		`<div class='ddbc-tab-options--layout-pill'> 
+		`<div class='ddbc-tab-options--layout-pill'>
 			<button id='fog_square_r' class='ddbc-tab-options__header-heading drawbutton menu-option fog-option button-enabled ddbc-tab-options__header-heading--is-active'
-				data-shape='rect' data-function="reveal" data-unique-with="fog" > 
-					Square 
-			</button> 
+				data-shape='rect' data-function="reveal" data-unique-with="fog" >
+					Square
+			</button>
 		</div>`);
 	fog_menu.append(
-		`<div class='ddbc-tab-options--layout-pill'> 
+		`<div class='ddbc-tab-options--layout-pill'>
 			<button id='fog_circle_r' class='ddbc-tab-options__header-heading drawbutton menu-option fog-option'
-				data-shape='arc' data-function="reveal" data-unique-with="fog" > 
-					Circle 
-				</button> 
+				data-shape='arc' data-function="reveal" data-unique-with="fog" >
+					Circle
+				</button>
 			</div>`);
 	fog_menu.append(
 		`<div class='ddbc-tab-options--layout-pill'>
@@ -1945,7 +1946,7 @@ function init_draw_menu(buttons){
 				 	Polygon
 			</button>
 		</div>`);
-	
+
 
 	draw_menu.append(`
         <input title='Background color' data-required="background_color" class='spectrum'
@@ -1970,7 +1971,7 @@ function init_draw_menu(buttons){
 	colorPickers.on('change.spectrum', colorPickerChange); // commit the changes when the user clicks the submit button
 	colorPickers.on('hide.spectrum', colorPickerChange);   // the hide event includes the original color so let's change it back when we get it
 
-	
+
 	draw_menu.append("<div class='menu-subtitle' data-skip='true'>Type</div>");
 	draw_menu.append(
 		`<div class='ddbc-tab-options--layout-pill'>
@@ -2051,5 +2052,5 @@ function init_draw_menu(buttons){
 	draw_button = $("<button style='display:inline;width:75px' id='draw_button' class='drawbutton menu-button hideable ddbc-tab-options__header-heading'><u>D</u>RAW</button>");
 
 	buttons.append(draw_button);
-	draw_menu.css("left",draw_button.position().left);	
+	draw_menu.css("left",draw_button.position().left);
 }

--- a/Fog.js
+++ b/Fog.js
@@ -1298,6 +1298,7 @@ function drawing_mouseup(e) {
 					});
 				}
 			}
+			
 		}
 
 		window.MULTIPLE_TOKEN_SELECTED = (c > 1);

--- a/Token.js
+++ b/Token.js
@@ -6,13 +6,13 @@ const CUSTOM_CONDITIONS = ["Concentration(Reminder)", "Flying", "Flamed", "Rage"
 
 /*const TOKEN_COLORS=  [
 	"D1BBD7","882E72","5289C7","4EB265","CAEOAB","F6C141","E8601C","777777","AE76A3","1965BO","7BAFDE","90C987","F7F056","F1932D","DC050C",
-	"FF0000", "00FF00", "0000FF", "FFFF00", "FF00FF", "00FFFF", 
-		"800000", "008000", "000080", "808000", "800080", "008080", "808080", 
-		"C00000", "00C000", "0000C0", "C0C000", "C000C0", "00C0C0", "C0C0C0", 
-		"400000", "004000", "000040", "404000", "400040", "004040", "404040", 
-		"200000", "002000", "000020", "202000", "200020", "002020", "202020", 
-		"600000", "006000", "000060", "606000", "600060", "006060", "606060", 
-		"A00000", "00A000", "0000A0", "A0A000", "A000A0", "00A0A0", "A0A0A0", 
+	"FF0000", "00FF00", "0000FF", "FFFF00", "FF00FF", "00FFFF",
+		"800000", "008000", "000080", "808000", "800080", "008080", "808080",
+		"C00000", "00C000", "0000C0", "C0C000", "C000C0", "00C0C0", "C0C0C0",
+		"400000", "004000", "000040", "404000", "400040", "004040", "404040",
+		"200000", "002000", "000020", "202000", "200020", "002020", "202020",
+		"600000", "006000", "000060", "606000", "600060", "006060", "606060",
+		"A00000", "00A000", "0000A0", "A0A000", "A000A0", "00A0A0", "A0A0A0",
 		"E00000", "00E000", "0000E0", "E0E000", "E000E0", "00E0E0", "E0E0E0", "000000"];*/
 
 // const TOKEN_COLORS = ["8DB6C7","","D1C6BF","CA9F92","","E3D9BO","B1C27A","B2E289","51COBF","59ADDO","","9FA3E3","099304","DB8DB2","F1C3DO"];
@@ -38,7 +38,7 @@ class Token {
 		this.persist = null;
 		if(window.CLOUD)
 			this.persist= ()=>{};
-		
+
 		this.doing_highlight = false;
 		if (typeof this.options.size == "undefined") {
 			this.options.size = window.CURRENT_SCENE_DATA.hpps; // one grid square
@@ -113,7 +113,7 @@ class Token {
 	        this.options.custom_conditions.push(conditionName);
 	    }
 	}
-	
+
 	removeCondition(conditionName) {
 		if (STANDARD_CONDITIONS.includes(conditionName)) {
 			if (this.isPlayer()) {
@@ -199,20 +199,20 @@ class Token {
 		if (window.DM && this.options.locked) return; // don't allow rotating if the token is locked
 		this.update_from_page();
 		this.options.rotation = newRotation;
-		// this is copied from the place() function. Rather than calling place() every time the draggable.drag function executes, 
+		// this is copied from the place() function. Rather than calling place() every time the draggable.drag function executes,
 		// this just rotates locally to help with performance.
-		// draggable.stop will call place_sync_persist to finalize the rotation. 
+		// draggable.stop will call place_sync_persist to finalize the rotation.
 		// If we ever want this to send to all players in real time, simply comment out the rest of this function and call place_sync_persist() instead.
 		let scale = this.get_token_scale();
 		if(this.options.imageSize === undefined) {
-			this.imageSize(1) 
+			this.imageSize(1)
 		}
 		let imageScale = this.options.imageSize;
 
 		var selector = "div[data-id='" + this.options.id + "']";
 		var tokenElement = $("#tokens").find(selector);
-		
-		tokenElement.children("img").css("transform", "scale(" + imageScale + ") rotate(" + newRotation + "deg)");	
+
+		tokenElement.children("img").css("transform", "scale(" + imageScale + ") rotate(" + newRotation + "deg)");
 	}
 	moveUp() {
 		let newTop = `${parseFloat(this.options.top) - parseFloat(window.CURRENT_SCENE_DATA.vpps)}px`;
@@ -247,7 +247,7 @@ class Token {
 		if (window.DM && this.options.locked) return; // don't allow moving if the token is locked
 		// shamelessly copied from the draggable code later in this file
 		// this should be a XOR... (A AND !B) OR (!A AND B)
-		let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);		
+		let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);
 		if (shallwesnap) {
 			// calculate offset in real coordinates
 			const startX = window.CURRENT_SCENE_DATA.offsetx;
@@ -255,7 +255,7 @@ class Token {
 
 			const selectedOldTop = parseInt(this.options.top);
 			const selectedOldleft = parseInt(this.options.left);
-			
+
 			const selectedNewtop =  Math.round(Math.round( (selectedOldTop - startY) / window.CURRENT_SCENE_DATA.vpps)) * window.CURRENT_SCENE_DATA.vpps + startY;
 			const selectedNewleft = Math.round(Math.round( (selectedOldleft - startX) / window.CURRENT_SCENE_DATA.hpps)) * window.CURRENT_SCENE_DATA.hpps + startX;
 
@@ -266,7 +266,7 @@ class Token {
 			this.options.top = `${selectedNewtop}px`;
 			this.options.left = `${selectedNewleft}px`;
 			this.place_sync_persist();
-		}		
+		}
 	}
 	place_sync_persist() {
 		this.place();
@@ -290,7 +290,7 @@ class Token {
 			var pageX = Math.round(parseInt(this.options.left) * window.ZOOM - ($(window).width() / 2));
 			var pageY = Math.round(parseInt(this.options.top) * window.ZOOM - ($(window).height() / 2));
 			console.log(this.options.left + " " + this.options.top + "->" + pageX + " " + pageY);
-			
+
 			if(!dontscroll){
 			$("html,body").animate({
 				scrollTop: pageY + 200,
@@ -344,7 +344,7 @@ class Token {
 		let tokenData = this.munge_token_data()
 		if(tokenData.max_hp > 0){
 			// add a cross if it doesn't exist
-			if(token.find(".dead").length === 0) 
+			if(token.find(".dead").length === 0)
 				token.prepend(`<div class="dead" hidden></div>`);
 			// update cross scale
 			const deadCross = token.find('.dead')
@@ -381,7 +381,7 @@ class Token {
 		if (tokenData.max_hp > 0) {
 		 	var tokenHpAuraColor = token_health_aura(
 				Math.round((tokenData.hp / tokenData.max_hp) * 100)
-			);	
+			);
 		}
 		token.css('--hp-percentage', Math.round((tokenData.hp / tokenData.max_hp) * 100) + "%");
 
@@ -389,11 +389,11 @@ class Token {
 
 		let tokenWidth = this.options.size;
 		let tokenHeight = this.options.size;
-			
+
 		if(tokenData.disableaura || !tokenData.hp || !tokenData.max_hp) {
 			token.css('--token-hp-aura-color', 'transparent');
 			token.css('--token-temp-hp', "transparent");
-		} 
+		}
 		else {
 			tokenWidth = tokenWidth - 10;
 			tokenHeight = tokenHeight - 10;
@@ -408,7 +408,7 @@ class Token {
 		if(tokenData.disableborder) {
 			token.css('--token-border-color', 'transparent');
 			$("token:before").css('--token-border-color', 'transparent');
-		} 
+		}
 		else {
 			tokenWidth = tokenWidth - 4;
 			tokenHeight = tokenHeight - 4;
@@ -448,7 +448,7 @@ class Token {
 						token.children('.token-image').css("min-height", tokenHeight + 'px');
 						token.children('.token-image').css("min-width", '');
 					}
-									
+
 				}
 			}
 		}
@@ -456,8 +456,8 @@ class Token {
 			token.children('.token-image').css("min-width", "");
 			token.children('.token-image').css("min-height", "");
 		}
-		
-		token.children('.token-image').css({		
+
+		token.children('.token-image').css({
 		    'max-width': tokenWidth + 'px',
 			'max-height': tokenHeight + 'px',
 		});
@@ -471,7 +471,7 @@ class Token {
 			};
 			window.MB.inject_chat(msgdata);
 		}
-		
+
 		console.groupEnd()
 	}
 
@@ -503,7 +503,7 @@ class Token {
 			this.options.hidden = true;
 		else
 			delete this.options.hidden;
-		
+
 		// one of either
 		// is a monster?
 		// is the DM
@@ -519,7 +519,7 @@ class Token {
 			$("input").blur();
 			this.options.hp = old.find(".hp").val();
 			this.options.max_hp = old.find(".max_hp").val();
-			
+
 			this.update_dead_cross(old)
 			this.update_health_aura(old)
 		}
@@ -550,12 +550,12 @@ class Token {
 		if((!window.DM && this.options.hidestat == true) || this.options.disablestat == true) {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'hidden');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'hidden');
-		}	
+		}
 		else {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'visible');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'visible');
 		}
-		
+
 		if (this.options.hidden == false || typeof this.options.hidden == 'undefined'){
 			console.log("Setting combat tracker opacity to 1.0")
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").find('img').css('opacity','1.0');
@@ -775,13 +775,13 @@ class Token {
 			array_remove_index_by_value(this.options.custom_conditions, "Inspiration");
 			array_remove_index_by_value(this.options.custom_conditions, "Inspiration");
 		}
-		
-		
+
+
 		const conditionsTotal = this.options.conditions.length + this.options.custom_conditions.length + (this.options.id in window.JOURNAL.notes && (window.DM || window.JOURNAL.notes[this.options.id].player));
 
 		if (conditionsTotal > 0) {
 			let conditionCount = 0;
-			
+
 			for (let i = 0; i < this.options.conditions.length; i++) {
 				const conditionName = this.options.conditions[i];
 				const isExhaustion = conditionName.startsWith("Exhaustion");
@@ -841,7 +841,7 @@ class Token {
 						cond.append(conditionContainer);
 					}
 				}
-				
+
 				conditionCount++;
 			}
 			// CHECK IF ADDING NOTE CONDITION
@@ -870,8 +870,8 @@ class Token {
 			}
 
 		}
-				
-		
+
+
 		if (parent) {
 			parent.find(".conditions").remove();
 			parent.append(cond);
@@ -883,7 +883,7 @@ class Token {
 	}
 
 	place(animationDuration) {
-		
+
 		if(!window.CURRENT_SCENE_DATA){
 			// No scene loaded!
 			return;
@@ -906,13 +906,13 @@ class Token {
 			console.log("trovato!!");
 
 			if (old.css("left") != this.options.left || old.css("top") != this.options.top)
-				
+
 				remove_selected_token_bounding_box();
 				if(old.is(':animated')){
 					// this token is being moved quickly, speed up the animation
 					animationDuration = 100;
 				}
-				
+
 				old.animate(
 					{
 						left: this.options.left,
@@ -920,7 +920,7 @@ class Token {
 					}, { duration: animationDuration, queue: true, complete: function() {
 						draw_selected_token_bounding_box();
 					} });
-				
+
 
 
 
@@ -932,16 +932,16 @@ class Token {
 			}
 			old.find("img").css("transition", "max-height 0.2s linear, max-width 0.2s linear, transform 0.2s linear")
 			old.find("img").css("transform", "scale(" + imageScale + ") rotate("+rotation+"deg)");
-	
+
 			setTimeout(function() {old.find("img").css("transition", "")}, 200);
-			
+
 			if (old.attr('name') != this.options.name) {
 				var selector = "tr[data-target='"+this.options.id+"']";
 				var entry = $("#combat_area").find(selector);
 				if (old.addClass('hasTooltip') && (!(this.options.name) || !(this.options.revealname))) {
 					old.removeClass('hasTooltip');
 						entry.removeClass("hasTooltip");
-				}	
+				}
 				if (this.options.name) {
 					if ((window.DM || !this.options.monster || this.options.revealname)) {
 						old.attr("data-name", this.options.name);
@@ -966,7 +966,7 @@ class Token {
 					width: this.options.size,
 					height: this.options.size
 				}, { duration: 1000, queue: false });
-				
+
 				var zindexdiff=(typeof this.options.zindexdiff == 'number') ? this.options.zindexdiff : Math.round(17/ (this.options.size/window.CURRENT_SCENE_DATA.hpps));
 				this.options.zindexdiff = Math.max(zindexdiff, -5000);
 				old.css("z-index", "calc(5000 + var(--z-index-diff))");
@@ -1002,21 +1002,21 @@ class Token {
 				old.css("border", "");
 				old.removeClass("tokenselected");
 			}
-			
+
 			if(old.find("img").attr("src")!=this.options.imgsrc){
 				old.find("img").attr("src",this.options.imgsrc);
 			}
-		
+
 			if(this.options.disableborder){
 				old.find("img").css("border-width","0");
 			}
-			
+
 			setTokenAuras(old, this.options);
 
 			if(!(this.options.square) && !(old.find("img").hasClass('token-round'))){
 				old.find("img").addClass("token-round");
 			}
-			
+
 			if(old.find("img").hasClass('token-round') && (this.options.square) ){
 				old.find("img").removeClass("token-round");
 			}
@@ -1027,7 +1027,7 @@ class Token {
 			}
 			else if((window.DM && this.options.restrictPlayerMove) || !this.options.locked){
 				old.draggable("enable");
-			}	
+			}
 			else if(!window.DM && (!this.options.restrictPlayerMove || !this.options.locked)){
 				old.draggable("enable");
 			}
@@ -1058,7 +1058,7 @@ class Token {
 			var hpbar = $("<input class='hpbar'>");
 			let scale = this.get_token_scale()
 			let imageScale = this.options.imageSize;
-			
+
 			var bar_height = Math.floor(this.options.size * 0.2);
 
 			if (bar_height > 60)
@@ -1085,7 +1085,7 @@ class Token {
 			var zindexdiff=(typeof this.options.zindexdiff == 'number') ? this.options.zindexdiff : Math.round(17/ (this.options.size/window.CURRENT_SCENE_DATA.hpps));
 			this.options.zindexdiff = Math.max(zindexdiff, -5000);
 			console.log("Diff: "+zindexdiff);
-			
+
 			tok.css("z-index", "calc(5000 + var(--z-index-diff))");
 			tok.width(this.options.size);
 			tok.height(this.options.size);
@@ -1098,7 +1098,7 @@ class Token {
 			tokimg.attr("src", this.options.imgsrc);
 			tokimg.css("max-height", this.options.size);
 			tokimg.css("max-width", this.options.size);
-		
+
 
 			tok.addClass("VTTToken");
 
@@ -1106,7 +1106,7 @@ class Token {
 
 			if(this.options.disableborder)
 				tokimg.css("border-width","0");
-				
+
 			tok.css("position", "absolute");
 			tok.css("--z-index-diff", zindexdiff);
 			tok.css("top", this.options.top);
@@ -1145,7 +1145,7 @@ class Token {
 				tok.append(cond_bar);
 			});
 
-			
+
 
 
 			$("#tokens").append(tok);
@@ -1153,7 +1153,7 @@ class Token {
 				opacity: newopacity
 			}, { duration: 500, queue: false });
 
-			
+
 			setTokenAuras(tok, this.options);
 
 			let click = {
@@ -1174,11 +1174,11 @@ class Token {
 						tok.removeAttr("data-dragging")
 						tok.removeAttr("data-drag-x")
 						tok.removeAttr("data-drag-y")
-			
+
 						// this should be a XOR... (A AND !B) OR (!A AND B)
 						let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);
 						console.log("shallwesnap",shallwesnap);
-						console.log("toggleSnap",window.toggleSnap);					
+						console.log("toggleSnap",window.toggleSnap);
 						if (shallwesnap) {
 
 							// calculate offset in real coordinates
@@ -1187,7 +1187,7 @@ class Token {
 
 							const selectedOldTop = parseInt($(event.target).css("top"));
 							const selectedOldleft = parseInt($(event.target).css("left"));
-							
+
 
 							const selectedNewtop =  Math.round(Math.round( (selectedOldTop - startY) / window.CURRENT_SCENE_DATA.vpps)) * window.CURRENT_SCENE_DATA.vpps + startY;
 							const selectedNewleft = Math.round(Math.round( (selectedOldleft - startX) / window.CURRENT_SCENE_DATA.hpps)) * window.CURRENT_SCENE_DATA.hpps + startX;
@@ -1250,7 +1250,7 @@ class Token {
 						}
 
 						window.DRAGGING = false;
-						
+
 						self.update_and_sync(event);
 						if (self.selected) {
 							for (id in window.TOKEN_OBJECTS) {
@@ -1285,9 +1285,9 @@ class Token {
 					if(tok.is(":animated")){
 						self.stopAnimation();
 					}
-					
+
 					// for dragging behind iframes so tokens don't "jump" when you move past it
-					$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));			
+					$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));
 					$("#sheet").append($('<div class="iframeResizeCover"></div>'));
 
 					console.log("Click x: " + click.x + " y: " + click.y);
@@ -1315,9 +1315,9 @@ class Token {
 								}
 							}
 
-						}												
+						}
 					}
-					
+
 
 					const el = $("#aura_" + self.options.id.replaceAll("/", ""));
 					if (el.length > 0) {
@@ -1382,7 +1382,7 @@ class Token {
 								context.setLineDash([])
 								// list the temp overlay so we can see the ruler
 								clear_temp_canvas()
-								
+
 								WaypointManager.setCanvas(canvas);
 								WaypointManager.registerMouseMove(tokenMidX, tokenMidY);
 								WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, tokenMidX, tokenMidY);
@@ -1397,7 +1397,7 @@ class Token {
 					currentTokenPosition.y = tokenPosition.y;
 
 					//console.log("Changing to " +ui.position.left+ " "+ui.position.top);
-					// HACK TEST 
+					// HACK TEST
 					/*$(event.target).css("left",ui.position.left);
 					$(event.target).css("top",ui.position.top);*/
 					// END OF HACK TEST
@@ -1441,7 +1441,7 @@ class Token {
 									selEl.css('top', (currTop + offsetTop) + "px");
 								}
 							}
-						}													
+						}
 					}
 
 				}
@@ -1475,26 +1475,50 @@ class Token {
 				if (shiftHeld == false) {
 					deselect_all_tokens();
 				}
-				if (thisSelected == true) {
-					parentToken.addClass('tokenselected');
-					toggle_player_selectable(window.TOKEN_OBJECTS[tokID], parentToken)
-				} else {
-					parentToken.removeClass('tokenselected');
-				}				
 
-				window.TOKEN_OBJECTS[tokID].selected = thisSelected;
+				// get the tokens that share a group with this one
+				let groupTokens = [];
+				let currentToken = window.TOKEN_OBJECTS[tokID];
+				let groupId = currentToken.options.group_id;
+				console.log(`Group ID ${groupId}`);
+				if (groupId) {
+					for (const tokenId in window.TOKEN_OBJECTS) {
+						if (window.TOKEN_OBJECTS[tokenId].options.group_id == groupId) {
+							groupTokens.push(window.TOKEN_OBJECTS[tokenId]);
+							console.log(`Pushing id ${tokenId}`);
+						}
+					}
+				} else {
+					groupTokens.push(window.TOKEN_OBJECTS[tokID]);
+				}
+				if (thisSelected == true) {
+					groupTokens.forEach(token => {
+						let currentParentToken = $("#tokens").find("div[data-id='" + token.options.id + "']");
+						console.log(currentParentToken);
+						currentParentToken.addClass('tokenselected');
+						toggle_player_selectable(token, currentParentToken);
+					});
+				} else {
+					groupTokens.forEach(token => {
+						let currentParentToken = $("#tokens").find("div[data-id='" + token.options.id + "']");
+						console.log(currentParentToken);
+						currentParentToken.removeClass('tokenselected');
+					});
+				}
+
+				groupTokens.forEach(token => token.selected = thisSelected);
 
 				for (var id in window.TOKEN_OBJECTS) {
 					var curr = window.TOKEN_OBJECTS[id];
 					if (curr.selected == true) {
 						count++;
-					}			
+					}
 				}
 
 				window.MULTIPLE_TOKEN_SELECTED = (count > 1);
 				draw_selected_token_bounding_box(); // update rotation bounding box
 			});
-			
+
 			console.groupEnd()
 		}
 		// HEALTH AURA / DEAD CROSS
@@ -1536,7 +1560,7 @@ class Token {
 		}
 		return storedValue;
 	}
-	
+
 }
 
 /**
@@ -1731,7 +1755,7 @@ function place_token_at_map_point(tokenObject, x, y) {
 	}
 	window.MB.sendMessage('custom/myVTT/token', options);
 
-	
+
 	fetch_and_cache_scene_monster_items();
 	update_pc_token_rows();
 }
@@ -1878,7 +1902,7 @@ function setTokenAuras (token, options) {
 							`;
 		const tokenId = token.attr("data-id").replaceAll("/", "");
 		if (token.parent().parent().find("#aura_" + tokenId).length > 0) {
-			token.parent().parent().find("#aura_" + tokenId).attr("style", auraStyles);	
+			token.parent().parent().find("#aura_" + tokenId).attr("style", auraStyles);
 		} else {
 			const auraElement = $(`<div class='aura-element' id="aura_${tokenId}" style='${auraStyles}' />`);
 			auraElement.contextmenu(function(){return false;});
@@ -1896,8 +1920,8 @@ function setTokenAuras (token, options) {
 			$("[id='aura_" + tokenId + "'] > [id='aura_" + tokenId + "']").remove();
 			let auraClone = $("[id='aura_" + tokenId + "']").clone();
 			auraClone.addClass("lightAura");
-			$("[id='aura_" + tokenId + "']").append(auraClone);		
-			$("[id='aura_" + tokenId + "']").attr("style", auraStyles);				
+			$("[id='aura_" + tokenId + "']").append(auraClone);
+			$("[id='aura_" + tokenId + "']").attr("style", auraStyles);
 			let lightblur = totalSize/50 + "px";
 			$("[id='aura_" + tokenId + "']").css('--light-blur', lightblur);
 			token.parent().parent().children("#aura_" + tokenId).toggleClass("haslightchild", true);
@@ -1907,7 +1931,7 @@ function setTokenAuras (token, options) {
 			token.parent().parent().children("#aura_" + tokenId).toggleClass("haslightchild", false);
 		}
 
-		
+
 	} else {
 		const tokenId = token.attr("data-id").replaceAll("/", "");
 		token.parent().parent().find("#aura_" + tokenId).remove();
@@ -1968,7 +1992,7 @@ function load_custom_monster_image_mapping() {
 function save_custom_monster_image_mapping() {
 	let customMappingData = JSON.stringify(window.CUSTOM_TOKEN_IMAGE_MAP);
 	localStorage.setItem("CustomDefaultTokenMapping", customMappingData);
-	// The JSON structure for CUSTOM_TOKEN_IMAGE_MAP looks like this { 17100: [ "some.url.com/img1.png", "some.url.com/img2.png" ] }	
+	// The JSON structure for CUSTOM_TOKEN_IMAGE_MAP looks like this { 17100: [ "some.url.com/img1.png", "some.url.com/img2.png" ] }
 }
 
 function copy_to_clipboard(text) {
@@ -2155,17 +2179,17 @@ function do_draw_selected_token_bounding_box() {
 		y: 0
 	};
 	grabber.draggable({
-		start: function (event) { 
+		start: function (event) {
 			// adjust based on zoom level
 			click.x = event.clientX;
 			click.y = event.clientY;
 			self.orig_top = grabberTop;
 			self.orig_left = grabberLeft;
-			
+
 			// the drag has started so remove the bounding boxes, but not the grabber
 			$("#selectedTokensBorder").remove();
 			$("#selectedTokensBorderRotationGrabberConnector").remove();
-			$("#rotationGrabberHolder").remove();		
+			$("#rotationGrabberHolder").remove();
 		},
 		drag: function(event, ui) {
 			// adjust based on zoom level
@@ -2184,7 +2208,7 @@ function do_draw_selected_token_bounding_box() {
 				token.rotate(angle);
 			}
 		},
-		stop: function (event) { 
+		stop: function (event) {
 			// rotate for all players
 			for (let i = 0; i < window.CURRENTLY_SELECTED_TOKENS.length; i++) {
 				let id = window.CURRENTLY_SELECTED_TOKENS[i];
@@ -2209,7 +2233,7 @@ function copy_selected_tokens() {
 	let redrawBoundingBox = false;
 	for (id in window.TOKEN_OBJECTS) {
 		let token = window.TOKEN_OBJECTS[id];
-		if (token.selected) { 
+		if (token.selected) {
 			if (token.isPlayer()) {
 				// deselect player tokens to avoid confusion about them being selected but not copy/pasted
 				window.TOKEN_OBJECTS[id].selected = false;
@@ -2257,13 +2281,13 @@ function paste_selected_tokens() {
 }
 
 function delete_selected_tokens() {
-	
+
 	// move all the tokens into a separate list so the DM can "undo" the deletion
 	let tokensToDelete = [];
 	for (id in window.TOKEN_OBJECTS) {
 		let token = window.TOKEN_OBJECTS[id];
 		if (token.selected) {
-			if (window.DM || token.options.deleteableByPlayers == true) {				
+			if (window.DM || token.options.deleteableByPlayers == true) {
 				window.TOKEN_OBJECTS_RECENTLY_DELETED[id] = Object.assign({}, token.options);
 				tokensToDelete.push(token);
 			}

--- a/Token.js
+++ b/Token.js
@@ -1844,7 +1844,8 @@ function token_menu() {
 			if ($(event.currentTarget).hasClass("tokenselected") && window.CURRENTLY_SELECTED_TOKENS.length > 0) {
 				token_context_menu_expanded(window.CURRENTLY_SELECTED_TOKENS, event);
 			} else {
-				token_context_menu_expanded([$(event.currentTarget).attr("data-id")], event);
+				let tokens = window.TOKEN_OBJECTS[$(event.currentTarget).attr("data-id")].get_grouped_tokens().map(t => t.options.id);
+				token_context_menu_expanded(tokens, event);
 			}
 		});
 		return;

--- a/Token.js
+++ b/Token.js
@@ -1295,7 +1295,6 @@ class Token {
 					self.orig_top = self.options.top;
 					self.orig_left = self.options.left;
 
-
 					if (self.selected && $(".token.tokenselected").length>1) {
 						for (let tok of $(".token.tokenselected")){
 							let id = $(tok).attr("data-id");
@@ -1414,7 +1413,6 @@ class Token {
 
 
 
-
 					if (self.selected && $(".token.tokenselected").length>1) {
 						// if dragging on a selected token, we should move also the other selected tokens
 						// try to move other tokens by the same amount
@@ -1477,31 +1475,16 @@ class Token {
 				}
 
 				// get the tokens that share a group with this one
-				let groupTokens = [];
-				let currentToken = window.TOKEN_OBJECTS[tokID];
-				let groupId = currentToken.options.group_id;
-				console.log(`Group ID ${groupId}`);
-				if (groupId) {
-					for (const tokenId in window.TOKEN_OBJECTS) {
-						if (window.TOKEN_OBJECTS[tokenId].options.group_id == groupId) {
-							groupTokens.push(window.TOKEN_OBJECTS[tokenId]);
-							console.log(`Pushing id ${tokenId}`);
-						}
-					}
-				} else {
-					groupTokens.push(window.TOKEN_OBJECTS[tokID]);
-				}
+				let groupTokens = window.TOKEN_OBJECTS[tokID].get_grouped_tokens();
 				if (thisSelected == true) {
 					groupTokens.forEach(token => {
 						let currentParentToken = $("#tokens").find("div[data-id='" + token.options.id + "']");
-						console.log(currentParentToken);
 						currentParentToken.addClass('tokenselected');
 						toggle_player_selectable(token, currentParentToken);
 					});
 				} else {
 					groupTokens.forEach(token => {
 						let currentParentToken = $("#tokens").find("div[data-id='" + token.options.id + "']");
-						console.log(currentParentToken);
 						currentParentToken.removeClass('tokenselected');
 					});
 				}
@@ -1559,6 +1542,23 @@ class Token {
 			return defaultValue;
 		}
 		return storedValue;
+	}
+
+  // returns a list of all token objects that share a group id with this one
+	// returns list with only current token if current token has no group
+	get_grouped_tokens() {
+		let groupTokens = [];
+		let groupId = this.options.group_id;
+		if (groupId) {
+			for (const tokenId in window.TOKEN_OBJECTS) {
+				if (window.TOKEN_OBJECTS[tokenId].options.group_id == groupId) {
+					groupTokens.push(window.TOKEN_OBJECTS[tokenId]);
+				}
+			}
+		} else {
+			groupTokens.push(this);
+		}
+		return groupTokens;
 	}
 
 }

--- a/Token.js
+++ b/Token.js
@@ -1179,6 +1179,17 @@ class Token {
 						let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);
 						console.log("shallwesnap",shallwesnap);
 						console.log("toggleSnap",window.toggleSnap);
+
+						// get all the tokens that move with the current one
+						let tokensToMove = [];
+						if (self.selected && $(".token.tokenselected").length>1) {
+							tokensToMove = $(".token.tokenselected");
+						} else if (self.get_grouped_tokens().length>1) {
+							tokensToMove = self.get_grouped_tokens().map(t => $("#tokens [data-id='" + t.options.id + "']").get(0));
+							console.log("TOKENS TO MOVE");
+							console.log(tokensToMove);
+						}
+
 						if (shallwesnap) {
 
 							// calculate offset in real coordinates
@@ -1208,59 +1219,56 @@ class Token {
 								el.css("left", `${selectedNewleft - ((auraSize - self.options.size) / 2)}px`);
 							}
 
-							for (var id in window.TOKEN_OBJECTS) {
-								if (window.TOKEN_OBJECTS[id].selected) {
-									setTimeout(function(tempID) {
-										$("[data-id='"+tempID+"']").removeClass("pause_click");
-										console.log($("[data-id='"+id+"']"));
-									}, 200, id);
-									if (id != self.options.id) {
-										const tok = $("#tokens div[data-id='" + id + "']");
+							for (let tokenToMove of tokensToMove) {
+								let id = $(tokenToMove).attr("data-id");
+								setTimeout(function(tempID) {
+									$("[data-id='"+tempID+"']").removeClass("pause_click");
+									console.log($("[data-id='"+id+"']"));
+								}, 200, id);
+								if (id != self.options.id) {
+									const tok = $("#tokens div[data-id='" + id + "']");
 
-										const oldtop = parseInt(tok.css("top"));
-										const oldleft = parseInt(tok.css("left"));
+									const oldtop = parseInt(tok.css("top"));
+									const oldleft = parseInt(tok.css("left"));
 
-										const newtop = Math.round((oldtop - startY) / window.CURRENT_SCENE_DATA.vpps) * window.CURRENT_SCENE_DATA.vpps + startY;
-										const newleft = Math.round((oldleft - startX) / window.CURRENT_SCENE_DATA.hpps) * window.CURRENT_SCENE_DATA.hpps + startX;
+									const newtop = Math.round((oldtop - startY) / window.CURRENT_SCENE_DATA.vpps) * window.CURRENT_SCENE_DATA.vpps + startY;
+									const newleft = Math.round((oldleft - startX) / window.CURRENT_SCENE_DATA.hpps) * window.CURRENT_SCENE_DATA.hpps + startX;
 
-										tok.css("top", newtop + "px");
-										tok.css("left", newleft + "px");
+									tok.css("top", newtop + "px");
+									tok.css("left", newleft + "px");
 
-										const selEl = tok.parent().parent().find("#aura_" + id.replaceAll("/", ""));
-										if (selEl.length > 0) {
-											const auraSize = parseInt(selEl.css("width"));
+									const selEl = tok.parent().parent().find("#aura_" + id.replaceAll("/", ""));
+									if (selEl.length > 0) {
+										const auraSize = parseInt(selEl.css("width"));
 
-											selEl.css("top", `${newtop - ((auraSize - window.TOKEN_OBJECTS[id].options.size) / 2)}px`);
-											selEl.css("left", `${newleft - ((auraSize - window.TOKEN_OBJECTS[id].options.size) / 2)}px`);
-										}
+										selEl.css("top", `${newtop - ((auraSize - window.TOKEN_OBJECTS[id].options.size) / 2)}px`);
+										selEl.css("left", `${newleft - ((auraSize - window.TOKEN_OBJECTS[id].options.size) / 2)}px`);
 									}
 								}
 							}
 
 						} else {
 							// we want to remove the pause_click even when grid snapping is turned off
-							for (var id in window.TOKEN_OBJECTS) {
-								if (window.TOKEN_OBJECTS[id].selected) {
-									setTimeout(function(tempID) {
-										$("[data-id='"+tempID+"']").removeClass("pause_click");
-										//console.log($("[data-id='"+id+"']"));
-									}, 200, id);
-								}
+							for (let tokenToMove of tokensToMove) {
+								let id = $(tokenToMove).attr("data-id");
+								setTimeout(function(tempID) {
+									$("[data-id='"+tempID+"']").removeClass("pause_click");
+									//console.log($("[data-id='"+id+"']"));
+								}, 200, id);
 							}
 						}
 
 						window.DRAGGING = false;
 
 						self.update_and_sync(event);
-						if (self.selected) {
-							for (id in window.TOKEN_OBJECTS) {
-								if ((id != self.options.id) && window.TOKEN_OBJECTS[id].selected) {
+							for (let tokenToMove of tokensToMove) {
+								let id = $(tokenToMove).attr("data-id");
+								if ((id != self.options.id)) {
 									var curr = window.TOKEN_OBJECTS[id];
 									var ev = { target: $("#tokens [data-id='" + id + "']").get(0) };
 									curr.update_and_sync(ev);
 								}
 							}
-						}
 
 						draw_selected_token_bounding_box();
 						window.toggleSnap=false;
@@ -1295,25 +1303,30 @@ class Token {
 					self.orig_top = self.options.top;
 					self.orig_left = self.options.left;
 
+					let tokensToMove = [];
 					if (self.selected && $(".token.tokenselected").length>1) {
-						for (let tok of $(".token.tokenselected")){
-							let id = $(tok).attr("data-id");
-							$(tok).addClass("pause_click");
-							if($(tok).is(":animated")){
-								window.TOKEN_OBJECTS[id].stopAnimation();
-							}
-							if (id != self.options.id) {
-								var curr = window.TOKEN_OBJECTS[id];
-								curr.orig_top = curr.options.top;
-								curr.orig_left = curr.options.left;
+						tokensToMove = $(".token.tokenselected");
+					} else if (self.get_grouped_tokens().length>1) {
+						tokensToMove = self.get_grouped_tokens().map(t => $("#tokens [data-id='" + t.options.id + "']").get(0));
+						console.log("TOKENS TO MOVE");
+						console.log(tokensToMove);
+					}
+					for (let tok of tokensToMove){
+						let id = $(tok).attr("data-id");
+						$(tok).addClass("pause_click");
+						if($(tok).is(":animated")){
+							window.TOKEN_OBJECTS[id].stopAnimation();
+						}
+						if (id != self.options.id) {
+							var curr = window.TOKEN_OBJECTS[id];
+							curr.orig_top = curr.options.top;
+							curr.orig_left = curr.options.left;
 
-								const el = $("#aura_" + id.replaceAll("/", ""));
-								if (el.length > 0) {
-									el.attr("data-left", el.css("left").replace("px", ""));
-									el.attr("data-top", el.css("top").replace("px", ""));
-								}
+							const el = $("#aura_" + id.replaceAll("/", ""));
+							if (el.length > 0) {
+								el.attr("data-left", el.css("left").replace("px", ""));
+								el.attr("data-top", el.css("top").replace("px", ""));
 							}
-
 						}
 					}
 
@@ -1412,36 +1425,40 @@ class Token {
 					}
 
 
-
+					let tokensToMove = [];
 					if (self.selected && $(".token.tokenselected").length>1) {
-						// if dragging on a selected token, we should move also the other selected tokens
-						// try to move other tokens by the same amount
-						var offsetLeft = Math.round(ui.position.left - parseInt(self.orig_left));
-						var offsetTop = Math.round(ui.position.top - parseInt(self.orig_top));
+						tokensToMove = $(".token.tokenselected");
+					} else if (self.get_grouped_tokens().length>1) {
+						tokensToMove = self.get_grouped_tokens().map(t => $("#tokens [data-id='" + t.options.id + "']").get(0));
+						console.log("TOKENS TO MOVE");
+						console.log(tokensToMove);
+					}
+					// if dragging on a selected token, we should move also the other selected tokens
+					// try to move other tokens by the same amount
+					var offsetLeft = Math.round(ui.position.left - parseInt(self.orig_left));
+					var offsetTop = Math.round(ui.position.top - parseInt(self.orig_top));
 
-						for (let tok of $(".token.tokenselected")){
-							let id = $(tok).attr("data-id");
-							if ((id != self.options.id) && window.TOKEN_OBJECTS[id].selected && (!window.TOKEN_OBJECTS[id].options.locked || (window.DM && window.TOKEN_OBJECTS[id].options.restrictPlayerMove))) {
-								//console.log("sposto!");
-								var curr = window.TOKEN_OBJECTS[id];
-								$(tok).css('left', (parseInt(curr.orig_left) + offsetLeft) + "px");
-								$(tok).css('top', (parseInt(curr.orig_top) + offsetTop) + "px");
-								//curr.options.top=(parseInt(curr.orig_top)+offsetTop)+"px";
-								//curr.place();
+					for (let tok of tokensToMove){
+						let id = $(tok).attr("data-id");
+						if ((id != self.options.id) && (!window.TOKEN_OBJECTS[id].options.locked || (window.DM && window.TOKEN_OBJECTS[id].options.restrictPlayerMove))) {
+							//console.log("sposto!");
+							var curr = window.TOKEN_OBJECTS[id];
+							$(tok).css('left', (parseInt(curr.orig_left) + offsetLeft) + "px");
+							$(tok).css('top', (parseInt(curr.orig_top) + offsetTop) + "px");
+							//curr.options.top=(parseInt(curr.orig_top)+offsetTop)+"px";
+							//curr.place();
 
-								const selEl = $(tok).parent().parent().find("#aura_" + id.replaceAll("/", ""));
-								if (selEl.length > 0) {
-									let currLeft = parseFloat(selEl.attr("data-left"));
-									let currTop = parseFloat(selEl.attr("data-top"));
-									let offsetLeft = Math.round(ui.position.left - parseInt(self.orig_left));
-									let offsetTop = Math.round(ui.position.top - parseInt(self.orig_top));
-									selEl.css('left', (currLeft + offsetLeft) + "px");
-									selEl.css('top', (currTop + offsetTop) + "px");
-								}
+							const selEl = $(tok).parent().parent().find("#aura_" + id.replaceAll("/", ""));
+							if (selEl.length > 0) {
+								let currLeft = parseFloat(selEl.attr("data-left"));
+								let currTop = parseFloat(selEl.attr("data-top"));
+								let offsetLeft = Math.round(ui.position.left - parseInt(self.orig_left));
+								let offsetTop = Math.round(ui.position.top - parseInt(self.orig_top));
+								selEl.css('left', (currLeft + offsetLeft) + "px");
+								selEl.css('top', (currTop + offsetTop) + "px");
 							}
 						}
 					}
-
 				}
 			});
 

--- a/Token.js
+++ b/Token.js
@@ -1578,6 +1578,27 @@ class Token {
 		return groupTokens;
 	}
 
+	/**
+	 * Defines how far tokens are allowed to move outside of the scene
+	 */
+	prepareWalkableArea() {
+		// sizeOnGrid needs to be at least one grid size to work for smaller tokens
+		const sizeOnGrid = {
+			y: Math.max(this.options.size, window.CURRENT_SCENE_DATA.hpps),
+			x: Math.max(this.options.size, window.CURRENT_SCENE_DATA.vpps)
+		};
+
+		// shorten variable to improve readability
+		const multi = this.SCENE_MOVE_GRID_PADDING_MULTIPLIER;
+
+		this.walkableArea = {
+			top:  0 - (sizeOnGrid.y * multi),
+			left: 0 - (sizeOnGrid.x * multi),
+			right:  window.ScenesHandler.scene.width  + (sizeOnGrid.x * (multi -1)), // we need to remove 1 token size because tokens are anchored in the top left
+			bottom: window.ScenesHandler.scene.height + (sizeOnGrid.y * (multi -1)), // ... same as above
+		};
+	}
+	
 }
 
 /**

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -243,14 +243,14 @@ function token_context_menu_expanded(tokenIds, e) {
 				let groupId = uuid();
 				tokens.forEach(token => {
 					token.options.group_id = groupId;
-					token.place_sync_persist();
+					token.update_and_sync();
 				});
 			} else {
 				clickedButton.removeClass("ungroup-tokens").addClass("group-tokens");
 				clickedButton.html(groupButtonInternals);
 				tokens.forEach(token => {
 					delete token.options.group_id;
-					token.place_sync_persist();
+					token.update_and_sync();
 				});
 			}
 		});

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -45,7 +45,7 @@ function context_menu_flyout(id, hoverEvent, buildFunction) {
 
 
 		if (diff > 0) {
-			// the flyout is smaller than the contextmenu. Make sure it's alongside the hovered row			
+			// the flyout is smaller than the contextmenu. Make sure it's alongside the hovered row
 			// align to the top of the row
 			let buttonPosition = $(".flyout-from-menu-item:hover")[0].getBoundingClientRect().y - $("#tokenOptionsPopup")[0].getBoundingClientRect().y
 			if(buttonPosition < contextMenuCenter) {
@@ -53,8 +53,8 @@ function context_menu_flyout(id, hoverEvent, buildFunction) {
 			}
 			else{
 				flyoutTop =  buttonPosition - (flyoutHeight / 1.2)
-			}				
-		}	
+			}
+		}
 
 		flyout.css({
 			left: contextMenu.width(),
@@ -70,8 +70,8 @@ function context_menu_flyout(id, hoverEvent, buildFunction) {
 				bottom: 0
 			});
 		}
-		
-	} 
+
+	}
 }
 
 function close_token_context_menu() {
@@ -102,12 +102,12 @@ function token_context_menu_expanded(tokenIds, e) {
 		tokenOptionsClickCloseDiv.remove();
 		$(".sp-container").spectrum("destroy");
 		$(".sp-container").remove();
-		$(`.context-menu-flyout`).remove(); 
+		$(`.context-menu-flyout`).remove();
 	});
 
 	let moveableTokenOptions = $("<div id='tokenOptionsPopup'></div>");
 
-	
+
 	let body = $("<div id='tokenOptionsContainer'></div>");
 	moveableTokenOptions.append(body);
 
@@ -136,6 +136,37 @@ function token_context_menu_expanded(tokenIds, e) {
 				body.append(button);
 			}
 		}
+	} else {
+		let groupButton = $(`<button></button>`);
+		let groupButtonInternals = `Group Tokens<span class="material-icons icon-person-add"></span>`;
+		let ungroupButtonInternals = `Ungroup Tokens<span class="material-icons icon-person-remove"></span>`;
+		if (tokens.every(token => token.options.group_id == undefined)) {
+			groupButton.addClass('group-tokens');
+			groupButton.html(groupButtonInternals);
+		} else {
+			groupButton.addClass('ungroup-tokens');
+			groupButton.html(ungroupButtonInternals);
+		}
+		groupButton.on("click", function(clickEvent) {
+			let clickedButton = $(clickEvent.currentTarget);
+			if (clickedButton.hasClass("group-tokens")) {
+				clickedButton.removeClass("group-tokens").addClass("ungroup-tokens");
+				clickedButton.html(ungroupButtonInternals);
+				let groupId = uuid();
+				tokens.forEach(token => {
+					token.options.group_id = groupId;
+					token.place_sync_persist();
+				});
+			} else {
+				clickedButton.removeClass("ungroup-tokens").addClass("group-tokens");
+				clickedButton.html(groupButtonInternals);
+				tokens.forEach(token => {
+					delete token.options.group_id;
+					token.place_sync_persist();
+				});
+			}
+		});
+		body.append(groupButton);
 	}
 
 	if(window.DM){
@@ -199,25 +230,25 @@ function token_context_menu_expanded(tokenIds, e) {
 
 		toTopMenuButton.off().on("click", function(tokenIds){
 			tokens.forEach(token => {
-				$(".token").each(function(){	
-					let tokenId = $(this).attr('data-id');	
+				$(".token").each(function(){
+					let tokenId = $(this).attr('data-id');
 					let tokenzindexdiff = window.TOKEN_OBJECTS[tokenId].options.zindexdiff;
 					if (tokenzindexdiff >= window.TOKEN_OBJECTS[token.options.id].options.zindexdiff && tokenId != token.options.id) {
 						window.TOKEN_OBJECTS[token.options.id].options.zindexdiff = tokenzindexdiff + 1;
-					}		
+					}
 				});
 				token.place_sync_persist();
 			});
 		});
 
 		toBottomMenuButton.off().on("click", function(tokenIds){
-			tokens.forEach(token => {			
-				$(".token").each(function(){	
-					let tokenId = $(this).attr('data-id');	
+			tokens.forEach(token => {
+				$(".token").each(function(){
+					let tokenId = $(this).attr('data-id');
 					let tokenzindexdiff = window.TOKEN_OBJECTS[tokenId].options.zindexdiff;
 					if (tokenzindexdiff <= window.TOKEN_OBJECTS[token.options.id].options.zindexdiff && tokenId != token.options.id) {
 						window.TOKEN_OBJECTS[token.options.id].options.zindexdiff = Math.max(tokenzindexdiff - 1, -5000);
-					}		
+					}
 				});
 				token.place_sync_persist();
 			});
@@ -240,18 +271,18 @@ function token_context_menu_expanded(tokenIds, e) {
 		});
 	}
 
-	
-	if(tokens.length == 1 && ((tokens[0].options.player_owned && !tokens[0].options.disablestat && !tokens[0].isPlayer()) || (window.DM && !tokens[0].isPlayer()))){ 
+
+	if(tokens.length == 1 && ((tokens[0].options.player_owned && !tokens[0].options.disablestat && !tokens[0].isPlayer()) || (window.DM && !tokens[0].isPlayer()))){
 		$(".maxHpMenuInput").prop('disabled', false);
 		$(".acMenuInput").prop('disabled', false);
 		$(".hpMenuInput").prop('disabled', false);
 	}
-	else { 
+	else {
 		$(".maxHpMenuInput").prop('disabled', true);
 		$(".acMenuInput").prop('disabled', true);
 		$(".hpMenuInput").prop('disabled', true);
-	}	
-	let conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Conditions / Markers</div></div>`);	
+	}
+	let conditionsRow = $(`<div class="token-image-modal-footer-select-wrapper flyout-from-menu-item"><div class="token-image-modal-footer-title">Conditions / Markers</div></div>`);
 	conditionsRow.hover(function (hoverEvent) {
 		context_menu_flyout("conditions-flyout", hoverEvent, function(flyout) {
 			flyout.append(build_conditions_and_markers_flyout_menu(tokenIds));
@@ -323,7 +354,7 @@ function token_context_menu_expanded(tokenIds, e) {
 			scroll: false,
 			containment: "#windowContainment",
 			start: function () {
-				$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));			
+				$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));
 				$("#sheet").append($('<div class="iframeResizeCover"></div>'));
 			},
 			stop: function () {
@@ -331,7 +362,7 @@ function token_context_menu_expanded(tokenIds, e) {
 
 			}
 		});
-	
+
 
 	moveableTokenOptions.css("left", Math.max(e.clientX - 230, 0) + 'px');
 
@@ -340,7 +371,7 @@ function token_context_menu_expanded(tokenIds, e) {
 	}
 	else {
 		moveableTokenOptions.css("top", e.clientY - 10 + 'px');
-	}	
+	}
 }
 
 /**
@@ -453,7 +484,7 @@ function build_token_auras_inputs(tokenIds) {
 			token.options[name] = newValue;
 			token.place_sync_persist();
 		});
-	});	
+	});
 	wrapper.find(".token-config-aura-wrapper").prepend(auraIsLightInput);
 	let hideAuraInFog = build_toggle_input("hideaurafog", "Hide aura when hidden in fog", hideAuraIsEnabled, "Token's aura is hidden from players when in fog", "Token's aura is visible to players when token is in fog", function(name, newValue) {
 		console.log(`${name} setting is now ${newValue}`);
@@ -465,7 +496,7 @@ function build_token_auras_inputs(tokenIds) {
 	if(window.DM) {
 		wrapper.find(".token-config-aura-wrapper").prepend(hideAuraInFog);
 	}
-	
+
 
 	wrapper.find("h3.token-image-modal-footer-title").after(enabledAurasInput);
 	if (auraIsEnabled) {
@@ -745,12 +776,12 @@ function build_notes_flyout_menu(tokenIds) {
 	if(tokenIds.length=1){
 		let has_note=id in window.JOURNAL.notes;
 		if(has_note){
-			let viewNoteButton = $(`<button class="icon-view-note material-icons">View Note</button>`)		
+			let viewNoteButton = $(`<button class="icon-view-note material-icons">View Note</button>`)
 			let deleteNoteButton = $(`<button class="icon-note-delete material-icons">Delete Note</button>`)
 			editNoteButton = $(`<button class="icon-note material-icons">Edit Note</button>`)
 			body.append(viewNoteButton);
-			body.append(editNoteButton);		
-			body.append(deleteNoteButton);	
+			body.append(editNoteButton);
+			body.append(deleteNoteButton);
 			viewNoteButton.off().on("click", function(){
 				window.JOURNAL.display_note(id);
 			});
@@ -776,13 +807,13 @@ function build_notes_flyout_menu(tokenIds) {
 				}
 			}
 			window.JOURNAL.edit_note(id);
-		});		
+		});
 	}
 
 	return body;
 }
 
-	
+
 
 function build_conditions_and_markers_flyout_menu(tokenIds) {
 
@@ -829,7 +860,7 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		{
 			isPlayerTokensSelected = true;
 		}
-	});	
+	});
 	let conditionsList = $(`<ul></ul>`);
 	conditionsList.css("width", "180px");
 	body.append(conditionsList);
@@ -935,12 +966,12 @@ function build_adjustments_flyout_menu(tokenIds) {
 	let imageSizeInputRange = $(`<input class="image-scale-input-range" type="range" value="1" min="0.2" max="6" step="0.1"/>`);
 	let tokenImageScales = tokens.map(t => t.options.imageSize);
 	if(tokenImageScales.length === 1) {
-		imageSizeInput.val(tokenImageScales[0] || 1);	
+		imageSizeInput.val(tokenImageScales[0] || 1);
 		imageSizeInputRange.val(tokenImageScales[0] || 1);
 	}
 	imageSizeInput.on('keyup', function(event) {
 		var imageSize;
-		if(event.target.value <= 6 && event.target.value >= 0.2) { 
+		if(event.target.value <= 6 && event.target.value >= 0.2) {
 			imageSize = event.target.value;
 		}
 		else if(event.target.value > 6){
@@ -950,7 +981,7 @@ function build_adjustments_flyout_menu(tokenIds) {
 			imageSize = 0.2;
 		}
 		if (event.key == "Enter") {
-			imageSizeInput.val(imageSize);	
+			imageSizeInput.val(imageSize);
 			imageSizeInputRange.val(imageSize);
 			tokens.forEach(token => {
 				token.options.imageSize = imageSize;
@@ -961,19 +992,19 @@ function build_adjustments_flyout_menu(tokenIds) {
 	});
 	imageSizeInput.on('focusout', function(event) {
 		var imageSize;
-		if(event.target.value <= 6 && event.target.value >= 0.2) { 
+		if(event.target.value <= 6 && event.target.value >= 0.2) {
 			imageSize = event.target.value;
 		}
 		else if(event.target.value > 6){
 			imageSize = 6;
-			imageSizeInput.val(imageSize);	
+			imageSizeInput.val(imageSize);
 			imageSizeInputRange.val(imageSize);
 		}
 		else if(event.target.value < 0.2){
 			imageSize = 0.2;
-			imageSizeInput.val(imageSize);	
+			imageSizeInput.val(imageSize);
 			imageSizeInputRange.val(imageSize);
-		}	
+		}
 		tokens.forEach(token => {
 			token.options.imageSize = imageSize;
 			token.place_sync_persist();
@@ -1007,14 +1038,14 @@ function build_adjustments_flyout_menu(tokenIds) {
 	let borderColorInput = $(`<input class="border-color-input" type="color" value="#ddd"/>`);
 	let tokenBorderColors = tokens.map(t => t.options.color);
 	if(tokenBorderColors.length === 1) {
-		borderColorInput.val(tokenBorderColors[0] || "#dddddd");	
+		borderColorInput.val(tokenBorderColors[0] || "#dddddd");
 	}
 	let borderColorWrapper = $(`
 		<div class="token-image-modal-url-label-wrapper border-color-wrapper">
 			<div class="token-image-modal-footer-title border-color-title">Border Color</div>
 		</div>
 	`);
-	borderColorWrapper.append(borderColorInput); 
+	borderColorWrapper.append(borderColorInput);
 	body.append(borderColorWrapper);
 	let colorPicker = $(borderColorInput);
 	colorPicker.spectrum({
@@ -1037,15 +1068,15 @@ function build_adjustments_flyout_menu(tokenIds) {
 		}
 		else {
 			tokens.forEach(token => {
-				token.options.color = borderColor;		
-				token.place_sync_persist();	
+				token.options.color = borderColor;
+				token.place_sync_persist();
 			});
 		}
 	};
 	colorPicker.on('dragstop.spectrum', borderColorPickerChange);   // update the token as the player messes around with colors
 	colorPicker.on('change.spectrum', borderColorPickerChange); // commit the changes when the user clicks the submit button
 	colorPicker.on('hide.spectrum', borderColorPickerChange);   // the hide event includes the original color so let's change it back when we get it
-	
+
 
 	let changeImageMenuButton = $("<button id='changeTokenImage' class='material-icons'>Change Token Image</button>")
 	if(tokens.length === 1 && window.DM){
@@ -1088,7 +1119,7 @@ function build_options_flyout_menu(tokenIds) {
 		{ name: "legacyaspectratio", label: "Ignore Image Aspect Ratio", enabledDescription:"Token will stretch non-square images to fill the token space", disabledDescription: "Token will respect the aspect ratio of the image provided" },
 		{ name: "player_owned", label: "Player access to sheet/stats", enabledDescription:"Tokens' sheet is accessible to players via RMB click on token. If token stats is visible to players, players can modify the hp of the token", disabledDescription: "Tokens' sheet is not accessible to players. Players can't modify token stats"}
 	];
-	if (tokens.length == 1 && !tokens[0].isPlayer()){		
+	if (tokens.length == 1 && !tokens[0].isPlayer()){
 		let removename = "hidestat";
 		token_settings = $.grep(token_settings, function(e){
 		     return e.name != removename;

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -136,37 +136,6 @@ function token_context_menu_expanded(tokenIds, e) {
 				body.append(button);
 			}
 		}
-	} else {
-		let groupButton = $(`<button></button>`);
-		let groupButtonInternals = `Group Tokens<span class="material-icons icon-person-add"></span>`;
-		let ungroupButtonInternals = `Ungroup Tokens<span class="material-icons icon-person-remove"></span>`;
-		if (tokens.every(token => token.options.group_id == undefined)) {
-			groupButton.addClass('group-tokens');
-			groupButton.html(groupButtonInternals);
-		} else {
-			groupButton.addClass('ungroup-tokens');
-			groupButton.html(ungroupButtonInternals);
-		}
-		groupButton.on("click", function(clickEvent) {
-			let clickedButton = $(clickEvent.currentTarget);
-			if (clickedButton.hasClass("group-tokens")) {
-				clickedButton.removeClass("group-tokens").addClass("ungroup-tokens");
-				clickedButton.html(ungroupButtonInternals);
-				let groupId = uuid();
-				tokens.forEach(token => {
-					token.options.group_id = groupId;
-					token.place_sync_persist();
-				});
-			} else {
-				clickedButton.removeClass("ungroup-tokens").addClass("group-tokens");
-				clickedButton.html(groupButtonInternals);
-				tokens.forEach(token => {
-					delete token.options.group_id;
-					token.place_sync_persist();
-				});
-			}
-		});
-		body.append(groupButton);
 	}
 
 	if(window.DM){
@@ -253,6 +222,39 @@ function token_context_menu_expanded(tokenIds, e) {
 				token.place_sync_persist();
 			});
 		});
+	}
+
+	if (tokens.length > 1) {
+		let groupButton = $(`<button></button>`);
+		let groupButtonInternals = `Group Tokens<span class="material-icons icon-group-add"></span>`;
+		let ungroupButtonInternals = `Ungroup Tokens<span class="material-icons icon-group-remove"></span>`;
+		if (tokens.every(token => token.options.group_id == undefined)) {
+			groupButton.addClass('group-tokens');
+			groupButton.html(groupButtonInternals);
+		} else {
+			groupButton.addClass('ungroup-tokens');
+			groupButton.html(ungroupButtonInternals);
+		}
+		groupButton.on("click", function(clickEvent) {
+			let clickedButton = $(clickEvent.currentTarget);
+			if (clickedButton.hasClass("group-tokens")) {
+				clickedButton.removeClass("group-tokens").addClass("ungroup-tokens");
+				clickedButton.html(ungroupButtonInternals);
+				let groupId = uuid();
+				tokens.forEach(token => {
+					token.options.group_id = groupId;
+					token.place_sync_persist();
+				});
+			} else {
+				clickedButton.removeClass("ungroup-tokens").addClass("group-tokens");
+				clickedButton.html(groupButtonInternals);
+				tokens.forEach(token => {
+					delete token.options.group_id;
+					token.place_sync_persist();
+				});
+			}
+		});
+		body.append(groupButton);
 	}
 
 	if (tokens.length === 1) {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -242,7 +242,7 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
     height: auto;
     background: #242527;
     z-index: 0;
-    
+
     transition: -webkit-transform ease-in-out 0.5s;
     transform-origin: top;
     transition-delay: 0.1s; /* Needed to calculate the vertical area to shift with translateX */
@@ -268,16 +268,16 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
     right: 340px;
     display: none;
     position: fixed !important;
-    border-radius: 5px; 
+    border-radius: 5px;
     z-index: 10010;
-    border: 1px solid gray;  
+    border: 1px solid gray;
     top: 28px;
     bottom: auto;
     height: calc(100vh - 50px);
 }
 
 #sheet.open {
-    display: block !important;  
+    display: block !important;
     transition: none;
     transform: none;
     backdrop-filter: opacity(0);
@@ -294,12 +294,12 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
     height: 85%;
     position: fixed !important;
     opacity: 1;
-    background: #242527;  
-    cursor: move;   
+    background: #242527;
+    cursor: move;
     z-index: 49000;
-    border-radius: 3px;   
+    border-radius: 3px;
     border: 1px solid gray;
-}  
+}
 
 #resizeDragMon.hideMon{
     visibility: hidden;
@@ -308,7 +308,7 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
 #sheet iframe {
     width: 100%;
     height: calc(100% - 24px) !important;
-    border-radius: 0 0 3px 3px;   
+    border-radius: 0 0 3px 3px;
 }
 
 
@@ -350,24 +350,24 @@ div.ct-sidebar__pane-content--is-dark-mode .sidebar-panel-content {
 #combat_tracker_inside .ui-resizable-s,
 #combat_tracker_inside .ui-resizable-se,
 #combat_tracker_inside .ui-resizable-sw {
-    bottom:-45px;  
+    bottom:-45px;
 }
 
 #combat_tracker_inside .ui-resizable-e,
 #combat_tracker_inside .ui-resizable-w {
-    height: calc(100% + 45px);  
+    height: calc(100% + 45px);
 }
 
 
 .body-rpgcharacter-sheet #combat_tracker_inside .ui-resizable-s,
 .body-rpgcharacter-sheet #combat_tracker_inside .ui-resizable-se,
 .body-rpgcharacter-sheet #combat_tracker_inside .ui-resizable-sw{
-    bottom: -5px;  
+    bottom: -5px;
 }
 
 .body-rpgcharacter-sheet #combat_tracker_inside .ui-resizable-e,
 .body-rpgcharacter-sheet #combat_tracker_inside .ui-resizable-w  {
-    height: 100%;  
+    height: 100%;
 }
 #combat_tracker_inside #combat_area{
     width: 100%;
@@ -429,21 +429,21 @@ div.top_menu.visible,
 #combat_footer,
 #combat_tracker_inside{
 	border-style: solid;
-	border-color: #ddd; 
+	border-color: #ddd;
 }
 #combat_footer{
 	border-width: 0px 1px 1px 1px;
-	border-radius: 0px 0px 5px 5px; 
+	border-radius: 0px 0px 5px 5px;
 	left: -1px;
 	right: -1px;
 	position: absolute;
 }
 
 #combat_footer button{
-	flex-grow: 1;   
+	flex-grow: 1;
 }
 #combat_footer{
-	display: flex;   
+	display: flex;
 }
 #combat_tracker_inside {
 	border-width: 1px 1px 0px 1px;
@@ -451,10 +451,10 @@ div.top_menu.visible,
     width: 250px;
 }
 #combat_tracker_inside #combat_footer button:last-of-type{
-	border-bottom-right-radius: 5px;   
+	border-bottom-right-radius: 5px;
 }
 #combat_tracker_inside #combat_footer button:first-of-type{
-	border-bottom-left-radius: 5px; 
+	border-bottom-left-radius: 5px;
 }
 
 .body-rpgcharacter-sheet #combat_tracker_inside{
@@ -554,13 +554,13 @@ div#scene_selector,
 /*combat UI Changes 2*/
 #combat_tracker_inside .tracker-list{
     height: calc(100% - 55px);
-    background: #f9f9f9 url(../images/background_texture.png) repeat !important;  
+    background: #f9f9f9 url(../images/background_texture.png) repeat !important;
 }
 #round_number_label{
     width: calc(100% + 2px);
     left: -1px;
     position: relative;
-    background: #f9f9f9 url(../images/background_texture.png) repeat !important;  
+    background: #f9f9f9 url(../images/background_texture.png) repeat !important;
 }
 
 
@@ -1584,6 +1584,14 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 .context-menu-icon-add-circle:before {
     content: "\e148" !important;
 }
+.icon-group-add:before,
+.context-menu-icon-group-add:before {
+    content: "\e7ef" !important;
+}
+.icon-group-remove:before,
+.context-menu-icon-group-remove:before {
+    content: "\e747" !important;
+}
 
 .context-menu-icon-hidden {
     border: 1px solid white;
@@ -1906,7 +1914,7 @@ audio::-webkit-media-controls-time-remaining-display{
     margin-top: 4px;
 }
 
-.note .mce-panel { 
+.note .mce-panel {
     border:  none;
 }
 
@@ -2274,7 +2282,7 @@ h5.token-image-modal-footer-title:after {
     width: auto;
 }
 .custom-token-image-item {
-    float: left; 
+    float: left;
     width: 33%;
     position: relative;
 }
@@ -2647,8 +2655,8 @@ h5.token-image-modal-footer-title:after {
 }
 .sidebar-panel-content .sidebar-panel-body {
     background-color: rgb(235, 241, 245);
-    position: relative; 
-    width:100%; 
+    position: relative;
+    width:100%;
     overflow-y: auto;
     flex: auto;
 }
@@ -2846,7 +2854,7 @@ h5.token-image-modal-footer-title:after {
 @keyframes beholder-float {
     0% { transform: translate(0,  0px); }
     50%  { transform: translate(0, -20px); }
-    100%   { transform: translate(0, -0px); }   
+    100%   { transform: translate(0, -0px); }
 }
 
 div.sidebar__pane-content div.tooltip::after {
@@ -2866,7 +2874,7 @@ button.avtt-roll-button {
     line-height: 18px;
     letter-spacing: 1px;
     padding: 1px 4px 0;
-}			
+}
 .MuiPaper-root {
     padding: 0px 16px;
     width: 100px;
@@ -2899,34 +2907,34 @@ button.avtt-roll-button {
 #combat_footer,
 #combat_tracker_inside{
     border-style: solid;
-    border-color: #ddd; 
+    border-color: #ddd;
 }
 #combat_footer{
     border-width: 0px 1px 1px 1px;
-    border-radius: 0px 0px 5px 5px; 
+    border-radius: 0px 0px 5px 5px;
     left: -1px;
     right: -1px;
     position: absolute;
 }
 
 #combat_footer button{
-    flex-grow: 1;   
+    flex-grow: 1;
 }
 #combat_footer{
-    display: flex;   
+    display: flex;
 }
 #combat_tracker_inside {
     border-width: 1px 1px 0px 1px;
     border-radius: 5px 5px 0 0;
 }
 .body-rpgcharacter-sheet #combat_tracker_inside{
-    width: 200px;   
+    width: 200px;
 }
 #combat_tracker_inside #combat_footer button:last-of-type{
-    border-bottom-right-radius: 5px;   
+    border-bottom-right-radius: 5px;
 }
 #combat_tracker_inside #combat_footer button:first-of-type{
-    border-bottom-left-radius: 5px; 
+    border-bottom-left-radius: 5px;
 }
 
 .body-rpgcharacter-sheet #combat_tracker_inside{
@@ -2969,7 +2977,7 @@ button.avtt-roll-button {
     border-top-right-radius: 5px;
     line-height: 26px;
     text-shadow: 0px 0px  #000,
-        -1px -1px 0  #000,  
+        -1px -1px 0  #000,
          1px -1px 0  #000,
          -1px 1px 0  #000,
          1px 1px 0  #000;
@@ -3073,7 +3081,7 @@ button.avtt-roll-button {
     transition: all linear 0.2s;
     cursor: pointer;
 }
- 
+
 .text-input-title-bar-exit svg,
 #text_controller_title_bar_exit svg,
 #combat_tracker_title_bar_exit svg,
@@ -3149,7 +3157,7 @@ button.avtt-roll-button {
     width: 100%;
     height: 100%;
 }
-#tokenOptionsContainer div, 
+#tokenOptionsContainer div,
 #tokenOptionsContainer h3 {
     font-size: 10px;
 }
@@ -3161,7 +3169,7 @@ button.avtt-roll-button {
     display: flex;
     align-self: center;
     line-height: 20px;
-}   
+}
 .menu-outer-aura,
 .menu-inner-aura{
     margin: 2px 0px;
@@ -3237,7 +3245,7 @@ button.avtt-roll-button {
 #resizeDragMon .ui-resizable-sw,
 #sheet .ui-resizable-s,
 #sheet .ui-resizable-sw{
-    bottom: -7px;  
+    bottom: -7px;
 }
 
 #resizeDragMon .ui-resizable-se,
@@ -3251,7 +3259,7 @@ button.avtt-roll-button {
 #resizeDragMon .ui-resizable-w,
 #sheet .ui-resizable-e,
 #sheet .ui-resizable-w   {
-    height: calc(100% + 4px);  
+    height: calc(100% + 4px);
 }
 
 /*Resizable Handle Test code */
@@ -3274,9 +3282,9 @@ button.avtt-roll-button {
 }
 
 #combat_area tr[data-current] td{
-    background: none;  
+    background: none;
 }
-#combat_area tr[data-current] td{  
+#combat_area tr[data-current] td{
     background: none;
     border: none;
 }
@@ -3287,25 +3295,25 @@ button.avtt-roll-button {
 }
 #combat_area tr td:last-of-type{
     border-bottom-right-radius: 8px;
-    border-top-right-radius: 8px; 
+    border-top-right-radius: 8px;
 }
  #combat_area tr td:first-of-type{
     border-bottom-left-radius: 8px;
-    border-top-left-radius: 8px;  
+    border-top-left-radius: 8px;
 }
 
 #combat_area tr[data-current][data-target*="characters"]{
-    background: #0F0;  
+    background: #0F0;
 }
 #combat_area tr[data-current]:not([data-target*="characters"]){
-    background: #0000;  
+    background: #0000;
 }
 
 #combat_area tr[data-current] input{
     border-color: #1b9af0;
 }
 #combat_area{
-    border-collapse:collapse;  
+    border-collapse:collapse;
 }
 
 #combat_area td input,
@@ -3334,15 +3342,15 @@ button.avtt-roll-button {
 #combat_area tr td div{
     top: 1px;
     position: relative;
-    font-size: 18px !important; 
+    font-size: 18px !important;
 }
 
 #combat_area tr td div.hp{
-    float: right;  
+    float: right;
 }
 
 #round_number_label{
-    height: 30px;  
+    height: 30px;
 }
 
 .VTTToken img ~ .hpbar:after {
@@ -3383,8 +3391,8 @@ button.avtt-roll-button {
  #combat_tracker button:focus{
     outline: 1px solid #ddd;
 }
-#combat_area tr[data-current] td img{      
-     box-shadow: 1px 1px 2px 0px #000000;  
+#combat_area tr[data-current] td img{
+     box-shadow: 1px 1px 2px 0px #000000;
 }
 #combat_area tr td input,
 .roundNum,
@@ -3392,7 +3400,7 @@ button.avtt-roll-button {
     box-shadow: 1px 1px 1px 0px #00000047;
 }
 
-#combat_tracker input[disabled=disabled], 
+#combat_tracker input[disabled=disabled],
 #combat_tracker input[disabled=disabled]:hover,
 #combat_tracker input[readonly]{
     opacity: 1;
@@ -3400,7 +3408,7 @@ button.avtt-roll-button {
 }
 
 #combat_footer{
-    background: #f9f9f9 url(../images/background_texture.png) repeat !important;  
+    background: #f9f9f9 url(../images/background_texture.png) repeat !important;
     padding-top: 13px;
 }
 
@@ -3437,7 +3445,7 @@ button.avtt-roll-button {
     content: 'Hide/Reveal in Combat Tracker for Players';
 }
 .rollInitiativeCombatButton:after{
-    content:'Roll Initiative';         
+    content:'Roll Initiative';
 }
 .findTokenCombatButton:after{
     content:'Find Token';
@@ -3446,7 +3454,7 @@ button.avtt-roll-button {
     content:'Remove from Combat';
 }
 .openSheetCombatButton:after{
-    content:'Open Sheet';   
+    content:'Open Sheet';
 }
 
 .combatHideFromPlayerInput{
@@ -3525,7 +3533,7 @@ button.avtt-roll-button {
 #combat_tracker td button svg{
     display: inline-block;
     vertical-align: middle;
-} 
+}
 #combat_area{
     width: 100%;
 }
@@ -3535,7 +3543,7 @@ button.avtt-roll-button {
 }
 /*minimize windows*/
 
-.minimized > *:not(#ct_text_title, .player_title, .monster_title, #text_controller_title), 
+.minimized > *:not(#ct_text_title, .player_title, .monster_title, #text_controller_title),
 #combat_tracker_title_bar.minimized:after,
 #combat_tracker_title_bar.minimized ~ *{
     display: none !important;
@@ -3557,7 +3565,7 @@ button.avtt-roll-button {
     font-weight: bold;
     line-height: 25px;
     text-shadow: 0px 0px  #000,
-        -1px -1px 0  #000,  
+        -1px -1px 0  #000,
         1px -1px 0  #000,
         -1px 1px 0  #000,
         1px 1px 0  #000;
@@ -3591,7 +3599,7 @@ button.avtt-roll-button {
     object-fit: cover;
     width: 100%;
     height: 100%;
-} 
+}
 
 .image-size-wrapper,
 .border-color-wrapper {
@@ -3641,7 +3649,7 @@ button.avtt-roll-button {
     font-size: 10px;
     display: flex;
     flex-direction: row;
-    width: 100%;    
+    width: 100%;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -3658,7 +3666,7 @@ button.avtt-roll-button {
 .menu-input-label{
     text-align: center;
     background: none;
-    font-size: 10px;   
+    font-size: 10px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -3668,7 +3676,7 @@ button.avtt-roll-button {
 }
 
 #menuStatDiv {
-    width: 100%; 
+    width: 100%;
     padding: 5px;
     display: flex;
     align-content: center;
@@ -3719,7 +3727,7 @@ button.avtt-roll-button {
 }
 
 #adjustments-flyout button#changeTokenImage:before{
-   content: "\e413"; 
+   content: "\e413";
 }
 
 
@@ -3745,10 +3753,10 @@ button.avtt-roll-button {
     content: '';
     right: 5px;
     top: 7px;
-    width: 0; 
-    height: 0; 
+    width: 0;
+    height: 0;
     border-top: 5px solid transparent;
-    border-bottom: 5px solid transparent; 
+    border-bottom: 5px solid transparent;
     border-left: 5px solid #738694;
 }
 .flyout-from-menu-item:hover:after {
@@ -3780,7 +3788,7 @@ button.avtt-roll-button {
 }
 
 
-#prewiz, 
+#prewiz,
 #wizard_popup{
     z-index: 58000;
 }
@@ -3860,9 +3868,9 @@ button.avtt-roll-button {
     color: rgb(111, 116, 120);
     box-shadow: 1px 1px 1px -1px #0003, 1px 2px 0px -2px #0003;
 }
-.stream-dice-button:hover:after { 
+.stream-dice-button:hover:after {
     opacity:1;
-    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 500ms, background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;  
+    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 500ms, background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
 .stream-dice-button:after{
@@ -3883,7 +3891,7 @@ button.avtt-roll-button {
 
 .stream-dice-button.enabled:hover:after {
     opacity:1;
-    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 500ms, background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;   
+    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1) 500ms, background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
 .stream-dice-button.enabled:after {
@@ -4138,4 +4146,3 @@ div.note[id^="ui-id"] .mce-btn button {
 .sidebar-list-item-row.ui-draggable-dragging {
     z-index: 100000;
 }
-


### PR DESCRIPTION
When selecting multiple tokens, tokens can be grouped so that clicking any one of them selects all of them.

Grouped tokens act as a single unit when clicked, right-clicked, or dragged.

![image](https://user-images.githubusercontent.com/5218040/174735319-13117aa2-4411-4674-88ff-9d7030e60290.png)
