### PR TITLE
Fix sending delete message for configurations "example token"

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -489,7 +489,7 @@ function build_example_token(options) {
 	let token = new Token(mergedOptions);
 	token.place(0);
 	let html = $(`#tokens div[data-id='${mergedOptions.id}']`).clone();
-	token.delete();
+	token.delete(false, false);
 
 	html.addClass("example-token");
 	// html.css({


### PR DESCRIPTION
This fixes an error when clicking the configuration menu. When it creates the example token it was also sending the delete message to players. This caused an error for trying to delete a non-existent token. 