### PR TITLE
Save combat status per scene and persist across scenes for the session. Also removes local storage requirement.

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -111,7 +111,7 @@ function init_combat_tracker(){
 
 			window.StatHandler.rollInit($(this).attr('data-monster'),function(value){
 				element.find(".init").val(value);
-				ct_reorder(false);
+				setTimeout(ct_reorder(), 500);
 			});
 			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 		});
@@ -165,7 +165,7 @@ function init_combat_tracker(){
 					
 			window.StatHandler.rollInit($(this).attr('data-monster'),function(value){
 				element.find(".init").val(value);
-				ct_reorder(false);
+				setTimeout(ct_reorder(), 500);
 			});
 			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 		});
@@ -320,7 +320,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 						window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 						window.TOKEN_OBJECTS[token.options.id].place_sync_persist()
 					}
-					ct_reorder();
+					setTimeout(ct_reorder(), 500);
 				}
 			);
 		}
@@ -333,7 +333,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 					init.val(value);
 					token.options.init = value;
 					token.sync();
-					ct_reorder();
+					setTimeout(ct_reorder(), 500);
 				});
 		}
 		
@@ -497,9 +497,8 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		$("#combat_area").append(entry);
 		$("#combat_area td").css("vertical-align","middle");
 
-		if(persist){
-			ct_reorder();
-			ct_persist();
+		if(window.DM){
+			setTimeout(ct_reorder(), 500);
 		}
 	}
 }
