### PR TITLE
fix some sources fail to load chapter listing in scene configuration

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -369,12 +369,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				}
 			}
 			else {
-				let elements;
-				if(keyword=="cotn")
-					elements=iframe.contents().find("h3 >a");
-				else
-					elements=iframe.contents().find(".adventure-chapter-header a,li >strong>a")
-				elements.each(function(idx) {
+				iframe.contents().find("h3 >a").each(function(idx) {
 					var title = $(this).html();
 					var url = $(this).attr('href');
 					var ch_keyword = url.replace('https://www.dndbeyond.com', '').replace('/sources/' + keyword + "/", '');


### PR DESCRIPTION
As reported in Discord, some books aren't loading properly. It looks like DDB finally got around to updating those books to match some of the newer ones. 

I also found that we fail to find some images. Here is an issue for that work https://github.com/cyruzzo/AboveVTT/issues/584
