### PR TITLE
Fix selection box rotation

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1114,7 +1114,7 @@ class Token {
 
 			old.find(".token-image").css("transition", "max-height 0.2s linear, max-width 0.2s linear, transform 0.2s linear")
 			old.find(".token-image").css("transform", "scale(" + imageScale + ") rotate("+rotation+"deg)");
-	
+			old.css("--token-rotation", rotation+"deg");
 			setTimeout(function() {old.find(".token-image").css("transition", "")}, 200);		
 			
 			var selector = "tr[data-target='"+this.options.id+"']";
@@ -1277,6 +1277,7 @@ class Token {
 				tokenImage = build_aoe_token_image(this, imageScale, rotation)
 
 			}
+			tok.css("--token-rotation", rotation + "deg");
 			tok.append(tokenImage);
 
 


### PR DESCRIPTION
Another missed part of #591 

This doesn't fix the ruler. 

I also ran into another issue where long line AoEs rotated still gets stopped by the token bounds as if it wasn't rotated. It may be worth and easy fix of just rotating the whole token for line aoes instead of the token-image since it likely won't have health, conditions etc as an AoE. Assuming that fixes this - not sure it would the bounds that contain the tokens might be based off something else.