### PR TITLE
Allow tooltips to scroll

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -795,7 +795,7 @@ div#scene_properties form > div {
 }
 
 .tooltip-body {
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .drag-cancelled {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -794,6 +794,10 @@ div#scene_properties form > div {
     transition: 0.2s ease-in-out 0.5s;
 }
 
+.tooltip-body {
+    overflow: scroll;
+}
+
 .drag-cancelled {
     display: none;
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -795,7 +795,7 @@ div#scene_properties form > div {
 }
 
 .tooltip-body {
-    overflow: scroll;
+    overflow-y: scroll;
 }
 
 .drag-cancelled {


### PR DESCRIPTION
An enhancement to dndbeyonds tooltips. This allows them to scroll - see example video: 

https://user-images.githubusercontent.com/65363489/184273469-7bc36287-a57b-4c9b-9861-d7bf280bd92a.mp4





