### PR TITLE
Fix drop down selection issue

### DIFF
--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1838,7 +1838,13 @@ function display_monster_filter_modal() {
             // it was just created. no need to do anything until it actually loads something
             return;
         }
-
+        $(event.target).contents().find("head").append(
+            `<style>
+                .input-select .input-select__dropdown-wrapper {
+                    transition: max-height 0.5s ease 0.1s;
+                }
+            </style>`
+        );
         $(event.target).contents().find("body").addClass("prevent-sidebar-modal-close");
         $(event.target).contents().find(".monster-listing__header button").click();
         $(event.target).contents().find(".popup-overlay").css("background", "rgb(235, 241, 245)");


### PR DESCRIPTION
> turtle_stew - AboveVTT: I'm unable to choose undead as a filter option for monsters. Probably because it is the last entry in the list?
>(No problem filtering when using the encounter builder via the dndbeyond website)
>https://cdn.discordapp.com/attachments/815028804103307354/988848856575934464/Filter_Undead.mp4


This should fix the above at least temporarily until we decide if we are going to build it ourselves. It delays the height change by 0.1s which seems to give it enough time to select the object.

The bug was happening most often with the items at the bottom of the dropdown.