### PR TITLE
Add indicator for sync activities

### DIFF
--- a/CloudHelper/CloudHelper.js
+++ b/CloudHelper/CloudHelper.js
@@ -1,0 +1,14 @@
+import { SyncIndicator } from "./SyncIndicator.js";
+
+/**
+ * Helper class for cloud functionality.
+ */
+class CloudHelper {
+    syncIndicator;
+
+    constructor() {
+        this.syncIndicator = new SyncIndicator();
+    }
+}
+
+window.CLOUD_HELPER = new CloudHelper();

--- a/CloudHelper/SyncIndicator.js
+++ b/CloudHelper/SyncIndicator.js
@@ -1,0 +1,75 @@
+/**
+ * A visual indicator to show syncing activities.
+ */
+export class SyncIndicator {
+    isSyncInProgress = false;
+    #domElement;
+    #syncIndicatorTimeout;
+
+    constructor() {
+        // Try to fetch DOM element (may fail on init, since DOM is not ready)
+        this.#domElement = $("#switch_settings .sidebar-tab-image div");
+
+        // Hook into Ajax
+        this.#patchAjax();
+    }
+
+    /**
+     * Starts the syncing animation
+     */
+    show() {
+        this.#updateUI(true);
+    }
+
+    /**
+     * Starts and auto stops the animation
+     * @param {number} [timeoutInMs] - auto stop after x milliseconds
+     */
+    showTimed(timeoutInMs) {
+        clearTimeout(this.#syncIndicatorTimeout);
+        this.#syncIndicatorTimeout = setTimeout(
+            this.hide.bind(this),
+            timeoutInMs || 500
+        );
+        this.show();
+    }
+
+    /**
+     * Stops the syncing animation
+     */
+    hide() {
+        this.#updateUI(false);
+    }
+
+    /**
+     * Updates the DOM element
+     * @param {boolean} isSyncing state indication
+     */
+    #updateUI(isSyncing) {
+        this.isSyncInProgress = isSyncing;
+
+        // Refetch DOM element if not already set
+        if (this.#domElement.length === 0) {
+            this.#domElement = $("#switch_settings .sidebar-tab-image div");
+        }
+
+        // Update animation state
+        this.#domElement.css({
+            animationPlayState: isSyncing ? "running" : "paused",
+        });
+    }
+
+    /**
+     * Hooks animation into all JQuery Ajax requests
+     */
+    #patchAjax() {
+        $.ajaxSetup({
+            beforeSend: function () {
+                this.show("beforeSend");
+            }.bind(this),
+            complete: function () {
+                this.hide("beforeSend");
+            }.bind(this),
+        });
+    }
+}

--- a/CloudHelper/syncIndicator.css
+++ b/CloudHelper/syncIndicator.css
@@ -1,0 +1,9 @@
+#switch_settings .sidebar-tab-image div {
+    animation: rotate360 10s linear infinite paused;
+}
+
+@keyframes rotate360 {
+    0%   { transform: rotate(0deg);   }
+    100% { transform: rotate(360deg); }
+}
+

--- a/Load.js
+++ b/Load.js
@@ -21,7 +21,8 @@ l.setAttribute("data-path", chrome.runtime.getURL("/"));
 	"color-picker.min.css",
 	"spectrum-2.0.8.min.css",
 	"magnific-popup.css",
-	"DiceContextMenu/DiceContextMenu.css"
+	"DiceContextMenu/DiceContextMenu.css",
+	"CloudHelper/syncIndicator.css"
 ].forEach(function(value, index, array) {
 	let l = document.createElement('link');
 	l.href = chrome.runtime.getURL(value);
@@ -75,6 +76,7 @@ let scripts = [
 	{ src: "TokensPanel.js" },
 	{ src: "TokenCustomization.js" },
 	{ src: "built-in-tokens.js" },
+	{ src: "CloudHelper/CloudHelper.js", type: "module" },
 	// Files that execute when loaded
 	{ src: "ajaxQueue/ajaxQueueIndex.js", type: "module" },
 	{ src: "DiceRoller.js" },

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -339,6 +339,9 @@ class MessageBroker {
 				return;
 			if (event.data == "ping")
 				return;
+				
+			// Triggers the sync animation for each received message
+			window.CLOUD_HELPER.syncIndicator.showTimed();
 
 			var msg = $.parseJSON(event.data);
 			console.log(msg.eventType);
@@ -1412,6 +1415,9 @@ class MessageBroker {
 		var self = this;
 
 		//this.sendDDBMB(eventType,data); 
+
+		// Triggers the sync animation for each outgoing message
+		window.CLOUD_HELPER.syncIndicator.showTimed();
 
 		if(eventType.startsWith("custom")){
 			this.sendAboveMB(eventType,data,skipSceneId);

--- a/manifest.json
+++ b/manifest.json
@@ -39,6 +39,7 @@
 		"assets/*",
 		"images/*",
 		"ajaxQueue/*",
+		"CloudHelper/*",
 		"jquery-ui.min.css",
 		"jquery.ui.theme.min.css",
 		"jquery.contextMenu.css",


### PR DESCRIPTION
I propose to add an indicator that shows users that a 'syncing activity' is currently under way.
It is not possible to see, if the changes made to the scene are synced with the server & other users.

I added a rotation animation to the settings icon (gear) to indicate syncing.

Currently the script is hooked into two places.

1. All `$.ajax` requests
2. The message broker's `sendMessage` method as well as the `onmessage` callback

Since there is no callback/return value from the `MessageBroker`, I just used a timeout function.
This however does not handle errors when the `MessageBroker` is not working as expected.
Any suggestions on how we could add more reliability to the whole message system?

This PR will also introduce a `CloudHelper` class which could house more cloud related utility functions.