### PR TITLE
Fix - Move Context menu to monster popout instead of main window

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -763,6 +763,23 @@ function load_monster_stat_iframe(monsterId, tokenId) {
 		monster_popout_button.click(function() {
 			let name = $("#resizeDragMon .avtt-stat-block-container .mon-stat-block__name-link").text();
 			popoutWindow(name, $("#resizeDragMon .avtt-stat-block-container"));
+			name = name.replace(/(\r\n|\n|\r)/gm, "").trim();
+			$(window.childWindows[name].document).find(".avtt-roll-button").on("contextmenu", function (contextmenuEvent) {
+				$(window.childWindows[name].document).find("body").append($("div[role='presentation']").clone(true, true));
+				let popoutContext = $(window.childWindows[name].document).find(".dcm-container");
+				let maxLeft = window.childWindows[name].innerWidth - popoutContext.width();
+				let maxTop =  window.childWindows[name].innerHeight - popoutContext.height();
+				if(parseInt(popoutContext.css("left")) > maxLeft){
+					popoutContext.css("left", maxLeft)
+				}
+				if(parseInt(popoutContext.css("top")) > maxTop){
+					popoutContext.css("top", maxTop)
+				}
+				$(window.childWindows[name].document).find("div[role='presentation']").on("click", function (clickEvent) {
+           			 $(window.childWindows[name].document).find("div[role='presentation']").remove();
+        		});
+				$(".dcm-backdrop").remove();
+			});
 			monster_close_title_button.click();
 		});
 	}
@@ -846,6 +863,23 @@ function build_draggable_monster_window() {
 		monster_popout_button.click(function() {
 			let name = $("#resizeDragMon .avtt-stat-block-container .mon-stat-block__name-link").text();
 			popoutWindow(name, $("#resizeDragMon .avtt-stat-block-container"));
+			name = name.replace(/(\r\n|\n|\r)/gm, "").trim();	
+			$(window.childWindows[name].document).find(".avtt-roll-button").on("contextmenu", function (contextmenuEvent) {
+				$(window.childWindows[name].document).find("body").append($("div[role='presentation']").clone(true, true));
+				let popoutContext = $(window.childWindows[name].document).find(".dcm-container");
+				let maxLeft = window.childWindows[name].innerWidth - popoutContext.width();
+				let maxTop =  window.childWindows[name].innerHeight - popoutContext.height();
+				if(parseInt(popoutContext.css("left")) > maxLeft){
+					popoutContext.css("left", maxLeft)
+				}
+				if(parseInt(popoutContext.css("top")) > maxTop){
+					popoutContext.css("top", maxTop)
+				}
+				$(window.childWindows[name].document).find("div[role='presentation']").on("click", function (clickEvent) {
+           			 $(window.childWindows[name].document).find("div[role='presentation']").remove();
+        		});
+				$(".dcm-backdrop").remove();
+			});
 			monster_close_title_button.click();
 		});
 	}


### PR DESCRIPTION
Reported by: invictus92 in discord
https://discord.com/channels/815028457851191326/815028804103307354/1011273608510849155

This moves the roll context menu to the monster popouts.  