### PR TITLE
Fix occasional error loop

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -334,6 +334,7 @@ class WaypointManagerClass {
 	fadeoutMeasuring(){
 		let alpha = 1.0
 		const self = this
+		if(self.ctx == undefined) return;
 		// only ever allow a single fadeout to occur
 		// this stops weird flashing behaviour with interacting
 		// interval function calls

--- a/Fog.js
+++ b/Fog.js
@@ -334,7 +334,12 @@ class WaypointManagerClass {
 	fadeoutMeasuring(){
 		let alpha = 1.0
 		const self = this
-		if(self.ctx == undefined) return;
+		if(self.ctx == undefined){
+				self.cancelFadeout()
+				self.clearWaypoints();
+				clear_temp_canvas()
+				return;
+		} 
 		// only ever allow a single fadeout to occur
 		// this stops weird flashing behaviour with interacting
 		// interval function calls


### PR DESCRIPTION
Occasionally I'm getting an error loop since it never gets to `cancelFadeout()` below since it errors at `clearRect`. This causes the `setInterval` to keep going forever. I'm unsure if this is weirdness with clicking to fast or out of the canvas or some race condition but this prevents the behaviour.

I can't reliably reproduce it unless I manually set the ctx to undefined. So I'm not sure of the cause. Edit: Clicking the canvas breaks the loop as `drawing_mousedown` triggers `cancelFadeout`. So not as bad but still an annoyance.

This was causing performance issues for about ~30 secs and sometimes it would remain unresponsive.