### PR TITLE
Fix snap to grid over calculation

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1564,7 +1564,7 @@ class Token {
 					}
 					
 					// this was copied the place function in this file. We should make this a single function to be used in other places
-					let tokenPosition = snap_point_to_grid(tokenX + (window.CURRENT_SCENE_DATA.hpps / 2), tokenY + (window.CURRENT_SCENE_DATA.vpps / 2));
+					let tokenPosition = snap_point_to_grid(tokenX, tokenY);
 
 					// Constrain token within scene
 					tokenPosition.x = clamp(tokenPosition.x, self.walkableArea.left, self.walkableArea.right);


### PR DESCRIPTION
Since this addition is handled in the lines (1562 & 1563) above adding it twice made snap to grid token drag off and it feels weird. This doesn't fix the problem I've noticed with dragging a token that scrolls the window - that still puts the token off the mouse a bit. 
 
This partially fixes #605 for one of the dragging issues.

Edit: Doing more testing this looks like this also fixes non snap to grid token dragging a bit. On main it snaps to the corner of the token with this it stays where you grab it.