### PR TITLE
Fix: Token should remain on cursor when dragging a token and scrolling the map or zooming

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1469,10 +1469,8 @@ class Token {
 						$("#temp_overlay").css("z-index", "50");
 					window.DRAWFUNCTION = "select"
 					window.DRAGGING = true;
-					click.x = event.clientX;
-					click.y = event.clientY;
-					click.scrollX = window.scrollX;
-					click.scrollY = window.scrollY;
+					click.x = event.pageX;
+					click.y = event.pageY;
 
 					if(tok.is(":animated")){
 						self.stopAnimation();
@@ -1556,8 +1554,8 @@ class Token {
 					var zoom = window.ZOOM;
 
 					var original = ui.originalPosition;
-					let tokenX = Math.round((event.clientX - click.x + original.left + window.scrollX - click.scrollX) / zoom);
-					let tokenY = Math.round((event.clientY - click.y + original.top + window.scrollY - click.scrollY) / zoom);
+					let tokenX = Math.round((event.pageX - click.x + original.left) / zoom);
+					let tokenY = Math.round((event.pageY - click.y + original.top) / zoom);
 
 
 					if (should_snap_to_grid()) {

--- a/Token.js
+++ b/Token.js
@@ -1556,8 +1556,8 @@ class Token {
 					var zoom = window.ZOOM;
 
 					var original = ui.originalPosition;
-					let tokenX = Math.round(((event.clientX - click.x + original.left) + (window.scrollX - click.scrollX))/ zoom);
-					let tokenY = Math.round(((event.clientY - click.y + original.top) + (window.scrollY - click.scrollY))/ zoom);
+					let tokenX = Math.round((event.clientX - click.x + original.left + window.scrollX - click.scrollX) / zoom);
+					let tokenY = Math.round((event.clientY - click.y + original.top + window.scrollY - click.scrollY) / zoom);
 
 
 					if (should_snap_to_grid()) {

--- a/Token.js
+++ b/Token.js
@@ -1471,6 +1471,8 @@ class Token {
 					window.DRAGGING = true;
 					click.x = event.clientX;
 					click.y = event.clientY;
+					click.scrollX = window.scrollX;
+					click.scrollY = window.scrollY;
 
 					if(tok.is(":animated")){
 						self.stopAnimation();
@@ -1554,8 +1556,8 @@ class Token {
 					var zoom = window.ZOOM;
 
 					var original = ui.originalPosition;
-					let tokenX = Math.round((event.clientX - click.x + original.left) / zoom);
-					let tokenY = Math.round((event.clientY - click.y + original.top) / zoom);
+					let tokenX = Math.round(((event.clientX - click.x + original.left) + (window.scrollX - click.scrollX))/ zoom);
+					let tokenY = Math.round(((event.clientY - click.y + original.top) + (window.scrollY - click.scrollY))/ zoom);
 
 
 					if (should_snap_to_grid()) {


### PR DESCRIPTION
Example:

https://user-images.githubusercontent.com/65363489/180084059-b3732766-37c6-44cf-8131-b6f1a7dcb5bd.mp4



Another token dragging issue that might help Fix #605