### PR TITLE
Fix combat tracker hp width for player view

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3263,8 +3263,15 @@ button.avtt-roll-button {
 }
 #combat_area tr td:nth-of-type(3),
 #combat_area tr td:nth-of-type(5) {
+    width: 13%;
+}
+.body-rpgcharacter-sheet #combat_area tr td:nth-of-type(3),
+.body-rpgcharacter-sheet #combat_area tr td:nth-of-type(5) {
     width: 18%;
 }
+
+
+
 #combat_area tr td:first-of-type,
 #combat_area tr td:nth-of-type(2),
 #combat_area tr td:nth-of-type(3)

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3254,16 +3254,16 @@ button.avtt-roll-button {
     padding: 13px 4px 4px 4px;
 }
 #combat_area tr td:first-of-type,
-#combat_area tr td:nth-of-type(2),
-#combat_area tr td:nth-of-type(5)
+#combat_area tr td:nth-of-type(2)
 {
     width: 13%;
 }
 #combat_area tr td:nth-of-type(4) {
     width: 5px;
 }
-#combat_area tr td:nth-of-type(3) {
-    width: 13%;
+#combat_area tr td:nth-of-type(3),
+#combat_area tr td:nth-of-type(5) {
+    width: 18%;
 }
 #combat_area tr td:first-of-type,
 #combat_area tr td:nth-of-type(2),

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3270,8 +3270,6 @@ button.avtt-roll-button {
     width: 18%;
 }
 
-
-
 #combat_area tr td:first-of-type,
 #combat_area tr td:nth-of-type(2),
 #combat_area tr td:nth-of-type(3)


### PR DESCRIPTION
Combat tracker in player view cuts of 3 digit+ health.

This allows for larger numbers without having to resize the tracker 'window' larger

![image](https://user-images.githubusercontent.com/65363489/184862755-b1e39004-8662-4192-b261-b3909a7964bb.png)



