### PR TITLE
Fix moving with arrow keys towards the right side of some maps

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -354,7 +354,7 @@ class Token {
 		// Stop movement if new position is outside of the scene
 		if (
 			top  < this.walkableArea.top - this.options.size    || 
-			top  > this.walkableArea.bottom + this.options.size |
+			top  > this.walkableArea.bottom + this.options.size ||
 			left < this.walkableArea.left - this.options.size || 
 			left > this.walkableArea.right + this.options.size 
 		) { return; }

--- a/Token.js
+++ b/Token.js
@@ -353,10 +353,10 @@ class Token {
 
 		// Stop movement if new position is outside of the scene
 		if (
-			top  < this.walkableArea.top    || 
-			top  > this.walkableArea.bottom ||
-			left < this.walkableArea.left   || 
-			left > this.walkableArea.bottom
+			top  < this.walkableArea.top - this.options.size    || 
+			top  > this.walkableArea.bottom + this.options.size |
+			left < this.walkableArea.left - this.options.size || 
+			left > this.walkableArea.right + this.options.size 
 		) { return; }
 
 		this.update_from_page();


### PR DESCRIPTION
Tracked it down to a copy paste error where it was comparing the ```token.options.left``` with ```token.walkableArea.bottom```.

I also added the 1 size padding we allow for moving with the mouse already.

Fixes #624