### PR TITLE
Fix: Build hidden sidebar for players so sound can be played properly

### DIFF
--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -26,12 +26,12 @@ function init_sidebar_tabs() {
     update_pclist();
   }
 
-  if (window.DM) { // players will eventually have audio volume control in the settings panel
-    $("#sounds-panel").remove();
-    soundsPanel = new SidebarPanel("sounds-panel", false);
-    sidebarContent.append(soundsPanel.build());
-    init_audio();
-  }
+  
+  $("#sounds-panel").remove();
+  soundsPanel = new SidebarPanel("sounds-panel", false);
+  sidebarContent.append(soundsPanel.build());
+  init_audio();
+  
 
   $("#journal-panel").remove();
   journalPanel = new SidebarPanel("journal-panel", false);

--- a/SoundPad.js
+++ b/SoundPad.js
@@ -385,67 +385,66 @@ function init_audio(){
 	
 	if(!window.DM)
 		youtube_section.hide();
-	
-	if(window.DM){
-		selector_section=$("<div/>");
-		soundpad_selector=$("<select id='soundpad_selector'/>");
-		soundpad_selector.append("<option value=''>-</option>");
-		for(k in window.SOUNDPADS){
-			soundpad_selector.append($("<option/>").attr('value',k).html(k));
-		}
-		selector_section.append("Load Soundpad:");
-		selector_section.append(soundpad_selector);
-		selector_section.append("Enable Edit:");
-		soundpad_enable_edit=$("<input type='checkbox' id='soundpad_enable_edit'>");
-		
-		soundpad_enable_edit.change(soundpad_check_editable);
-		selector_section.append(soundpad_enable_edit);
-		
-		btn_addsoundpad=$("<button class='soundpad_add'>NEW</button>");
-		selector_section.append(btn_addsoundpad);
-		soundsPanel.body.append(selector_section);
-		
-		btn_addsoundpad.click(function(){
-			var newname=prompt("New Soundpad Name");
-			if(newname){
-				window.SOUNDPADS[newname]={};
-				soundpad_selector.append($("<option/>").attr('value',newname).html(newname));
-				soundpad_selector.val(newname);
-				$("#soundpad_enable_edit").prop('checked', true);
-				build_soundpad(window.SOUNDPADS[newname]);
-			}
-		});
-		
-		
-		btn_delsoundpad=$("<button class='soundpad_del'>DEL</button>");
-		btn_delsoundpad.click(function(){
-			c=confirm("Are you sure that you want to delete the current soundpad?");
-			if(c){
-				delete window.SOUNDPADS[soundpad_selector.val()];
-				$("#soundpad").empty();
-				soundpad_selector.empty();
-				soundpad_selector.append("<option value=''>-</option>");
-				for (k in window.SOUNDPADS) {
-					soundpad_selector.append($("<option/>").attr('value', k).html(k));
-				}
-				persist_soundpad();
-			}
-		});
-		selector_section.append(btn_delsoundpad);
-		
-		soundpad_selector.on("change",function(){
-			$("#soundpad").empty();
-			soundpad_id=$("#soundpad_selector").val();
-			if(soundpad_id!=""){
-				build_soundpad(window.SOUNDPADS[soundpad_id]);
-				
-				data={
-					soundpad: window.SOUNDPADS[soundpad_id]
-				}
-				window.MB.sendMessage("custom/myVTT/soundpad",data);
-			}
-		});
+
+	selector_section=$("<div/>");
+	soundpad_selector=$("<select id='soundpad_selector'/>");
+	soundpad_selector.append("<option value=''>-</option>");
+	for(k in window.SOUNDPADS){
+		soundpad_selector.append($("<option/>").attr('value',k).html(k));
 	}
+	selector_section.append("Load Soundpad:");
+	selector_section.append(soundpad_selector);
+	selector_section.append("Enable Edit:");
+	soundpad_enable_edit=$("<input type='checkbox' id='soundpad_enable_edit'>");
+	
+	soundpad_enable_edit.change(soundpad_check_editable);
+	selector_section.append(soundpad_enable_edit);
+	
+	btn_addsoundpad=$("<button class='soundpad_add'>NEW</button>");
+	selector_section.append(btn_addsoundpad);
+	soundsPanel.body.append(selector_section);
+	
+	btn_addsoundpad.click(function(){
+		var newname=prompt("New Soundpad Name");
+		if(newname){
+			window.SOUNDPADS[newname]={};
+			soundpad_selector.append($("<option/>").attr('value',newname).html(newname));
+			soundpad_selector.val(newname);
+			$("#soundpad_enable_edit").prop('checked', true);
+			build_soundpad(window.SOUNDPADS[newname]);
+		}
+	});
+	
+	
+	btn_delsoundpad=$("<button class='soundpad_del'>DEL</button>");
+	btn_delsoundpad.click(function(){
+		c=confirm("Are you sure that you want to delete the current soundpad?");
+		if(c){
+			delete window.SOUNDPADS[soundpad_selector.val()];
+			$("#soundpad").empty();
+			soundpad_selector.empty();
+			soundpad_selector.append("<option value=''>-</option>");
+			for (k in window.SOUNDPADS) {
+				soundpad_selector.append($("<option/>").attr('value', k).html(k));
+			}
+			persist_soundpad();
+		}
+	});
+	selector_section.append(btn_delsoundpad);
+	
+	soundpad_selector.on("change",function(){
+		$("#soundpad").empty();
+		soundpad_id=$("#soundpad_selector").val();
+		if(soundpad_id!=""){
+			build_soundpad(window.SOUNDPADS[soundpad_id]);
+			
+			data={
+				soundpad: window.SOUNDPADS[soundpad_id]
+			}
+			window.MB.sendMessage("custom/myVTT/soundpad",data);
+		}
+	});
+	
 	
 	soundpad_element=$("<div id='soundpad'>");
 	soundsPanel.body.append(soundpad_element);

--- a/SoundPad.js
+++ b/SoundPad.js
@@ -385,66 +385,67 @@ function init_audio(){
 	
 	if(!window.DM)
 		youtube_section.hide();
-
-	selector_section=$("<div/>");
-	soundpad_selector=$("<select id='soundpad_selector'/>");
-	soundpad_selector.append("<option value=''>-</option>");
-	for(k in window.SOUNDPADS){
-		soundpad_selector.append($("<option/>").attr('value',k).html(k));
-	}
-	selector_section.append("Load Soundpad:");
-	selector_section.append(soundpad_selector);
-	selector_section.append("Enable Edit:");
-	soundpad_enable_edit=$("<input type='checkbox' id='soundpad_enable_edit'>");
 	
-	soundpad_enable_edit.change(soundpad_check_editable);
-	selector_section.append(soundpad_enable_edit);
-	
-	btn_addsoundpad=$("<button class='soundpad_add'>NEW</button>");
-	selector_section.append(btn_addsoundpad);
-	soundsPanel.body.append(selector_section);
-	
-	btn_addsoundpad.click(function(){
-		var newname=prompt("New Soundpad Name");
-		if(newname){
-			window.SOUNDPADS[newname]={};
-			soundpad_selector.append($("<option/>").attr('value',newname).html(newname));
-			soundpad_selector.val(newname);
-			$("#soundpad_enable_edit").prop('checked', true);
-			build_soundpad(window.SOUNDPADS[newname]);
+	if(window.DM){
+		selector_section=$("<div/>");
+		soundpad_selector=$("<select id='soundpad_selector'/>");
+		soundpad_selector.append("<option value=''>-</option>");
+		for(k in window.SOUNDPADS){
+			soundpad_selector.append($("<option/>").attr('value',k).html(k));
 		}
-	});
-	
-	
-	btn_delsoundpad=$("<button class='soundpad_del'>DEL</button>");
-	btn_delsoundpad.click(function(){
-		c=confirm("Are you sure that you want to delete the current soundpad?");
-		if(c){
-			delete window.SOUNDPADS[soundpad_selector.val()];
+		selector_section.append("Load Soundpad:");
+		selector_section.append(soundpad_selector);
+		selector_section.append("Enable Edit:");
+		soundpad_enable_edit=$("<input type='checkbox' id='soundpad_enable_edit'>");
+		
+		soundpad_enable_edit.change(soundpad_check_editable);
+		selector_section.append(soundpad_enable_edit);
+		
+		btn_addsoundpad=$("<button class='soundpad_add'>NEW</button>");
+		selector_section.append(btn_addsoundpad);
+		soundsPanel.body.append(selector_section);
+		
+		btn_addsoundpad.click(function(){
+			var newname=prompt("New Soundpad Name");
+			if(newname){
+				window.SOUNDPADS[newname]={};
+				soundpad_selector.append($("<option/>").attr('value',newname).html(newname));
+				soundpad_selector.val(newname);
+				$("#soundpad_enable_edit").prop('checked', true);
+				build_soundpad(window.SOUNDPADS[newname]);
+			}
+		});
+		
+		
+		btn_delsoundpad=$("<button class='soundpad_del'>DEL</button>");
+		btn_delsoundpad.click(function(){
+			c=confirm("Are you sure that you want to delete the current soundpad?");
+			if(c){
+				delete window.SOUNDPADS[soundpad_selector.val()];
+				$("#soundpad").empty();
+				soundpad_selector.empty();
+				soundpad_selector.append("<option value=''>-</option>");
+				for (k in window.SOUNDPADS) {
+					soundpad_selector.append($("<option/>").attr('value', k).html(k));
+				}
+				persist_soundpad();
+			}
+		});
+		selector_section.append(btn_delsoundpad);
+		
+		soundpad_selector.on("change",function(){
 			$("#soundpad").empty();
-			soundpad_selector.empty();
-			soundpad_selector.append("<option value=''>-</option>");
-			for (k in window.SOUNDPADS) {
-				soundpad_selector.append($("<option/>").attr('value', k).html(k));
+			soundpad_id=$("#soundpad_selector").val();
+			if(soundpad_id!=""){
+				build_soundpad(window.SOUNDPADS[soundpad_id]);
+				
+				data={
+					soundpad: window.SOUNDPADS[soundpad_id]
+				}
+				window.MB.sendMessage("custom/myVTT/soundpad",data);
 			}
-			persist_soundpad();
-		}
-	});
-	selector_section.append(btn_delsoundpad);
-	
-	soundpad_selector.on("change",function(){
-		$("#soundpad").empty();
-		soundpad_id=$("#soundpad_selector").val();
-		if(soundpad_id!=""){
-			build_soundpad(window.SOUNDPADS[soundpad_id]);
-			
-			data={
-				soundpad: window.SOUNDPADS[soundpad_id]
-			}
-			window.MB.sendMessage("custom/myVTT/soundpad",data);
-		}
-	});
-	
+		});
+	}
 	
 	soundpad_element=$("<div id='soundpad'>");
 	soundsPanel.body.append(soundpad_element);
@@ -455,4 +456,3 @@ function init_audio(){
 	}
 	
 }
-


### PR DESCRIPTION
This builds the sound panel for the players so the DM can control it. It seems it wasn't being built for players at all and sounds couldn't be played.

May also work better with #613 due to some syncing issues. 

Credit to @pensan for digging through this as well