### PR TITLE
Fix save 'Show Grid' setting when clicking super wizard

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -686,7 +686,6 @@ function edit_scene_dialog(scene_id) {
 			aligner2.draggable({
 				stop: regrid,
 				start: function(event) {
-					window.CURRENT_SCENE_DATA.grid = 0;
 					reset_canvas(); redraw_fog();
 					click2.x = event.clientX;
 					click2.y = event.clientY;
@@ -746,7 +745,6 @@ function edit_scene_dialog(scene_id) {
 			aligner1.draggable({
 				stop: regrid,
 				start: function(event) {
-					window.CURRENT_SCENE_DATA.grid = 0;
 					reset_canvas();
 					redraw_fog();
 					click1.x = event.clientX;


### PR DESCRIPTION
Another fix missed in #593 that fixes #504

The show grid option wasn't saving if you moved the 'aligners' as it was resetting it to off.