### PR TITLE
Fix player view journal initial scrollbars

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -267,6 +267,8 @@ class JournalManager{
 				$('.iframeResizeCover').remove();			
 			}
 		});
+		if(!window.DM)
+			$("[role='dialog']").css("height", "calc(100vh - 35px)")	
 		note.parent().mousedown(function() {
 			frame_z_index_when_click($(this));
 		});		


### PR DESCRIPTION
Reported by Nikki on discord: https://discord.com/channels/815028457851191326/815028457851191329/1007692971644297306

The scrollbars are not showing up until resizing the journal window for players. This is due to height auto not playing well with overflow contents for whatever reason. This overrides the height in player view setting an initial height other than auto.