### PR TITLE
Popout Notes

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -274,14 +274,14 @@ class JournalManager{
 		});		
 		let btn_popout=$(`<div class="popout-button journal-button"><svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1zM14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1z"></path></svg></div>"`);
 		note.parent().append(btn_popout);
-		btn_popout.click(function(){
-			console.log(id + " !!!!!!!!!!!");			
+		btn_popout.click(function(){	
 			let uiId = $(this).siblings(".note").attr("id");
 			let journal_text = $(`#${uiId}.note .note-text`)
 			popoutWindow(self.notes[id].title, note, journal_text.width(), journal_text.height());
 			removeFromPopoutWindow(self.notes[id].title, ".visibility-container");
 			removeFromPopoutWindow(self.notes[id].title, ".ui-resizable-handle");
 			$(window.childWindows[self.notes[id].title].document).find(".note").attr("style", "overflow:visible; max-height: none !important; height: auto; min-height: 100%;");
+			$(this).siblings(".ui-dialog-titlebar").children(".ui-dialog-titlebar-close").click();
 		});
 	}
 	

--- a/Journal.js
+++ b/Journal.js
@@ -281,7 +281,7 @@ class JournalManager{
 			popoutWindow(self.notes[id].title, note, journal_text.width(), journal_text.height());
 			removeFromPopoutWindow(self.notes[id].title, ".visibility-container");
 			removeFromPopoutWindow(self.notes[id].title, ".ui-resizable-handle");
-			$(window.childWindows[self.notes[id].title].document).find(".note").attr("style", "overflow:visible; max-height: none !important; height: auto;, min-height: 100%;");
+			$(window.childWindows[self.notes[id].title].document).find(".note").attr("style", "overflow:visible; max-height: none !important; height: auto; min-height: 100%;");
 		});
 	}
 	

--- a/Journal.js
+++ b/Journal.js
@@ -231,7 +231,7 @@ class JournalManager{
 			note.append(visibility_container);
 			
 		}
-		let note_text=$("<div/>");
+		let note_text=$("<div class='note-text'/>");
 		note_text.append(DOMPurify.sanitize(self.notes[id].text,{ADD_TAGS: ['img','div','p', 'b', 'button', 'span', 'style', 'path', 'svg','iframe','a','video','ul','ol','li'], ADD_ATTR: ['allowfullscreen', 'allow', 'scrolling','src','frameborder','width','height']}));
 		note.append(note_text);
 		note.find("a").attr("target","_blank");
@@ -272,6 +272,17 @@ class JournalManager{
 		note.parent().mousedown(function() {
 			frame_z_index_when_click($(this));
 		});		
+		let btn_popout=$(`<div class="popout-button journal-button"><svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1zM14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1z"></path></svg></div>"`);
+		note.parent().append(btn_popout);
+		btn_popout.click(function(){
+			console.log(id + " !!!!!!!!!!!");			
+			let uiId = $(this).siblings(".note").attr("id");
+			let journal_text = $(`#${uiId}.note .note-text`)
+			popoutWindow(self.notes[id].title, note, journal_text.width(), journal_text.height());
+			removeFromPopoutWindow(self.notes[id].title, ".visibility-container");
+			removeFromPopoutWindow(self.notes[id].title, ".ui-resizable-handle");
+			$(window.childWindows[self.notes[id].title].document).find(".note").attr("style", "overflow:visible; max-height: none !important; height: auto;, min-height: 100%;");
+		});
 	}
 	
 	note_visibility(id,visibility){

--- a/Main.js
+++ b/Main.js
@@ -3968,6 +3968,20 @@ function closePopout(name){
 	}
 }
 
+
+
+
+
+
+
+function removeFromPopoutWindow(name, selector){
+	name = name.replace(/(\r\n|\n|\r)/gm, "").trim();
+	if(!childWindows[name])
+		return;
+	$(childWindows[name].document).find(selector).remove();
+	return childWindows[name];
+}
+
 /**
  * This will hide the sidebar regardless of which page we are playing on.
  * It will also adjust the position of the character sheet .

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3429,6 +3429,14 @@ button.avtt-roll-button {
     fill: #ddd;
 }
 
+.journal-button.popout-button svg path:not([fill='none']){
+    fill: #878787; 
+}
+
+.journal-button.popout-button:hover svg path:not([fill='none']){
+    fill: #000; 
+}
+
 .text-input-title-bar-enter {
     fill: #ddd;
     position: absolute;
@@ -3473,7 +3481,42 @@ button.avtt-roll-button {
 .popout-button {
     top: 2px;
 }
+.journal-button{
+    filter: none;
+    border: 1px solid #c5c5c5;
+    background: #f6f6f6;
+    font-weight: normal;
+    position: absolute;
+    right: 33px;
+    top: 9px;
+    width: 20px;
+    height: 20px;
+    border-radius: 3px;
 
+}
+.journal-button svg{
+    padding: 2px 1px 2px 0px;
+}
+    
+.body-rpgcharacter-sheet .journal-button{
+    filter: none;
+    border: 1px solid #c5c5c5;
+    background: #f6f6f6;
+    font-weight: normal;
+    position: absolute;
+    right: 43px;
+    top: 6px;
+    width: 30px;
+    height: 27px;   
+    border-radius: 3px;
+}
+.body-rpgcharacter-sheet .journal-button svg {
+    padding: 0px;
+    transform: scale(1.1);
+    left: 4px;
+    top: 3px;
+    position: relative;
+}
 #tokenOptionsPopup{
     position: fixed;
     z-index: 59000;


### PR DESCRIPTION
This allows for popout notes. Useful for DM's if they have an map/adventure plan in the journal. The popout button is only available when displaying/viewing a note not editing it. Due to the editing requiring the iframe this may not be so simple or possible to popout when editing - similar to the gamelog requiring more from dndbeyond.

One of the functions used in this is copied over from #644. It will cause conflict but is the same function.

Another part of #630 

Example Video:
https://user-images.githubusercontent.com/65363489/186228725-4b7ab79a-196b-4afb-99a1-ee1dd4665272.mp4


