### PR TITLE
Fix fog get resetted after editing a scene  #597

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -430,7 +430,8 @@ function edit_scene_dialog(scene_id) {
 		}
 
 		if(window.CLOUD){
-			window.ScenesHandler.persist_scene(scene_id,true,true);
+			const isNew = false;
+			window.ScenesHandler.persist_scene(scene_id, isNew);
 		}
 		else{
 			window.ScenesHandler.persist();
@@ -1130,7 +1131,7 @@ function init_scene_selector() {
 			offsety: 0,
 			grid: 0,
 			snap: 0,
-			reveals: [[0, 0, 0, 0, 2, 0]], // SPECIAL MESSAGE TO REVEAL EVERYTHING
+			reveals: [], // SPECIAL MESSAGE TO REVEAL EVERYTHING
 			order: Date.now()
 		}
 		);


### PR DESCRIPTION
The server adds some FogData when the `update_scene` event is fired on the server and `isnewscene` is set.

```
if(recvMessage.data.isnewscene){
  delete recvMessage.data.isnewscene;
  promises.push(ddb.put({ // also initialize fog data
    TableName: process.env.TABLE_NAME,
      Item: {
        campaignId: campaignId,
        objectId: "scenes#"+recvMessage.data.id+"#fogdata",
        data: [[0, 0, 0, 0, 2, 0]],
      }
  }).promise());
}
```

Currently, the `ScenesHandler.persist_scene` function is always called with `isnew = true` in the ScenesPaneljs.
This will lead to scene updates are always treated as 'new' which causes the server to add the reveal.
When later the `custom/myVTT/fetchscene` is fired, the data send by the server will always include the 'reveal all' data.

This PR will set the `isnew` flag to be always false when clicking the save button.
I put it into a new variable so we can easily extend it with some logic for 'new' scenes.

I am however not sure, what side effects this may cause.

In my tests the fog works know, also for new maps where the `isnew` flag should be true.
Maybe someone with more knowledge on how exactly the fog data is used can provide me some insights?