### PR TITLE
Fix loading combat tracker on initial load and scene swaps for players

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2777,8 +2777,6 @@ function init_ui() {
 			if(!window.CLOUD){
 				window.ScenesHandler.switch_scene(window.ScenesHandler.current_scene_id, ct_load); // LOAD THE SCENE AND PASS CT_LOAD AS CALLBACK
 			}
-			// also sync the journal
-			window.JOURNAL.sync();
 		}, 5000);
 	}
 	setTimeout(function() {

--- a/Main.js
+++ b/Main.js
@@ -2751,8 +2751,7 @@ function init_ui() {
 	}
 	else
 	{
-		setTimeout(function() {
-			window.MB.sendMessage("custom/myVTT/syncmeup");
+		setTimeout(function() {		
 			notify_player_join();
 			init_player_sheet(window.PLAYER_SHEET);
 			report_connection();

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1338,6 +1338,8 @@ class MessageBroker {
 				}
 				window.MB.sendMessage("custom/myVTT/soundpad", data); // refresh soundpad
 			}
+			// also sync the journal
+			window.JOURNAL.sync();
 		}
 	}
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1284,7 +1284,8 @@ class MessageBroker {
 
 			if(window.DM)
 				get_pclist_player_data();
-
+			else
+				window.MB.sendMessage("custom/myVTT/syncmeup");
 
 
 			if (window.EncounterHandler !== undefined) {


### PR DESCRIPTION
Better place to request syncmeup for loading both initial and into new scenes for players. I think this stops the race condition that was a problem before.

Credit to @Rishabh2 for working through this to find the issue

Edit: Also move the journal sync here as it was erroring out the same