### PR TITLE
Add ability to update HP from combat tracker

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -1,10 +1,10 @@
 
 function init_combat_tracker(){
 	window.ROUND_NUMBER =1;
-	
+
 	ct=$("<div id='combat_tracker'/>");
 	ct.css("height","20px"); // IMPORTANT
-	
+
 	toggle=$("<button id='combat_button' class='hideable ddbc-tab-options__header-heading' style='display:inline-block'><u>C</u>OMBAT</button>");
 	toggle.click(function(){
 		if($("#combat_tracker_inside #combat_tracker_title_bar.minimized").length>0) {
@@ -67,10 +67,10 @@ function init_combat_tracker(){
 			$("#ct_text_title").remove();
 		}
 	});
-	
+
 	rn = $(`<div id='round_number_label'><strong>ROUND:</strong><input class="roundNum" style="font-size: 11px; width: 42px; appearance: none;" type='number' id='round_number' value=${window.ROUND_NUMBER}></div>`)
 	reset_rounds=$("<button style='font-size: 10px;'>RESET</button>");
-	
+
 	reset_rounds.click(function (){
 		window.ROUND_NUMBER = 1;
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
@@ -87,7 +87,7 @@ function init_combat_tracker(){
 		}
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
 	});
-	
+
 	ct_inside.append(rn);
 	if(window.DM)
 	{
@@ -97,9 +97,9 @@ function init_combat_tracker(){
 	{
 		rn.find("#round_number").prop("readonly", true);
 	}
-	
+
 	buttons=$("<div id='combat_footer'/>");
-	
+
 	reroll=$("<button>REROLL</button>");
 	reroll.click(function(){
 		$("#combat_area tr[data-target]").each(function(){
@@ -118,7 +118,7 @@ function init_combat_tracker(){
 
 		$("#combat_area tr").first().attr('data-current','1');
 	});
-	
+
 	clear=$("<button>CLEAR</button>");
 	clear.click(function(){
 		$("#combat_area button.removeTokenCombatButton").each(function() {
@@ -128,7 +128,7 @@ function init_combat_tracker(){
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
 		ct_persist();
 	});
-	
+
 	next=$("<button id='combat_next_button'><u>N</u>EXT</button>");
 	next.click(function(){
 		if($("#combat_area tr").length==0)
@@ -156,34 +156,34 @@ function init_combat_tracker(){
 		ct_persist();
 		//var target=$("#combat_area tr[data-current=1]").attr('data-target');
 	});
-	
+
 	roll=$('<button class="rollInitiativeCombatButton"><svg class="rollSVG" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 339.09 383.21"><path d="M192.91,3q79.74,45.59,159.52,91.1c4.9,2.79,7.05,6,7,11.86q-.29,87.76,0,175.52c0,5.14-1.79,8.28-6.19,10.85q-78.35,45.75-156.53,91.78c-4.75,2.8-8.81,2.8-13.57,0q-77.7-45.75-155.59-91.18c-5.17-3-7.2-6.52-7.18-12.56q.31-87.39,0-174.78c0-5.5,2.06-8.64,6.7-11.28q80-45.53,159.84-91.3ZM115.66,136h3.67c12.1,0,24.19-.05,36.29,0,5.24,0,8.38,3.15,8.34,8s-3.56,8-9.73,8c-11.85.08-23.69,0-35.54,0-4.14,0-4.21.16-2.11,3.8q35.54,61.53,71.09,123.06c.59,1,.82,2.7,2.32,2.62s1.66-1.7,2.25-2.74q35.47-61.35,70.9-122.74c2.3-4,2.31-4-2.5-4-11.72,0-23.45.06-35.17,0-6.18-.05-9.6-3.08-9.59-8.1,0-5.18,3.27-7.9,9.58-7.91,11.47,0,22.94,0,34.42,0,1.27,0,2.71.54,3.93-.63a11.49,11.49,0,0,0-.69-1.36q-35.49-53-71-106c-2.15-3.22-3.2-1.77-4.7.46q-35.06,52.36-70.19,104.71C116.82,133.87,116.44,134.63,115.66,136Zm89,153.29c1.51,0,2.25.06,3,0,12.51-1.17,25-2.39,37.53-3.54,14.75-1.35,29.5-2.61,44.25-4,15.11-1.39,30.22-2.89,45.34-4.25,4.39-.39,4.47-.32,2.46-4.21q-10.79-20.94-21.61-41.87-17.31-33.56-34.64-67.11c-.49-1-.69-2.45-1.9-2.57s-1.48,1.46-2.14,2.31a9.38,9.38,0,0,0-.56,1q-27.49,47.6-55,95.2C215.87,269.75,210.42,279.24,204.62,289.31Zm-29.49.12c-1-1.84-1.57-3.05-2.24-4.22Q154,252.49,135.13,219.79,119.05,191.94,103,164.1c-.53-.91-.8-2.38-2.13-2.32-1.1.05-1.29,1.39-1.73,2.24Q70.69,219,42.3,274c-1.35,2.6-.88,3.39,2.09,3.56,6.71.38,13.4,1.06,20.09,1.68q23,2.11,46.08,4.27c12.26,1.15,24.53,2.34,36.79,3.47C156.37,287.81,165.4,288.57,175.13,289.43ZM44.49,102.78c1.34.83,2.16,1.37,3,1.86C63,113.46,78.55,122.19,94,131.17c3.21,1.88,4.7,1.46,6.75-1.63Q131,83.87,161.64,38.39c.66-1,1.64-1.84,1.8-3.6Zm172.2-67.85-.38.49c.31.53.58,1.08.93,1.59q30.94,46.15,61.84,92.33c2.12,3.18,3.67,3.68,7,1.72,15.4-9,31-17.7,46.45-26.54.8-.45,1.95-.58,2.22-2.08ZM36,250l.72.09C37.84,248,39,246,40.05,243.86Q64.23,197,88.47,150.12c1.35-2.6.68-3.58-1.6-4.86C71.21,136.48,55.62,127.56,40,118.7c-4-2.25-4-2.22-4,2.29V250Zm307.45.82a12.72,12.72,0,0,0,.35-1.55q0-64.51.06-129c0-3.33-1.17-3.17-3.5-1.85Q316.51,132,292.56,145.51c-2.11,1.18-2.42,2.21-1.29,4.38q18.11,34.83,36,69.76C332.56,229.83,337.84,240,343.46,250.84ZM64.23,295.22l-.14.56,47.09,27.59q33.88,19.86,67.78,39.7c1.11.64,3.21,3.18,3.21-.87,0-17.71,0-35.42,0-53.13,0-2.21-1-3.17-3.09-3.36q-17.29-1.51-34.59-3.07-18.22-1.63-36.45-3.29Q86.15,297.33,64.23,295.22Zm252.49,0c-11.13,1-21.24,2-31.37,2.92-12.15,1.1-24.31,2.1-36.46,3.21-15.62,1.41-31.23,3-46.86,4.26-3.38.27-4.46,1.44-4.43,4.8.14,16.84.06,33.68.07,50.52,0,4.1,0,4.1,3.73,1.93L286,313.28C296,307.43,305.91,301.56,316.72,295.2Z" transform="translate(-20.37 -3.01)"/><path d="M197.64,143.89a7.9,7.9,0,0,1-7.72,8,7.81,7.81,0,0,1-7.73-7.93,7.73,7.73,0,1,1,15.45,0Z" transform="translate(-20.37 -3.01)"/></svg></button>');
 	roll.click(function(){
 		$("#combat_area tr[data-monster]").each(function(idx){
 			let element=$(this);
 			if(element.find(".init").val()!=0) // DON'T ROLL AGAIN'
 				return;
-					
+
 			window.StatHandler.rollInit($(this).attr('data-monster'),function(value){
 				element.find(".init").val(value);
 				ct_reorder(false);
 			});
 			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 		});
-		
+
 	});
-	
-	
+
+
 	if(window.DM){
 		buttons.append(roll);
 		buttons.append(clear);
 		buttons.append(reroll);
 		buttons.append(next);
 		buttons.css('font-size','10px');
-		
+
 		ct_inside.append(buttons);
 	}
-	
+
 	if(window.DM) {
 		ct.addClass('tracker-dm');
 	} else {
@@ -198,7 +198,7 @@ function init_combat_tracker(){
 			scroll: false,
 			containment: "#windowContainment",
 			start: function () {
-				$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));			
+				$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));
 				$("#sheet").append($('<div class="iframeResizeCover"></div>'));
 			},
 			stop: function () {
@@ -211,7 +211,7 @@ function init_combat_tracker(){
 		handles: "all",
 		containment: "#windowContainment",
 		start: function () {
-			$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));			
+			$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));
 			$("#sheet").append($('<div class="iframeResizeCover"></div>'));
 		},
 		stop: function () {
@@ -220,7 +220,7 @@ function init_combat_tracker(){
 		minWidth: 215,
 		minHeight: 200
 	});
-	
+
 	$("#combat_tracker_inside").mousedown(function() {
 		frame_z_index_when_click($(this));
 	});
@@ -253,17 +253,17 @@ function ct_add_token(token,persist=true,disablerolling=false){
 
 	entry=$("<tr/>");
 	entry.css("height","30px");
-	entry.attr("data-target",token.options.id);	
+	entry.attr("data-target",token.options.id);
 	entry.attr("ishidden", token.options.hidden);
 	entry.addClass("CTToken");
-	
+
 	if (typeof(token.options.ct_show) == 'undefined'){
 		if(token.options.hidden) {
 			token.options.ct_show = false;
 		}
 		else {
 			token.options.ct_show = true;
-		}	
+		}
 	}
 
 	if (token.options.ct_show == true || window.DM){
@@ -274,7 +274,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 
 		if(token.options.monster > 0)
 			entry.attr('data-monster',token.options.monster);
-		
+
 		img=$("<img width=35 height=35 class='Avatar_AvatarPortrait__2dP8u'>");
 		img.attr('src',token.options.imgsrc);
 		img.css('border','3px solid '+token.options.color);
@@ -293,21 +293,23 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			init.attr("disabled","disabled");
 		}
 		entry.append($("<td/>").append(init));
-		
+
 		// auto roll initiative for monsters
-		
+
 		if(window.DM && (token.options.monster > 0) && (!disablerolling)){
 			window.StatHandler.rollInit(token.options.monster,function(value){
 					init.val(value);
 					setTimeout(ct_reorder,1000);
 				});
 		}
-		
-		
-		
+
+
+
 		hp=$("<div class='hp'/>");
-		hp.text(token.options.hp);
-		if(hp.text() === '0'){
+		var hp_input = $("<input class='hp'>");
+		hp_input.val(token.options.hp);
+		hp.append(hp_input);
+		if(hp_input.val() === '0'){
 			entry.toggleClass("ct_dead", true);
 		}
 		else{
@@ -319,8 +321,21 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			entry.append($("<td/>").append(hp));
 		else
 			entry.append($("<td/>"))
+
+		var divider = $("<div style='display:inline-block;float:left'>/</>");
+		if((token.options.hidestat == true && !window.DM) || token.options.disablestat) {
+			divider.css('visibility', 'hidden');
+			divider.css('visibility', 'hidden');
+		}
+		if(window.DM || !(token.options.monster > 0) )
+			entry.append($("<td/>").append(divider));
+		else
+			entry.append($("<td/>"));
+
 		max_hp=$("<div class='max_hp'/>");
-		max_hp.text("/"+token.options.max_hp);
+		var maxhp_input = $("<input class='max_hp'>");
+		maxhp_input.val(token.options.max_hp);
+		max_hp.append(maxhp_input);
 		max_hp.css('font-size','11px');
 		//max_hp.css('width','20px');
 		if((token.options.hidestat == true && !window.DM) || token.options.disablestat) {
@@ -331,11 +346,38 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			entry.append($("<td/>").append(max_hp));
 		else
 			entry.append($("<td/>"));
-		
-		
+
+		// bind update functions to hp inputs, same as Token.js
+		// token update logic for hp pulls hp from token hpbar, so update hp bar manually
+		if (!token.isPlayer()) {
+			hp_input.change(function(e) {
+				var selector = "div[data-id='" + token.options.id + "']";
+				var old = $("#tokens").find(selector);
+				old.find(".hp").val(hp_input.val().trim());
+				self.update_and_sync(e);
+			});
+			hp_input.click(function(e) {
+				$(e.target).select();
+			});
+			maxhp_input.change(function(e) {
+				var selector = "div[data-id='" + token.options.id + "']";
+				var old = $("#tokens").find(selector);
+				old.find(".max_hp").val(maxhp_input.val().trim());
+				self.update_and_sync(e);
+			});
+			maxhp_input.click(function(e) {
+				$(e.target).select();
+			});
+		}
+		else {
+			hp_input.keydown(function(e) { if (e.keyCode == '13') self.update_from_page(); e.preventDefault(); }); // DISABLE WITHOUT MAKING IT LOOK UGLY
+			maxhp_input.keydown(function(e) { if (e.keyCode == '13') self.update_from_page(); e.preventDefault(); });
+		}
+
+
 		var buttons=$("<td/>");
-		
-		
+
+
 		find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg></button>');
 		find.click(function(){
 			var target=$(this).parent().parent().attr('data-target');
@@ -343,10 +385,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				window.TOKEN_OBJECTS[target].highlight();
 			}
 		});
-		
-		
+
+
 		buttons.append(find);
-		
+
 		del=$('<button class="removeTokenCombatButton" style="font-size:10px;"><svg class="delSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg></button>');
 		del.click(
 			function(){
@@ -356,10 +398,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		);
 		if(window.DM)
 			buttons.append(del);
-		
+
 		if(token.isMonster()){
 			stat=$('<button class="openSheetCombatButton" style="font-size:10px;"><svg class="statSVG" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/><g><path d="M19,5v14H5V5H19 M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3L19,3z"/></g><path d="M14,17H7v-2h7V17z M17,13H7v-2h10V13z M17,9H7V7h10V9z"/></g></svg></button>');
-			
+
 			stat.click(function(){
 				load_monster_stat(token.options.monster, token.options.id);
 			});
@@ -401,7 +443,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				buttons.prepend(eye_button);
 				buttons.prepend(ct_show_checkbox);
 			}
-		}	
+		}
 		else if (token.isPlayer()) {
 			stat=$('<button class="openSheetCombatButton" style="font-size:10px;"><svg class="statSVG" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/><g><path d="M19,5v14H5V5H19 M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3L19,3z"/></g><path d="M14,17H7v-2h7V17z M17,13H7v-2h10V13z M17,9H7V7h10V9z"/></g></svg></button>');
 			stat.click(function(){
@@ -410,13 +452,13 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			if(window.DM)
 				buttons.append(stat);
 		}
-		
+
 			entry.append(buttons);
-		
-		
+
+
 		$("#combat_area").append(entry);
 		$("#combat_area td").css("vertical-align","middle");
-		
+
 		if(persist){
 			ct_persist();
 		}
@@ -443,21 +485,21 @@ function ct_persist(){
 	});
 	data.push({'data-target': 'round',
 				'round_number':window.ROUND_NUMBER});
-	
+
 	var itemkey="CombatTracker"+find_game_id();
-	
+
 	localStorage.setItem(itemkey,JSON.stringify(data));
 	window.MB.sendMessage("custom/myVTT/CT",data);
 }
 
 function ct_load(data=null){
-	
+
 	if(data==null){
 		var itemkey="CombatTracker"+find_game_id();
 		data=$.parseJSON(localStorage.getItem(itemkey));
 	}
-	
-	if(data){	
+
+	if(data){
 		for(i=0;i<data.length;i++){
 			if (data[i]['data-target'] === 'round'){
 				window.ROUND_NUMBER = data[i]['round_number'];

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -306,7 +306,11 @@ function ct_add_token(token,persist=true,disablerolling=false){
 
 
 		hp=$("<div class='hp'/>");
+
 		var hp_input = $("<input class='hp'>");
+		if(token.isPlayer()){
+			hp_input.prop("disabled", true);
+		}
 		hp_input.val(token.options.hp);
 		hp.append(hp_input);
 		if(hp_input.val() === '0'){
@@ -325,7 +329,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		var divider = $("<div style='display:inline-block;float:left'>/</>");
 		if((token.options.hidestat == true && !window.DM) || token.options.disablestat) {
 			divider.css('visibility', 'hidden');
-			divider.css('visibility', 'hidden');
 		}
 		if(window.DM || !(token.options.monster > 0) )
 			entry.append($("<td/>").append(divider));
@@ -334,6 +337,9 @@ function ct_add_token(token,persist=true,disablerolling=false){
 
 		max_hp=$("<div class='max_hp'/>");
 		var maxhp_input = $("<input class='max_hp'>");
+		if(token.isPlayer()){
+			maxhp_input.prop("disabled", true);
+		}
 		maxhp_input.val(token.options.max_hp);
 		max_hp.append(maxhp_input);
 		max_hp.css('font-size','11px');
@@ -354,7 +360,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				var selector = "div[data-id='" + token.options.id + "']";
 				var old = $("#tokens").find(selector);
 				old.find(".hp").val(hp_input.val().trim());
-				self.update_and_sync(e);
+				token.update_and_sync(e);
 			});
 			hp_input.click(function(e) {
 				$(e.target).select();
@@ -363,7 +369,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				var selector = "div[data-id='" + token.options.id + "']";
 				var old = $("#tokens").find(selector);
 				old.find(".max_hp").val(maxhp_input.val().trim());
-				self.update_and_sync(e);
+				token.update_and_sync(e);
 			});
 			maxhp_input.click(function(e) {
 				$(e.target).select();

--- a/Token.js
+++ b/Token.js
@@ -6,13 +6,13 @@ const CUSTOM_CONDITIONS = ["Concentration(Reminder)", "Flying", "Flamed", "Rage"
 
 /*const TOKEN_COLORS=  [
 	"D1BBD7","882E72","5289C7","4EB265","CAEOAB","F6C141","E8601C","777777","AE76A3","1965BO","7BAFDE","90C987","F7F056","F1932D","DC050C",
-	"FF0000", "00FF00", "0000FF", "FFFF00", "FF00FF", "00FFFF", 
-		"800000", "008000", "000080", "808000", "800080", "008080", "808080", 
-		"C00000", "00C000", "0000C0", "C0C000", "C000C0", "00C0C0", "C0C0C0", 
-		"400000", "004000", "000040", "404000", "400040", "004040", "404040", 
-		"200000", "002000", "000020", "202000", "200020", "002020", "202020", 
-		"600000", "006000", "000060", "606000", "600060", "006060", "606060", 
-		"A00000", "00A000", "0000A0", "A0A000", "A000A0", "00A0A0", "A0A0A0", 
+	"FF0000", "00FF00", "0000FF", "FFFF00", "FF00FF", "00FFFF",
+		"800000", "008000", "000080", "808000", "800080", "008080", "808080",
+		"C00000", "00C000", "0000C0", "C0C000", "C000C0", "00C0C0", "C0C0C0",
+		"400000", "004000", "000040", "404000", "400040", "004040", "404040",
+		"200000", "002000", "000020", "202000", "200020", "002020", "202020",
+		"600000", "006000", "000060", "606000", "600060", "006060", "606060",
+		"A00000", "00A000", "0000A0", "A0A000", "A000A0", "00A0A0", "A0A0A0",
 		"E00000", "00E000", "0000E0", "E0E000", "E000E0", "00E0E0", "E0E0E0", "000000"];*/
 
 // const TOKEN_COLORS = ["8DB6C7","","D1C6BF","CA9F92","","E3D9BO","B1C27A","B2E289","51COBF","59ADDO","","9FA3E3","099304","DB8DB2","F1C3DO"];
@@ -52,7 +52,7 @@ class Token {
 		this.persist = null;
 		if(window.CLOUD)
 			this.persist= ()=>{};
-		
+
 		this.doing_highlight = false;
 		if (typeof this.options.size == "undefined") {
 			this.options.size = window.CURRENT_SCENE_DATA.hpps; // one grid square
@@ -211,7 +211,7 @@ class Token {
 	        this.options.custom_conditions.push(conditionName);
 	    }
 	}
-	
+
 	removeCondition(conditionName) {
 		if (STANDARD_CONDITIONS.includes(conditionName)) {
 			if (this.isPlayer()) {
@@ -304,13 +304,13 @@ class Token {
 		if (window.DM && this.options.locked) return; // don't allow rotating if the token is locked
 		this.update_from_page();
 		this.options.rotation = newRotation;
-		// this is copied from the place() function. Rather than calling place() every time the draggable.drag function executes, 
+		// this is copied from the place() function. Rather than calling place() every time the draggable.drag function executes,
 		// this just rotates locally to help with performance.
-		// draggable.stop will call place_sync_persist to finalize the rotation. 
+		// draggable.stop will call place_sync_persist to finalize the rotation.
 		// If we ever want this to send to all players in real time, simply comment out the rest of this function and call place_sync_persist() instead.
 		let scale = this.get_token_scale();
 		if(this.options.imageSize === undefined) {
-			this.imageSize(1) 
+			this.imageSize(1)
 		}
 		let imageScale = this.options.imageSize;
 
@@ -353,9 +353,9 @@ class Token {
 
 		// Stop movement if new position is outside of the scene
 		if (
-			top  < this.walkableArea.top    || 
+			top  < this.walkableArea.top    ||
 			top  > this.walkableArea.bottom ||
-			left < this.walkableArea.left   || 
+			left < this.walkableArea.left   ||
 			left > this.walkableArea.bottom
 		) { return; }
 
@@ -374,7 +374,7 @@ class Token {
 		if (window.DM && this.options.locked) return; // don't allow moving if the token is locked
 		// shamelessly copied from the draggable code later in this file
 		// this should be a XOR... (A AND !B) OR (!A AND B)
-		let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);		
+		let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);
 		if (shallwesnap) {
 			// calculate offset in real coordinates
 			const startX = window.CURRENT_SCENE_DATA.offsetx;
@@ -382,7 +382,7 @@ class Token {
 
 			const selectedOldTop = parseInt(this.options.top);
 			const selectedOldleft = parseInt(this.options.left);
-			
+
 			const selectedNewtop =  Math.round(Math.round( (selectedOldTop - startY) / window.CURRENT_SCENE_DATA.vpps)) * window.CURRENT_SCENE_DATA.vpps + startY;
 			const selectedNewleft = Math.round(Math.round( (selectedOldleft - startX) / window.CURRENT_SCENE_DATA.hpps)) * window.CURRENT_SCENE_DATA.hpps + startX;
 
@@ -393,7 +393,7 @@ class Token {
 			this.options.top = `${selectedNewtop}px`;
 			this.options.left = `${selectedNewleft}px`;
 			this.place_sync_persist();
-		}		
+		}
 	}
 	place_sync_persist() {
 		this.place();
@@ -417,7 +417,7 @@ class Token {
 			var pageX = Math.round(parseInt(this.options.left) * window.ZOOM - ($(window).width() / 2));
 			var pageY = Math.round(parseInt(this.options.top) * window.ZOOM - ($(window).height() / 2));
 			console.log(this.options.left + " " + this.options.top + "->" + pageX + " " + pageY);
-			
+
 			if(!dontscroll){
 			$("html,body").animate({
 				scrollTop: pageY + 200,
@@ -471,7 +471,7 @@ class Token {
 		let tokenData = this.munge_token_data()
 		if(tokenData.max_hp > 0){
 			// add a cross if it doesn't exist
-			if(token.find(".dead").length === 0) 
+			if(token.find(".dead").length === 0)
 				token.prepend(`<div class="dead" hidden></div>`);
 			// update cross scale
 			const deadCross = token.find('.dead')
@@ -508,7 +508,7 @@ class Token {
 		if (tokenData.max_hp > 0) {
 		 	var tokenHpAuraColor = token_health_aura(
 				Math.round((tokenData.hp / tokenData.max_hp) * 100)
-			);	
+			);
 		}
 		token.css('--hp-percentage', Math.round((tokenData.hp / tokenData.max_hp) * 100) + "%");
 
@@ -516,11 +516,11 @@ class Token {
 
 		let tokenWidth = this.sizeWidth();
 		let tokenHeight = this.sizeHeight();
-			
+
 		if(tokenData.disableaura || !tokenData.hp || !tokenData.max_hp) {
 			token.css('--token-hp-aura-color', 'transparent');
 			token.css('--token-temp-hp', "transparent");
-		} 
+		}
 		else {
 			if(this.options.tokenStyleSelect === "circle" || this.options.tokenStyleSelect === "square"){
 				tokenWidth = tokenWidth - 6;
@@ -537,7 +537,7 @@ class Token {
 		if(tokenData.disableborder) {
 			token.css('--token-border-color', 'transparent');
 			$("token:before").css('--token-border-color', 'transparent');
-		} 
+		}
 		else {
 			if(this.options.tokenStyleSelect === "circle" || this.options.tokenStyleSelect === "square"){
 				tokenWidth = tokenWidth - 1;
@@ -579,7 +579,7 @@ class Token {
 						token.children('.token-image').css("min-height", tokenHeight + 'px');
 						token.children('.token-image').css("min-width", '');
 					}
-									
+
 				}
 			}
 		}
@@ -587,8 +587,8 @@ class Token {
 			token.children('.token-image').css("min-width", "");
 			token.children('.token-image').css("min-height", "");
 		}
-		
-		token.children('.token-image').css({		
+
+		token.children('.token-image').css({
 		    'max-width': tokenWidth + 'px',
 			'max-height': tokenHeight + 'px',
 		});
@@ -602,7 +602,7 @@ class Token {
 			};
 			window.MB.inject_chat(msgdata);
 		}
-		
+
 		console.groupEnd()
 	}
 
@@ -634,7 +634,7 @@ class Token {
 			this.options.hidden = true;
 		else
 			delete this.options.hidden;
-		
+
 		// one of either
 		// is a monster?
 		// is the DM
@@ -650,7 +650,7 @@ class Token {
 			$("input").blur();
 			this.options.hp = old.find(".hp").val();
 			this.options.max_hp = old.find(".max_hp").val();
-			
+
 			this.update_dead_cross(old)
 			this.update_health_aura(old)
 		}
@@ -674,14 +674,14 @@ class Token {
 	}
 	update_combat_tracker(){
 		/* UPDATE COMBAT TRACKER */
-		$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").text(this.options.hp);
-		$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").text("/"+this.options.max_hp);
+		$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").val(this.options.hp);
+		$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").val(this.options.max_hp);
 
 
 		if((!window.DM && this.options.hidestat == true) || this.options.disablestat == true) {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'hidden');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'hidden');
-		}	
+		}
 		else {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'visible');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'visible');
@@ -692,7 +692,7 @@ class Token {
 		else{
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").toggleClass("ct_dead", false);
 		}
-		
+
 		if (this.options.hidden == false || typeof this.options.hidden == 'undefined'){
 			console.log("Setting combat tracker opacity to 1.0")
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").find('img').css('opacity','1.0');
@@ -954,13 +954,13 @@ class Token {
 			array_remove_index_by_value(this.options.custom_conditions, "Inspiration");
 			array_remove_index_by_value(this.options.custom_conditions, "Inspiration");
 		}
-		
-		
+
+
 		const conditionsTotal = this.options.conditions.length + this.options.custom_conditions.length + (this.options.id in window.JOURNAL.notes && (window.DM || window.JOURNAL.notes[this.options.id].player));
 
 		if (conditionsTotal > 0) {
 			let conditionCount = 0;
-			
+
 			for (let i = 0; i < this.options.conditions.length; i++) {
 				const conditionName = this.options.conditions[i];
 				const isExhaustion = conditionName.startsWith("Exhaustion");
@@ -1020,7 +1020,7 @@ class Token {
 						cond.append(conditionContainer);
 					}
 				}
-				
+
 				conditionCount++;
 			}
 			// CHECK IF ADDING NOTE CONDITION
@@ -1049,8 +1049,8 @@ class Token {
 			}
 
 		}
-				
-		
+
+
 		if (parent) {
 			parent.find(".conditions").remove();
 			parent.append(cond);
@@ -1062,7 +1062,7 @@ class Token {
 	}
 
 	place(animationDuration) {
-		
+
 		if(!window.CURRENT_SCENE_DATA){
 			// No scene loaded!
 			return;
@@ -1093,13 +1093,13 @@ class Token {
 			console.log("trovato!!");
 
 			if (old.css("left") != this.options.left || old.css("top") != this.options.top)
-				
+
 				remove_selected_token_bounding_box();
 				if(old.is(':animated')){
 					// this token is being moved quickly, speed up the animation
 					animationDuration = 100;
 				}
-				
+
 				old.animate(
 					{
 						left: this.options.left,
@@ -1107,7 +1107,7 @@ class Token {
 					}, { duration: animationDuration, queue: true, complete: function() {
 						draw_selected_token_bounding_box();
 					} });
-				
+
 
 
 
@@ -1115,14 +1115,14 @@ class Token {
 			old.find(".token-image").css("transition", "max-height 0.2s linear, max-width 0.2s linear, transform 0.2s linear")
 			old.find(".token-image").css("transform", "scale(" + imageScale + ") rotate("+rotation+"deg)");
 			old.css("--token-rotation", rotation+"deg");
-			setTimeout(function() {old.find(".token-image").css("transition", "")}, 200);		
-			
+			setTimeout(function() {old.find(".token-image").css("transition", "")}, 200);
+
 			var selector = "tr[data-target='"+this.options.id+"']";
 			var entry = $("#combat_area").find(selector);
 			if((!(this.options.name) || !(this.options.revealname)) && !window.DM) {
 				old.toggleClass('hasTooltip', false);
 				entry.toggleClass('hasTooltip', false);
-			}	
+			}
 			else if (this.options.name) {
 				if ((window.DM || !this.options.monster || this.options.revealname)) {
 					old.attr("data-name", this.options.name);
@@ -1146,7 +1146,7 @@ class Token {
 					width: this.sizeWidth(),
 					height: this.sizeHeight()
 				}, { duration: 1000, queue: false });
-				
+
 				var zindexdiff=(typeof this.options.zindexdiff == 'number') ? this.options.zindexdiff : Math.round(17/ (this.options.size/window.CURRENT_SCENE_DATA.hpps)); // width vs height here?
 				this.options.zindexdiff = Math.max(zindexdiff, -5000);
 				old.css("z-index", "calc(5000 + var(--z-index-diff))");
@@ -1224,7 +1224,7 @@ class Token {
 			}
 			else if((window.DM && this.options.restrictPlayerMove) || !this.options.locked){
 				old.draggable("enable");
-			}	
+			}
 			else if(!window.DM && (!this.options.restrictPlayerMove || !this.options.locked)){
 				old.draggable("enable");
 			}
@@ -1243,7 +1243,7 @@ class Token {
 		else { // adding a new token
 			// console.group("new token")
 			var tok = $("<div/>");
-			
+
 			var bar_height = Math.floor(this.sizeHeight() * 0.2);
 
 			if (bar_height > 60)
@@ -1291,7 +1291,7 @@ class Token {
 			var zindexdiff=(typeof this.options.zindexdiff == 'number') ? this.options.zindexdiff : Math.round(17/ (this.options.size/window.CURRENT_SCENE_DATA.hpps)); // sizeHeight() or sizeWidth() here?
 			this.options.zindexdiff = Math.max(zindexdiff, -5000);
 			console.log("Diff: "+zindexdiff);
-			
+
 			tok.css("z-index", "calc(5000 + var(--z-index-diff))");
 			tok.width(this.sizeWidth());
 			tok.height(this.sizeHeight());
@@ -1306,7 +1306,7 @@ class Token {
 			this.update_health_aura(tok);
 
 
-				
+
 			tok.css("position", "absolute");
 			tok.css("--z-index-diff", zindexdiff);
 			tok.css("top", this.options.top);
@@ -1364,11 +1364,11 @@ class Token {
 						tok.removeAttr("data-dragging")
 						tok.removeAttr("data-drag-x")
 						tok.removeAttr("data-drag-y")
-			
+
 						// this should be a XOR... (A AND !B) OR (!A AND B)
 						let shallwesnap=  (window.CURRENT_SCENE_DATA.snap == "1"  && !(window.toggleSnap)) || ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);
 						console.log("shallwesnap",shallwesnap);
-						console.log("toggleSnap",window.toggleSnap);					
+						console.log("toggleSnap",window.toggleSnap);
 						if (shallwesnap) {
 
 							// calculate offset in real coordinates
@@ -1377,7 +1377,7 @@ class Token {
 
 							const selectedOldTop = parseInt($(event.target).css("top"));
 							const selectedOldleft = parseInt($(event.target).css("left"));
-							
+
 
 							const selectedNewtop =  Math.round(Math.round( (selectedOldTop - startY) / window.CURRENT_SCENE_DATA.vpps)) * window.CURRENT_SCENE_DATA.vpps + startY;
 							const selectedNewleft = Math.round(Math.round( (selectedOldleft - startX) / window.CURRENT_SCENE_DATA.hpps)) * window.CURRENT_SCENE_DATA.hpps + startX;
@@ -1440,7 +1440,7 @@ class Token {
 						}
 
 						window.DRAGGING = false;
-						
+
 						self.update_and_sync(event);
 						if (self.selected) {
 							for (id in window.TOKEN_OBJECTS) {
@@ -1475,9 +1475,9 @@ class Token {
 					if(tok.is(":animated")){
 						self.stopAnimation();
 					}
-					
+
 					// for dragging behind iframes so tokens don't "jump" when you move past it
-					$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));			
+					$("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));
 					$("#sheet").append($('<div class="iframeResizeCover"></div>'));
 
 					console.log("Click x: " + click.x + " y: " + click.y);
@@ -1505,9 +1505,9 @@ class Token {
 								}
 							}
 
-						}												
+						}
 					}
-					
+
 
 					const el = $("#aura_" + self.options.id.replaceAll("/", ""));
 					if (el.length > 0) {
@@ -1562,7 +1562,7 @@ class Token {
 						tokenX += (window.CURRENT_SCENE_DATA.hpps / 2);
 						tokenY += (window.CURRENT_SCENE_DATA.vpps / 2);
 					}
-					
+
 					// this was copied the place function in this file. We should make this a single function to be used in other places
 					let tokenPosition = snap_point_to_grid(tokenX + (window.CURRENT_SCENE_DATA.hpps / 2), tokenY + (window.CURRENT_SCENE_DATA.vpps / 2));
 
@@ -1588,7 +1588,7 @@ class Token {
 								context.setLineDash([])
 								// list the temp overlay so we can see the ruler
 								clear_temp_canvas()
-								
+
 								WaypointManager.setCanvas(canvas);
 								WaypointManager.registerMouseMove(tokenMidX, tokenMidY);
 								WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, tokenMidX, tokenMidY);
@@ -1603,7 +1603,7 @@ class Token {
 					currentTokenPosition.y = tokenPosition.y;
 
 					//console.log("Changing to " +ui.position.left+ " "+ui.position.top);
-					// HACK TEST 
+					// HACK TEST
 					/*$(event.target).css("left",ui.position.left);
 					$(event.target).css("top",ui.position.top);*/
 					// END OF HACK TEST
@@ -1647,7 +1647,7 @@ class Token {
 									selEl.css('top', (currTop + offsetTop) + "px");
 								}
 							}
-						}													
+						}
 					}
 
 				}
@@ -1686,7 +1686,7 @@ class Token {
 					toggle_player_selectable(window.TOKEN_OBJECTS[tokID], parentToken)
 				} else {
 					parentToken.removeClass('tokenselected');
-				}				
+				}
 
 				window.TOKEN_OBJECTS[tokID].selected = thisSelected;
 
@@ -1694,13 +1694,13 @@ class Token {
 					var curr = window.TOKEN_OBJECTS[id];
 					if (curr.selected == true) {
 						count++;
-					}			
+					}
 				}
 
 				window.MULTIPLE_TOKEN_SELECTED = (count > 1);
 				draw_selected_token_bounding_box(); // update rotation bounding box
 			});
-			
+
 			console.groupEnd()
 		}
 		// HEALTH AURA / DEAD CROSS
@@ -1754,16 +1754,16 @@ class Token {
 		};
 
 		// shorten variable to improve readability
-		const multi = this.SCENE_MOVE_GRID_PADDING_MULTIPLIER; 
+		const multi = this.SCENE_MOVE_GRID_PADDING_MULTIPLIER;
 
 		this.walkableArea = {
 			top:  0 - (sizeOnGrid.y * multi),
 			left: 0 - (sizeOnGrid.x * multi),
 			right:  window.CURRENT_SCENE_DATA.width  + (sizeOnGrid.x * (multi -1)), // we need to remove 1 token size because tokens are anchored in the top left
 			bottom: window.CURRENT_SCENE_DATA.height + (sizeOnGrid.y * (multi -1)), // ... same as above
-		};	
+		};
 	}
-	
+
 }
 
 /**
@@ -1959,7 +1959,7 @@ function place_token_at_map_point(tokenObject, x, y) {
 	}
 	window.MB.sendMessage('custom/myVTT/token', options);
 
-	
+
 	fetch_and_cache_scene_monster_items();
 	update_pc_token_rows();
 }
@@ -2109,7 +2109,7 @@ function setTokenAuras (token, options) {
 							`;
 		const tokenId = token.attr("data-id").replaceAll("/", "");
 		if (token.parent().parent().find("#aura_" + tokenId).length > 0) {
-			token.parent().parent().find("#aura_" + tokenId).attr("style", auraStyles);	
+			token.parent().parent().find("#aura_" + tokenId).attr("style", auraStyles);
 		} else {
 			const auraElement = $(`<div class='aura-element' id="aura_${tokenId}" style='${auraStyles}' />`);
 			auraElement.contextmenu(function(){return false;});
@@ -2127,8 +2127,8 @@ function setTokenAuras (token, options) {
 			$("[id='aura_" + tokenId + "'] > [id='aura_" + tokenId + "']").remove();
 			let auraClone = $("[id='aura_" + tokenId + "']").clone();
 			auraClone.addClass("lightAura");
-			$("[id='aura_" + tokenId + "']").append(auraClone);		
-			$("[id='aura_" + tokenId + "']").attr("style", auraStyles);				
+			$("[id='aura_" + tokenId + "']").append(auraClone);
+			$("[id='aura_" + tokenId + "']").attr("style", auraStyles);
 			let lightblur = totalSize/50 + "px";
 			$("[id='aura_" + tokenId + "']").css('--light-blur', lightblur);
 			token.parent().parent().children("#aura_" + tokenId).toggleClass("haslightchild", true);
@@ -2138,7 +2138,7 @@ function setTokenAuras (token, options) {
 			token.parent().parent().children("#aura_" + tokenId).toggleClass("haslightchild", false);
 		}
 
-		
+
 	} else {
 		const tokenId = token.attr("data-id").replaceAll("/", "");
 		token.parent().parent().find("#aura_" + tokenId).remove();
@@ -2301,7 +2301,7 @@ function load_custom_monster_image_mapping() {
 function save_custom_monster_image_mapping() {
 	let customMappingData = JSON.stringify(window.CUSTOM_TOKEN_IMAGE_MAP);
 	localStorage.setItem("CustomDefaultTokenMapping", customMappingData);
-	// The JSON structure for CUSTOM_TOKEN_IMAGE_MAP looks like this { 17100: [ "some.url.com/img1.png", "some.url.com/img2.png" ] }	
+	// The JSON structure for CUSTOM_TOKEN_IMAGE_MAP looks like this { 17100: [ "some.url.com/img1.png", "some.url.com/img2.png" ] }
 }
 
 function copy_to_clipboard(text) {
@@ -2486,17 +2486,17 @@ function do_draw_selected_token_bounding_box() {
 		y: 0
 	};
 	grabber.draggable({
-		start: function (event) { 
+		start: function (event) {
 			// adjust based on zoom level
 			click.x = event.clientX;
 			click.y = event.clientY;
 			self.orig_top = grabberTop;
 			self.orig_left = grabberLeft;
-			
+
 			// the drag has started so remove the bounding boxes, but not the grabber
 			$("#selectedTokensBorder").remove();
 			$("#selectedTokensBorderRotationGrabberConnector").remove();
-			$("#rotationGrabberHolder").remove();		
+			$("#rotationGrabberHolder").remove();
 		},
 		drag: function(event, ui) {
 			// adjust based on zoom level
@@ -2515,7 +2515,7 @@ function do_draw_selected_token_bounding_box() {
 				token.rotate(angle);
 			}
 		},
-		stop: function (event) { 
+		stop: function (event) {
 			// rotate for all players
 			for (let i = 0; i < window.CURRENTLY_SELECTED_TOKENS.length; i++) {
 				let id = window.CURRENTLY_SELECTED_TOKENS[i];
@@ -2540,7 +2540,7 @@ function copy_selected_tokens() {
 	let redrawBoundingBox = false;
 	for (id in window.TOKEN_OBJECTS) {
 		let token = window.TOKEN_OBJECTS[id];
-		if (token.selected) { 
+		if (token.selected) {
 			if (token.isPlayer()) {
 				// deselect player tokens to avoid confusion about them being selected but not copy/pasted
 				window.TOKEN_OBJECTS[id].selected = false;
@@ -2593,7 +2593,7 @@ function delete_selected_tokens() {
 	for (id in window.TOKEN_OBJECTS) {
 		let token = window.TOKEN_OBJECTS[id];
 		if (token.selected) {
-			if (window.DM || token.options.deleteableByPlayers == true) {				
+			if (window.DM || token.options.deleteableByPlayers == true) {
 				tokensToDelete.push(token);
 			}
 		}

--- a/Token.js
+++ b/Token.js
@@ -686,7 +686,7 @@ class Token {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'visible');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'visible');
 		}
-		if($("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").text() === '0'){
+		if($("#combat_tracker_inside tr[data-target='" + this.options.id + "'] input.hp").val() === '0'){
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").toggleClass("ct_dead", true);
 		}
 		else{

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -882,13 +882,44 @@ div#scene_properties form > div {
 .ct_dead img{
     filter: saturate(0);
 }
+.hp,
+.max_hp,
+td:nth-of-type(4){
+    color: #000000dd;
+}
 .ct_dead .hp,
-.ct_dead .max_hp{
+.ct_dead .max_hp,
+.ct_dead td:nth-of-type(4){
     color: #bc0f0f;
 }
 #combat_area .ct_dead[data-current][data-target*="characters"]{
     background: none;
 }
+#combat_area [data-target*="characters"] input:not(.init){
+    text-decoration: none;
+    background: none;
+    border-width: 0;
+}
+#combat_area [data-monster] input.hp{
+    text-decoration: underline solid 0.5px #1b9af033;
+}
+#combat_area [data-monster].ct_dead input.hp{
+    text-decoration-color: #bc0f0f33;
+}
+
+#combat_area [data-monster] input:not(.init){
+    border-width: 0;
+    background: none;
+}
+
+#combat_area [data-monster] input.hp:focus{
+    text-decoration: underline;
+}
+#combat_area [data-monster] input:not(.init):focus{
+    border-width: 1px;
+}
+
+
 .ct_dead:not([data-target*="characters"]) .delSVG path:not([fill*="none"]){
     fill: #ff4848;
     opacity: 0.7;
@@ -3206,11 +3237,15 @@ button.avtt-roll-button {
 }
 #combat_area tr td:first-of-type,
 #combat_area tr td:nth-of-type(2),
-#combat_area tr td:nth-of-type(4){
-    width: 10%;
+#combat_area tr td:nth-of-type(5)
+{
+    width: 13%;
 }
-#combat_area tr td:nth-of-type(3){
-    width: 15%;
+#combat_area tr td:nth-of-type(4) {
+    width: 5px;
+}
+#combat_area tr td:nth-of-type(3) {
+    width: 13%;
 }
 #combat_area tr td:first-of-type,
 #combat_area tr td:nth-of-type(2),
@@ -3570,7 +3605,7 @@ button.avtt-roll-button {
     border-collapse:collapse;  
 }
 
-#combat_area td input,
+#combat_area td input.init,
 #round_number_label input{
     border-radius: 3px;
     border-color: #ddd;
@@ -3579,6 +3614,20 @@ button.avtt-roll-button {
     text-align:center;
     font-size: 14px !important;
 }
+#combat_area td input:not(.init){
+    border-radius: 3px;
+    border-color: #ddd;
+    width: 100% !important;
+    height:22px;
+}
+#combat_area td input.hp{
+    text-align: right;
+}
+
+#combat_area td input.max_hp{
+    text-align: left;
+}
+
 #round_number_label input{
     font-weight: 600;
     -moz-appearance: textfield !important;
@@ -3593,7 +3642,9 @@ button.avtt-roll-button {
 }
 
 
-#combat_area tr td div{
+#combat_area tr td div,
+#combat_area tr td input.hp,
+#combat_area tr td input.max_hp{
     top: 1px;
     position: relative;
     font-size: 18px !important; 
@@ -3648,7 +3699,8 @@ button.avtt-roll-button {
 #combat_area tr[data-current] td img{      
      box-shadow: 1px 1px 2px 0px #000000;  
 }
-#combat_area tr td input,
+#combat_area tr td input.init,
+#combat_area tr td input:focus,
 .roundNum,
 #combat_area tr td img {
     box-shadow: 1px 1px 1px 0px #00000047;
@@ -3659,6 +3711,10 @@ button.avtt-roll-button {
 #combat_tracker input[readonly]{
     opacity: 1;
     border-style: solid;
+}
+input.hp[disabled],
+input.max_hp[disabled]{
+    opacity: 1;
 }
 
 #combat_footer{


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5218040/179305904-19feffd3-0742-48e6-af11-f453b08e6d21.png)

With this change, the current and max hp options on the combat tracker are input fields for DMs, so they can change monster hp from the tracker. Changes on either the token or combat tracker affect the other.

Open to feedback on css/visual style