### PR TITLE
Only player token names should always be visible

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -267,7 +267,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	}
 
 	if (token.options.ct_show == true || window.DM){
-		if ((token.options.name) && (window.DM || !token.options.monster || token.options.revealname)) {
+		if ((token.options.name) && (window.DM || token.isPlayer() || token.options.revealname)) {
 			entry.attr("data-name", token.options.name);
 			entry.addClass("hasTooltip");
 		}

--- a/Token.js
+++ b/Token.js
@@ -1124,7 +1124,7 @@ class Token {
 				entry.toggleClass('hasTooltip', false);
 			}	
 			else if (this.options.name) {
-				if ((window.DM || !this.options.monster || this.options.revealname)) {
+				if ((window.DM || this.isPlayer() || this.options.revealname)) {
 					old.attr("data-name", this.options.name);
 					old.toggleClass('hasTooltip', true);
 					entry.attr("data-name", this.options.name);
@@ -1319,7 +1319,7 @@ class Token {
 			if (typeof this.options.monster !== "undefined")
 				tok.attr('data-monster', this.options.monster);
 
-			if ((this.options.name) && (window.DM || !this.options.monster || this.options.revealname)) {
+			if ((this.options.name) && (window.DM || this.isPlayer() || this.options.revealname)) {
 				tok.attr("data-name", this.options.name);
 				tok.addClass("hasTooltip");
 			}


### PR DESCRIPTION
The current logic only checks the hidden-name token option for monster tokens. This PR extends that check to all non-player tokens.