### PR TITLE
Fix center of view drop for AoE and tokens

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1861,6 +1861,13 @@ function center_of_view() {
 	return { x: centerX, y: centerY };
 }
 
+
+function center_of_view() {
+	let centerX = $("#scene_map").width() - (($("#scene_map")[0].getBoundingClientRect().right - (window.innerWidth/2))/window.ZOOM) - 170/window.ZOOM
+	let centerY = $("#scene_map").height() - (($("#scene_map")[0].getBoundingClientRect().bottom - (window.innerHeight/2))/window.ZOOM)
+	return { x: centerX, y: centerY };
+}
+
 function should_snap_to_grid() {
 	return (window.CURRENT_SCENE_DATA.snap == "1" && !(window.toggleSnap))
 		|| ((window.CURRENT_SCENE_DATA.snap != "1") && window.toggleSnap);
@@ -1909,7 +1916,7 @@ function convert_point_from_map_to_view(mapX, mapY) {
 
 function place_token_in_center_of_view(tokenObject) {
 	let center = center_of_view();
-	place_token_at_view_point(tokenObject, center.x, center.y);
+	place_token_at_map_point(tokenObject, center.x, center.y);
 }
 
 function place_token_at_view_point(tokenObject, pageX, pageY) {
@@ -1940,8 +1947,6 @@ function place_token_at_map_point(tokenObject, x, y) {
 		options.imgsrc = parse_img(options.imgsrc);
 	}
 
-	options.left = `${x}px`;
-	options.top = `${y}px`;
 	if (options.size == undefined) {
 		if (options.sizeId != undefined) {
 			// sizeId was specified, convert it to size. This is used when adding from the monster pane
@@ -1965,7 +1970,8 @@ function place_token_at_map_point(tokenObject, x, y) {
 			options.size = Math.round(window.CURRENT_SCENE_DATA.hpps) * 1;
 		}
 	}
-
+	options.left = `${x - options.size/2}px`;
+	options.top = `${y - options.size/2}px`;
 	// set reasonable defaults for any global settings that aren't already set
 	const setReasonableDefault = function(optionName, reasonableDefault) {
 		if (options[optionName] === undefined) {

--- a/Token.js
+++ b/Token.js
@@ -1856,8 +1856,11 @@ function default_options() {
 }
 
 function center_of_view() {
-	let centerX = $("#scene_map").width() - (($("#scene_map")[0].getBoundingClientRect().right - (window.innerWidth/2))/window.ZOOM) - 170/window.ZOOM
-	let centerY = $("#scene_map").height() - (($("#scene_map")[0].getBoundingClientRect().bottom - (window.innerHeight/2))/window.ZOOM)
+	let centerX = (window.innerWidth/2) + window.scrollX 
+	if($("#hide_rightpanel").hasClass("point-right")){
+		centerX = centerX - 170;
+	}
+	let centerY = (window.innerHeight/2) + window.scrollY
 	return { x: centerX, y: centerY };
 }
 
@@ -1909,7 +1912,7 @@ function convert_point_from_map_to_view(mapX, mapY) {
 
 function place_token_in_center_of_view(tokenObject) {
 	let center = center_of_view();
-	place_token_at_map_point(tokenObject, center.x, center.y);
+	place_token_at_view_point(tokenObject, center.x, center.y);
 }
 
 function place_token_at_view_point(tokenObject, pageX, pageY) {

--- a/Token.js
+++ b/Token.js
@@ -1856,13 +1856,6 @@ function default_options() {
 }
 
 function center_of_view() {
-	let centerX = ($(window).width() / 2) + window.scrollX;
-	let centerY = ($(window).height() / 2) + window.scrollY;
-	return { x: centerX, y: centerY };
-}
-
-
-function center_of_view() {
 	let centerX = $("#scene_map").width() - (($("#scene_map")[0].getBoundingClientRect().right - (window.innerWidth/2))/window.ZOOM) - 170/window.ZOOM
 	let centerY = $("#scene_map").height() - (($("#scene_map")[0].getBoundingClientRect().bottom - (window.innerHeight/2))/window.ZOOM)
 	return { x: centerX, y: centerY };

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -638,7 +638,7 @@ function enable_draggable_token_creation(html, specificImage = undefined) {
                 if (ui.helper.attr("data-shape") && ui.helper.attr("data-style")) {
                     src = build_aoe_img_name(ui.helper.attr("data-style"), ui.helper.attr("data-shape"));
                 }
-                create_and_place_token(draggedItem, hidden, src, event.pageX - ui.helper.width() / 2, event.pageY - ui.helper.height() / 2, false);
+                create_and_place_token(draggedItem, hidden, src, event.pageX, event.pageY, false);
                 // create_and_place_token(draggedItem, hidden, src, event.pageX - ui.helper.width() / 2, event.pageY - ui.helper.height() / 2, false, ui.helper.attr("data-name-override"));
                 close_sidebar_modal();
             } else {


### PR DESCRIPTION
Currently Token drop in center of view places token somewhat off to the side as it wasn't taking into account the size of the token. When zoomed out or using larger AoE's this problem appears worse. This should fix that. This also takes into account if your side bar is open and centers it on the playable area that is visable. 

See example video:
https://youtu.be/raLP3ALdV0w