### PR TITLE
Fix provided token ? showing up as !

### DIFF
--- a/built-in-tokens.js
+++ b/built-in-tokens.js
@@ -554,13 +554,13 @@ const builtInTokens = [
       })
     });
 builtInTokens.push({
-  "name": `!`,
+  "name": `! Exclamation Mark`,
   "folderPath": "/Letters",
   "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/EXCLAMATION.png`,
   "disableborder": true
 })
 builtInTokens.push({
-  "name": `?`,
+  "name": `? Question Mark`,
   "folderPath": "/Letters",
   "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/QUESTION.png`,
   "disableborder": true

--- a/built-in-tokens.js
+++ b/built-in-tokens.js
@@ -554,13 +554,13 @@ const builtInTokens = [
       })
     });
 builtInTokens.push({
-  "name": `! Exclamation Mark`,
+  "name": `! - Exclamation Mark`,
   "folderPath": "/Letters",
   "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/EXCLAMATION.png`,
   "disableborder": true
 })
 builtInTokens.push({
-  "name": `? Question Mark`,
+  "name": `? - Question Mark`,
   "folderPath": "/Letters",
   "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/QUESTION.png`,
   "disableborder": true


### PR DESCRIPTION
Item id's are set using the folder path and name but sanatize them removing special characters and replacing them with _

This caused ! and ? to have the same ID. I've set a name with normal characters for now but prehaps we should look at allowing special characters as names but I feel this would only apply to this type of token as others would have other characters too.