### PR TITLE
Force cloud migration

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2912,6 +2912,10 @@ function init_ui() {
 		setTimeout(get_pclist_player_data,25000);
 	}
 
+	if(window.DM && (!window.CLOUD)){
+		alert("YOUR SCENES ARE BEING MIGRATED TO THE CLOUD IN 20 SECONDS. AFTER THIS MIGRATION YOU'LL FIND YOUR SCENES ON THE RIGHT PANEL.");
+		setTimeout(cloud_migration,20000);
+	}
 }
 
 const DRAW_COLORS = ["#D32F2F", "#FB8C00", "#FFEB3B", "#9CCC65", "#039BE5", 


### PR DESCRIPTION
It turned out that #605 was related to "non cloud" users.

This PR forces the cloud_migration for campaigns that are still non-migrated.

