### PR TITLE
Fix - DM scene button on initial load

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -241,7 +241,8 @@ function ct_reorder(persist=true) {
 
 
 function ct_add_token(token,persist=true,disablerolling=false){
-
+	if(token.options.name == "Not in the current map")
+		return;
 	if (token.isAoe()) {
 		return; // don't add aoe to combat tracker
 	}


### PR DESCRIPTION
The DM button is not highlighted on initial load. This is due to not creating a new Token() and instead sending a false token back when it's not on the map. This causes an error when we try and call functions from the token class.

This fixes that error and allows the rest of the function to load - which allows the scene button to be highlighted properly and other behavior returns to normal