### PR TITLE
Fix token selection for aoe - changes the selection target to the image

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1243,11 +1243,13 @@ function drawing_mouseup(e) {
 		var c = 0;
 		for (id in window.TOKEN_OBJECTS) {
 			var curr = window.TOKEN_OBJECTS[id];
-			var toktop = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().top) + window.scrollY - 200) * (1.0 / window.ZOOM);
-			var tokleft = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
-			var tokright = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().right) + window.scrollX - 200) * (1.0 / window.ZOOM);
-			var tokbottom = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
-
+			
+			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();			
+			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM);
+			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
+			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM);
+			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
+			
 			if ((Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom)) == tokbottom || (Math.max(window.BEGIN_MOUSEY, mouseY, toktop) == toktop))
 				continue;
 			if ((Math.min(window.BEGIN_MOUSEX, mouseX, tokright)) == tokright || (Math.max(window.BEGIN_MOUSEX, mouseX, tokleft) == tokleft))

--- a/Fog.js
+++ b/Fog.js
@@ -1243,10 +1243,10 @@ function drawing_mouseup(e) {
 		var c = 0;
 		for (id in window.TOKEN_OBJECTS) {
 			var curr = window.TOKEN_OBJECTS[id];
-			var toktop = parseInt(curr.options.top);
-			var tokleft = parseInt(curr.options.left);
-			var tokright = tokleft + parseInt(curr.options.size);
-			var tokbottom = toktop + parseInt(curr.options.size);
+			var toktop = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().top) + window.scrollY - 200) * (1.0 / window.ZOOM);
+			var tokleft = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
+			var tokright = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().right) + window.scrollX - 200) * (1.0 / window.ZOOM);
+			var tokbottom = (parseInt($("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect().bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
 
 			if ((Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom)) == tokbottom || (Math.max(window.BEGIN_MOUSEY, mouseY, toktop) == toktop))
 				continue;

--- a/Token.js
+++ b/Token.js
@@ -1272,10 +1272,11 @@ class Token {
 				tokenImage.css("max-height", this.options.size);
 				tokenImage.css("max-width", this.options.size);
 				tokenImage.attr("src", this.options.imgsrc);
+				tok.toggleClass("isAoe", false);
 
 			} else {
 				tokenImage = build_aoe_token_image(this, imageScale, rotation)
-
+				tok.toggleClass("isAoe", true);
 			}
 			tok.css("--token-rotation", rotation + "deg");
 			tok.append(tokenImage);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1890,7 +1890,12 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 
 
 /* END AOE STYLES */
-
+.token.isAoe{
+    visibility: hidden;
+}
+.token.isAoe *{
+    visibility: visible;
+}
 .aoe-token-tileable {
     height: 100%;
     width: 100%;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1893,7 +1893,9 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
 .token.isAoe{
     visibility: hidden;
 }
-.token.isAoe *{
+.token.isAoe .token-image,
+.token.isAoe .token-image *,
+.token.isAoe:before{
     visibility: visible;
 }
 .aoe-token-tileable {


### PR DESCRIPTION
Here's an option for fixing the aoe selection of lines. This changes token selection target to the images which are also already the drag handles for tokens. It made sense to me to have the drag and selection targets the same and it fixes this issue and allows selection of some other scaled tokens that might not be square. Might want to do some testing to see how it feels for you guys.

This also hides the invisible parts of the line aoe token so they don't stop you from interacting with the rest of the map around it.