@@ -570,10 +569,10 @@ function ct_load(data=null){
 		}
 	}
 	if(window.DM){
-		ct_reorder();
+		setTimeout(ct_reorder(), 500);
 	}
 	else{
-		ct_reorder(false);
+		setTimeout(ct_reorder(false), 500);
 	}
 }
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -286,10 +286,11 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		init.css('width','20px');
 		init.css('-webkit-appearance','none');
 		if(window.DM && typeof(token.options.init) == 'undefined'){
-			if(typeof window.all_token_objects != undefined) {
-				if(typeof window.all_token_objects[token.options.id] != undefined)	{
-					if (typeof window.all_token_objects[token.options.id].options.init != undefined){
+			if(typeof window.all_token_objects != 'undefined') {
+				if(typeof window.all_token_objects[token.options.id] != 'undefined')	{
+					if (typeof window.all_token_objects[token.options.id].options.init != 'undefined'){
 				 		token.options.init = window.all_token_objects[token.options.id].options.init;
+				 		window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 						init.val(token.options.init);
 						token.place_sync_persist();
 					}
@@ -300,9 +301,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			}
 			init.change(function(){
 					ct_reorder();
-					if(typeof window.all_token_objects != undefined) {
+					if(typeof window.all_token_objects != 'undefined') {
 						window.all_token_objects[token.options.id].options.init = init.val()
 					}
+					window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 					token.options.init = init.val();
 					token.place_sync_persist();
 				}
@@ -312,9 +314,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			init.val(token.options.init);
 			init.change(function(){
 					ct_reorder();
-					if(typeof window.all_token_objects != undefined) {
+					if(typeof window.all_token_objects != 'undefined') {
 						window.all_token_objects[token.options.id].options.init = init.val()
 					}
+					window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 					token.options.init = init.val();
 					token.place_sync_persist();
 				}
@@ -324,6 +327,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			init.val(token.options.init);
 			init.attr("disabled","disabled");
 		}
+	
 		entry.append($("<td/>").append(init));
 		
 		// auto roll initiative for monsters
@@ -535,18 +539,10 @@ function ct_persist(){
 	data.push({'data-target': 'round',
 				'round_number':window.ROUND_NUMBER});
 	
-	var itemkey="CombatTracker"+find_game_id();
-	
-	localStorage.setItem(itemkey,JSON.stringify(data));
 	window.MB.sendMessage("custom/myVTT/CT",data);
 }
 
 function ct_load(data=null){
-	
-	if(data==null && window.DM){
-		var itemkey="CombatTracker"+find_game_id();
-		data=$.parseJSON(localStorage.getItem(itemkey));
-	}
 	
 	if(data){	
 		for(i=0;i<data.length;i++){
@@ -586,13 +582,7 @@ function ct_load(data=null){
 					token.options.init = data[i]['init'];	
 					ct_add_token(token,false,true);
 				}
-				
-				for(tokenID in window.TOKEN_OBJECTS){
-					if(window.TOKEN_OBJECTS[tokenID].options.ct_show == true)
-					{
-						ct_add_token(window.TOKEN_OBJECTS[tokenID],false,true);
-					}		
-				}
+
 
 				$("#combat_area tr[data-target='"+data[i]['data-target']+"']").find(".init").val(data[i]['init']);
 				if(data[i]['current']){
@@ -600,6 +590,13 @@ function ct_load(data=null){
 				}
 			}
 		}
+	}
+
+	for(tokenID in window.TOKEN_OBJECTS){
+		if(window.TOKEN_OBJECTS[tokenID].options.ct_show == true)
+		{
+			ct_add_token(window.TOKEN_OBJECTS[tokenID],false,true);
+		}		
 	}
 	ct_reorder(false);
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -611,7 +611,7 @@ function ct_load(data=null){
 function ct_remove_token(token,persist=true) {
 
 	if (persist == true) {
-		token.sync();
+		if(token.options.id in window.TOKEN_OBJECTS) token.sync();
 		if (token.persist != null) token.persist();
 	}
 	

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -473,7 +473,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.closedEye").css('display', 'block');
 						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.openEye").css('display', 'none');
 					}
-					token.update_and_sync()
+					if(token.options.id in window.TOKEN_OBJECTS) token.update_and_sync();		
 					ct_persist();
 				});
 				eye_button.append(open_eye);

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -501,6 +501,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		$("#combat_area").append(entry);
 		$("#combat_area td").css("vertical-align","middle");
 		
+		ct_reorder();
 		if(persist){
 			ct_persist();
 		}

--- a/Fog.js
+++ b/Fog.js
@@ -334,6 +334,12 @@ class WaypointManagerClass {
 	fadeoutMeasuring(){
 		let alpha = 1.0
 		const self = this
+		if(self.ctx == undefined){
+				self.cancelFadeout()
+				self.clearWaypoints();
+				clear_temp_canvas()
+				return;
+		} 
 		// only ever allow a single fadeout to occur
 		// this stops weird flashing behaviour with interacting
 		// interval function calls
@@ -1633,12 +1639,6 @@ function drawPolygon (
 		ctx.stroke();
 	}
 
-}
-
-function clear_temp_canvas(){
-	const canvas = document.getElementById("temp_overlay");
-	const context = canvas.getContext("2d");
-	context.clearRect(0, 0, canvas.width, canvas.height);
 }
 
 function clear_temp_canvas(){

--- a/Journal.js
+++ b/Journal.js
@@ -231,7 +231,7 @@ class JournalManager{
 			note.append(visibility_container);
 			
 		}
-		let note_text=$("<div/>");
+		let note_text=$("<div class='note-text'/>");
 		note_text.append(DOMPurify.sanitize(self.notes[id].text,{ADD_TAGS: ['img','div','p', 'b', 'button', 'span', 'style', 'path', 'svg','iframe','a','video','ul','ol','li'], ADD_ATTR: ['allowfullscreen', 'allow', 'scrolling','src','frameborder','width','height']}));
 		note.append(note_text);
 		note.find("a").attr("target","_blank");
@@ -272,6 +272,17 @@ class JournalManager{
 		note.parent().mousedown(function() {
 			frame_z_index_when_click($(this));
 		});		
+		let btn_popout=$(`<div class="popout-button journal-button"><svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1zM14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1z"></path></svg></div>"`);
+		note.parent().append(btn_popout);
+		btn_popout.click(function(){	
+			let uiId = $(this).siblings(".note").attr("id");
+			let journal_text = $(`#${uiId}.note .note-text`)
+			popoutWindow(self.notes[id].title, note, journal_text.width(), journal_text.height());
+			removeFromPopoutWindow(self.notes[id].title, ".visibility-container");
+			removeFromPopoutWindow(self.notes[id].title, ".ui-resizable-handle");
+			$(window.childWindows[self.notes[id].title].document).find(".note").attr("style", "overflow:visible; max-height: none !important; height: auto; min-height: 100%;");
+			$(this).siblings(".ui-dialog-titlebar").children(".ui-dialog-titlebar-close").click();
+		});
 	}
 	
 	note_visibility(id,visibility){

--- a/Main.js
+++ b/Main.js
@@ -452,26 +452,27 @@ function set_pointer(data, dontscroll = false) {
 	let marker = $("<div></div>");
 	marker.css({
 		"position": "absolute",
-		"top": data.y - 5,
-		"left": data.x - 5,
-		"width": "10px",
-		"height": "10px",
+		"top": data.y - 50,
+		"left": data.x - 50,
+		"width": "100px",
+		"height": "100px",
 		"z-index": "30",
 		"border-radius": "50%",
 		"opacity": "1.0",
-		"border-width": "8px",
+		"border-width": "18px",
 		"border-style": "double",
 		"border-color": data.color,
+		"transform": `scale(${(1 / window.ZOOM)})`,
+		"--ping-scale":`${(1 / window.ZOOM)}`,
+		"animation": 'pingAnimate linear 3s infinite',
+		"filter": "drop-shadow(1px 1px 0px #000)"
 	});
 	$("#tokens").append(marker);
 
-	marker.animate({
-		opacity: 0,
-		width: "120px",
-		height: "120px",
-		top: data.y - 60,
-		left: data.x - 60,
-	}, 1375, function() { marker.remove() });
+	
+	setTimeout(function(){marker.fadeOut(1000)}, 2000);
+	setTimeout(function(){marker.remove()}, 3000);
+
 
 	// Calculate pageX and pageY and scroll there!
 
@@ -3960,12 +3961,43 @@ width=${width},height=${height},left=100,top=100`;
 	});
 	return childWindows[name];
 }
-
+function updatePopoutWindow(name, cloneSelector){
+	name = name.replace(/(\r\n|\n|\r)/gm, "").trim();
+	if(!childWindows[name])
+		return;
+	$(childWindows[name].document).find('body').empty();
+	$(childWindows[name].document).find('body').append(cloneSelector.clone(true,true));
+	$(childWindows[name].document).find('a[href^="/"]').each(function() {
+        this.href = `https://dndbeyond.com${this.getAttribute("href")}`;
+	});
+	return childWindows[name];
+}
+function removeFromPopoutWindow(name, selector){
+	name = name.replace(/(\r\n|\n|\r)/gm, "").trim();
+	if(!childWindows[name])
+		return;
+	$(childWindows[name].document).find(selector).remove();
+	return childWindows[name];
+}
 function closePopout(name){
 	if(childWindows[name]){
 		childWindows[name].close();
 		delete childWindows[name];
 	}
+}
+
+
+
+
+
+
+
+function removeFromPopoutWindow(name, selector){
+	name = name.replace(/(\r\n|\n|\r)/gm, "").trim();
+	if(!childWindows[name])
+		return;
+	$(childWindows[name].document).find(selector).remove();
+	return childWindows[name];
 }
 
 /**

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -949,6 +949,9 @@ class MessageBroker {
 							var converted = $(this).attr('data-id').replace(/^.*\/([0-9]*)$/, "$1"); // profiles/ciccio/1234 -> 1234
 							if(converted==entityid){
 								ct_add_token(window.TOKEN_OBJECTS[$(this).attr('data-id')]);
+								window.TOKEN_OBJECTS[$(this).attr('data-id')].options.init = total;
+								window.TOKEN_OBJECTS[$(this).attr('data-id')].place_sync_persist();
+								ct_reorder();
 							}
 						}
 					);
@@ -959,6 +962,8 @@ class MessageBroker {
 						console.log(converted);
 						if (converted == entityid) {
 							$(this).find(".init").val(total);
+							window.TOKEN_OBJECTS[$(this).attr('data-target')].options.init = total;
+							window.TOKEN_OBJECTS[$(this).attr('data-target')].place_sync_persist();
 							ct_reorder();
 						}
 					});

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1001,8 +1001,8 @@ class MessageBroker {
 		}, 4000), 15000);
 	}
 
-    	handleCT(data){
-		$("#combat_area").empty();
+  handleCT(data){
+  	$("#combat_area").empty();
 		ct_load(data);
 	}
 
@@ -1156,7 +1156,8 @@ class MessageBroker {
 		var data = msg.data;
 		//let t=new Token($.parseJSON(msg.data));
 
-
+		if(data.id == undefined)
+			return;
 		if (data.id in window.TOKEN_OBJECTS) {
 			for (var property in data) {
 				window.TOKEN_OBJECTS[data.id].options[property] = data[property];
@@ -1278,7 +1279,6 @@ class MessageBroker {
 					check_token_visibility();
 	
 			if(window.CLOUD && window.DM){
-				$("#combat_area").empty();
 				ct_load();
 			}
 

--- a/Token.js
+++ b/Token.js
@@ -1358,7 +1358,18 @@ class Token {
 			if (typeof this.options.tokendataname !== "undefined") {
 				tok.attr("data-tokendataname", this.options.tokendataname);
 			}
-
+			if(window.all_token_objects == undefined){
+				window.all_token_objects = {};
+			}
+			if(window.all_token_objects[this.options.id] == undefined){
+				window.all_token_objects[this.options.id] = {};
+			}
+			if (this.options !== undefined){
+				window.all_token_objects[this.options.id] = new Token(this.options);
+			}
+			else if (typeof window.all_token_objects[this.options.id].options.init !== undefined){		
+				this.options.init = window.all_token_objects[this.options.id].options.init;
+			}
 			// CONDITIONS
 			this.build_conditions().forEach(cond_bar => {
 				tok.append(cond_bar);

--- a/Token.js
+++ b/Token.js
@@ -1502,7 +1502,7 @@ class Token {
 					},
 
 				start: function (event) {
-					event.stopPropagation()
+					event.stopImmediatePropagation();
 					if(window.ALLOWTOKENMEASURING)
 						$("#temp_overlay").css("z-index", "50");
 					window.DRAWFUNCTION = "select"
@@ -1554,7 +1554,6 @@ class Token {
 					}
 
 					if (window.ALLOWTOKENMEASURING){
-						setTimeout(function() {
 							// Setup waypoint manager
 							// reset measuring when a new token is picked up
 							if(window.previous_measured_token != self.options.id){
@@ -1576,7 +1575,13 @@ class Token {
 							}else{
 								WaypointManager.resetDefaultDrawStyle()
 							}
-						});
+							const canvas = document.getElementById("temp_overlay");
+							const context = canvas.getContext("2d");
+							// incase we click while on select, remove any line dashes
+							context.setLineDash([])
+							context.fillStyle = '#f50';
+							
+							WaypointManager.setCanvas(canvas);
 					}
 
 					remove_selected_token_bounding_box();
@@ -1588,7 +1593,7 @@ class Token {
 				 * @param {Object} ui UI-object
 				 */
 				drag: function(event, ui) {
-					event.stopPropagation()
+					event.stopImmediatePropagation();
 					var zoom = window.ZOOM;
 
 					var original = ui.originalPosition;
@@ -1614,31 +1619,13 @@ class Token {
 					};
 
 					if (window.ALLOWTOKENMEASURING) {
-						if (WaypointManager.numWaypoints === 0 || tokenPosition.x !== currentTokenPosition.x || tokenPosition.y !== currentTokenPosition.y) {
-							setTimeout(function() {
+						const tokenMidX = tokenPosition.x + Math.round(self.options.size / 2);
+						const tokenMidY = tokenPosition.y + Math.round(self.options.size / 2);
 
-								const tokenMidX = tokenPosition.x + Math.round(self.options.size / 2);
-								const tokenMidY = tokenPosition.y + Math.round(self.options.size / 2);
-
-								const canvas = document.getElementById("temp_overlay");
-								const context = canvas.getContext("2d");
-								// incase we click while on select, remove any line dashes
-								context.setLineDash([])
-								// list the temp overlay so we can see the ruler
-								clear_temp_canvas()
-								
-								WaypointManager.setCanvas(canvas);
-								WaypointManager.registerMouseMove(tokenMidX, tokenMidY);
-								WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, tokenMidX, tokenMidY);
-								WaypointManager.draw(false, Math.round(tokenPosition.x + (self.options.size / 2)), Math.round(tokenPosition.y + self.options.size + 10));
-								context.fillStyle = '#f50';
-
-							});
-						}
+						clear_temp_canvas();
+						WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, tokenMidX, tokenMidY);
+						WaypointManager.draw(false, Math.round(tokenPosition.x + (self.options.size / 2)), Math.round(tokenPosition.y + self.options.size + 10));
 					}
-
-					currentTokenPosition.x = tokenPosition.x;
-					currentTokenPosition.y = tokenPosition.y;
 
 					//console.log("Changing to " +ui.position.left+ " "+ui.position.top);
 					// HACK TEST 
@@ -1867,8 +1854,11 @@ function default_options() {
 }
 
 function center_of_view() {
-	let centerX = ($(window).width() / 2) + window.scrollX;
-	let centerY = ($(window).height() / 2) + window.scrollY;
+	let centerX = (window.innerWidth/2) + window.scrollX 
+	if($("#hide_rightpanel").hasClass("point-right")){
+		centerX = centerX - 170;
+	}
+	let centerY = (window.innerHeight/2) + window.scrollY
 	return { x: centerX, y: centerY };
 }
 
@@ -1951,8 +1941,6 @@ function place_token_at_map_point(tokenObject, x, y) {
 		options.imgsrc = parse_img(options.imgsrc);
 	}
 
-	options.left = `${x}px`;
-	options.top = `${y}px`;
 	if (options.size == undefined) {
 		if (options.sizeId != undefined) {
 			// sizeId was specified, convert it to size. This is used when adding from the monster pane
@@ -1976,7 +1964,8 @@ function place_token_at_map_point(tokenObject, x, y) {
 			options.size = Math.round(window.CURRENT_SCENE_DATA.hpps) * 1;
 		}
 	}
-
+	options.left = `${x - options.size/2}px`;
+	options.top = `${y - options.size/2}px`;
 	// set reasonable defaults for any global settings that aren't already set
 	const setReasonableDefault = function(optionName, reasonableDefault) {
 		if (options[optionName] === undefined) {

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -168,12 +168,16 @@ function token_context_menu_expanded(tokenIds, e) {
 				clickedButton.html(addButtonInternals);
 				tokens.forEach(t =>{
 					t.options.ct_show = undefined;
-					ct_remove_token(t, false)
+					ct_remove_token(t, false);
+					t.place_sync_persist();
 				});
 			} else {
 				clickedButton.removeClass("add-to-ct").addClass("remove-from-ct");
 				clickedButton.html(removeButtonInternals);
-				tokens.forEach(t => ct_add_token(t, false));
+				tokens.forEach(t => {
+					ct_add_token(t, false)
+					t.place_sync_persist();
+				});
 			}
 			ct_persist();
 		});

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -638,7 +638,7 @@ function enable_draggable_token_creation(html, specificImage = undefined) {
                 if (ui.helper.attr("data-shape") && ui.helper.attr("data-style")) {
                     src = build_aoe_img_name(ui.helper.attr("data-style"), ui.helper.attr("data-shape"));
                 }
-                create_and_place_token(draggedItem, hidden, src, event.pageX - ui.helper.width() / 2, event.pageY - ui.helper.height() / 2, false);
+                create_and_place_token(draggedItem, hidden, src, event.pageX, event.pageY, false);
                 // create_and_place_token(draggedItem, hidden, src, event.pageX - ui.helper.width() / 2, event.pageY - ui.helper.height() / 2, false, ui.helper.attr("data-name-override"));
                 close_sidebar_modal();
             } else {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -957,7 +957,19 @@ td:nth-of-type(4){
         filter: saturate(1);
     }
 }
+@keyframes pingAnimate {
+    0%{
 
+        transform: scale(0);
+    }
+    50%{
+        transform: scale(calc(var(--ping-scale)));
+    }
+    100%{
+        transform: scale(0);
+    }
+
+}
 #combat_tracker {
     position: fixed;
     height: 450px;
@@ -3429,6 +3441,14 @@ button.avtt-roll-button {
     fill: #ddd;
 }
 
+.journal-button.popout-button svg path:not([fill='none']){
+    fill: #878787; 
+}
+
+.journal-button.popout-button:hover svg path:not([fill='none']){
+    fill: #000; 
+}
+
 .text-input-title-bar-enter {
     fill: #ddd;
     position: absolute;
@@ -3473,7 +3493,42 @@ button.avtt-roll-button {
 .popout-button {
     top: 2px;
 }
+.journal-button{
+    filter: none;
+    border: 1px solid #c5c5c5;
+    background: #f6f6f6;
+    font-weight: normal;
+    position: absolute;
+    right: 33px;
+    top: 9px;
+    width: 20px;
+    height: 20px;
+    border-radius: 3px;
 
+}
+.journal-button svg{
+    padding: 2px 1px 2px 0px;
+}
+    
+.body-rpgcharacter-sheet .journal-button{
+    filter: none;
+    border: 1px solid #c5c5c5;
+    background: #f6f6f6;
+    font-weight: normal;
+    position: absolute;
+    right: 43px;
+    top: 6px;
+    width: 30px;
+    height: 27px;   
+    border-radius: 3px;
+}
+.body-rpgcharacter-sheet .journal-button svg {
+    padding: 0px;
+    transform: scale(1.1);
+    left: 4px;
+    top: 3px;
+    position: relative;
+}
 #tokenOptionsPopup{
     position: fixed;
     z-index: 59000;


### PR DESCRIPTION
Fixed and new PR of #653 with less commits

Save combat tracker initiative per scene using token options.

Also persist the combat tracker throughout a session - this means it will bring other scenes combatants with you to the next. Easy to clear still with the clear button and won't erase the previous scenes save.

This allows for combat across scenes during a session while retaining individual scene saves.

https://www.youtube.com/watch?v=DAZ_rHMlCZ4