### PR TITLE
Save combat tracker status of tokens to cloud. Persist CT through session scene swaps. Option to add tokens from CT to scene with the same ID if not present already. Sync tokens with the same id across scenes. Copy paste from other scenes (different IDs).

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -111,7 +111,7 @@ function init_combat_tracker(){
 
 			window.StatHandler.rollInit($(this).attr('data-monster'),function(value){
 				element.find(".init").val(value);
-				ct_reorder(false);
+				setTimeout(ct_reorder(), 500);
 			});
 			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 		});
@@ -165,7 +165,7 @@ function init_combat_tracker(){
 					
 			window.StatHandler.rollInit($(this).attr('data-monster'),function(value){
 				element.find(".init").val(value);
-				ct_reorder(false);
+				setTimeout(ct_reorder(), 500);
 			});
 			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 		});
@@ -320,7 +320,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 						window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 						window.TOKEN_OBJECTS[token.options.id].place_sync_persist()
 					}
-					ct_reorder();
+					setTimeout(ct_reorder(), 500);
 				}
 			);
 		}
@@ -333,7 +333,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 					init.val(value);
 					token.options.init = value;
 					token.sync();
-					ct_reorder();
+					setTimeout(ct_reorder(), 500);
 				});
 		}
 		
@@ -497,9 +497,8 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		$("#combat_area").append(entry);
 		$("#combat_area td").css("vertical-align","middle");
 
-		if(persist){
-			ct_reorder();
-			ct_persist();
+		if(window.DM){
+			setTimeout(ct_reorder(), 500);
 		}
 	}
 }
@@ -570,10 +569,10 @@ function ct_load(data=null){
 		}
 	}
 	if(window.DM){
-		ct_reorder();
+		setTimeout(ct_reorder(), 500);
 	}
 	else{
-		ct_reorder(false);
+		setTimeout(ct_reorder(false), 500);
 	}
 }
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -286,10 +286,11 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		init.css('width','20px');
 		init.css('-webkit-appearance','none');
 		if(window.DM && typeof(token.options.init) == 'undefined'){
-			if(typeof window.all_token_objects != undefined) {
-				if(typeof window.all_token_objects[token.options.id] != undefined)	{
-					if (typeof window.all_token_objects[token.options.id].options.init != undefined){
+			if(typeof window.all_token_objects != 'undefined') {
+				if(typeof window.all_token_objects[token.options.id] != 'undefined')	{
+					if (typeof window.all_token_objects[token.options.id].options.init != 'undefined'){
 				 		token.options.init = window.all_token_objects[token.options.id].options.init;
+				 		window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 						init.val(token.options.init);
 						token.place_sync_persist();
 					}
@@ -300,9 +301,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			}
 			init.change(function(){
 					ct_reorder();
-					if(typeof window.all_token_objects != undefined) {
+					if(typeof window.all_token_objects != 'undefined') {
 						window.all_token_objects[token.options.id].options.init = init.val()
 					}
+					window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 					token.options.init = init.val();
 					token.place_sync_persist();
 				}
@@ -312,9 +314,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			init.val(token.options.init);
 			init.change(function(){
 					ct_reorder();
-					if(typeof window.all_token_objects != undefined) {
+					if(typeof window.all_token_objects != 'undefined') {
 						window.all_token_objects[token.options.id].options.init = init.val()
 					}
+					window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
 					token.options.init = init.val();
 					token.place_sync_persist();
 				}
@@ -324,6 +327,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			init.val(token.options.init);
 			init.attr("disabled","disabled");
 		}
+	
 		entry.append($("<td/>").append(init));
 		
 		// auto roll initiative for monsters
@@ -535,18 +539,10 @@ function ct_persist(){
 	data.push({'data-target': 'round',
 				'round_number':window.ROUND_NUMBER});
 	
-	var itemkey="CombatTracker"+find_game_id();
-	
-	localStorage.setItem(itemkey,JSON.stringify(data));
 	window.MB.sendMessage("custom/myVTT/CT",data);
 }
 
 function ct_load(data=null){
-	
-	if(data==null && window.DM){
-		var itemkey="CombatTracker"+find_game_id();
-		data=$.parseJSON(localStorage.getItem(itemkey));
-	}
 	
 	if(data){	
 		for(i=0;i<data.length;i++){
@@ -586,13 +582,7 @@ function ct_load(data=null){
 					token.options.init = data[i]['init'];	
 					ct_add_token(token,false,true);
 				}
-				
-				for(tokenID in window.TOKEN_OBJECTS){
-					if(window.TOKEN_OBJECTS[tokenID].options.ct_show == true)
-					{
-						ct_add_token(window.TOKEN_OBJECTS[tokenID],false,true);
-					}		
-				}
+
 
 				$("#combat_area tr[data-target='"+data[i]['data-target']+"']").find(".init").val(data[i]['init']);
 				if(data[i]['current']){
@@ -600,6 +590,13 @@ function ct_load(data=null){
 				}
 			}
 		}
+	}
+
+	for(tokenID in window.TOKEN_OBJECTS){
+		if(window.TOKEN_OBJECTS[tokenID].options.ct_show == true)
+		{
+			ct_add_token(window.TOKEN_OBJECTS[tokenID],false,true);
+		}		
 	}
 	ct_reorder(false);
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -118,9 +118,6 @@ function init_combat_tracker(){
 		$("#combat_area tr").first().attr('data-current','1');
 		next.removeAttr('data-current');
 		next.css('background','');
-		window.ScenesHandler.scene.currentCTID = $("#combat_area tr").first.attr('data-target');
-		window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
-		window.ScenesHandler.persist_current_scene(true);
 		ct_persist();
 		ct_update_popout();
 	});
@@ -131,8 +128,6 @@ function init_combat_tracker(){
 			ct_persist();
 		}
 		ct_update_popout();
-		window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
-		window.ScenesHandler.persist_current_scene(true);
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
 	});
 	
@@ -167,7 +162,7 @@ function init_combat_tracker(){
 				}
 			});
 		});
-
+		
 		setTimeout(ct_reorder,500); // quick hack to save and resync only one time
 		setTimeout(ct_update_popout,600);
 
@@ -191,8 +186,6 @@ function init_combat_tracker(){
 		}
 		window.ROUND_NUMBER = 1;
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
-		window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
-		window.ScenesHandler.persist_current_scene(true);
 		ct_persist();
 	});
 	
@@ -212,7 +205,6 @@ function init_combat_tracker(){
 			next=current.next();
 			if(next.length==0){
 				window.ROUND_NUMBER++;
-				window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
 				document.getElementById('round_number').value = window.ROUND_NUMBER;
 				next=$("#combat_area tr").first()
 			}
@@ -221,8 +213,6 @@ function init_combat_tracker(){
 				$("[data-current][data-monster] button.openSheetCombatButton").click();
 			}
 		}
-		window.ScenesHandler.scene.currentCTID = $("#combat_area tr[data-current]").attr('data-target');
-		window.ScenesHandler.persist_current_scene(true);
 		ct_persist();
 		ct_update_popout();
 		//var target=$("#combat_area tr[data-current=1]").attr('data-target');
@@ -723,6 +713,7 @@ function ct_load(data=null){
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
 				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || (window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined))
 				{
+
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
 					if([data[i]['data-target']] in window.TOKEN_OBJECTS){
 						window.TOKEN_OBJECTS[data[i]['data-target']].options.hp = window.all_token_objects[data[i]['data-target']].options.hp;
@@ -747,12 +738,6 @@ function ct_load(data=null){
 		}
 		if(data.current){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
-		}
-		else if(window.CURRENT_SCENE_DATA.currentCTID != undefined){
-			$("#combat_area tr[data-target='"+window.CURRENT_SCENE_DATA.currentCTID+"']").attr("data-current","1"); 
-		}
-		if(window.ScenesHandler.scene.ROUND_NUMBER != undefined && document.getElementById('round_number').value < 2){
-			document.getElementById('round_number').value = window.ScenesHandler.scene.ROUND_NUMBER;
 		}
 	}
 	if(window.DM){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -449,11 +449,17 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		
 		// bind update functions to hp inputs, same as Token.js
 		// token update logic for hp pulls hp from token hpbar, so update hp bar manually
-				if (!token.isPlayer()) {
+		if (!token.isPlayer()) {
 			hp_input.change(function(e) {
 				var selector = "div[data-id='" + token.options.id + "']";
 				var old = $("#tokens").find(selector);
-				old.find(".hp").val(hp_input.val().trim());
+			
+				if (hp_input.val().trim().startsWith("+") || hp_input.val().trim().startsWith("-")) {
+					hp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(hp_input.val())));
+				}
+
+				old.find(".hp").val(hp_input.val().trim());	
+
 				if(window.all_token_objects[token.options.id] != undefined){
 					window.all_token_objects[token.options.id].options.hp = hp_input.val();
 					window.all_token_objects[token.options.id].update_and_sync();
@@ -470,13 +476,18 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			maxhp_input.change(function(e) {
 				var selector = "div[data-id='" + token.options.id + "']";
 				var old = $("#tokens").find(selector);
+
+				if (maxhp_input.val().trim().startsWith("+") || maxhp_input.val().trim().startsWith("-")) {
+					maxhp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(maxhp_input.val())));
+				}
+
 				old.find(".max_hp").val(maxhp_input.val().trim());
 				if(window.all_token_objects[token.options.id] != undefined){
 					window.all_token_objects[token.options.id].options.max_hp = maxhp_input.val();
 					window.all_token_objects[token.options.id].update_and_sync();
 				}
 				if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
-					window.TOKEN_OBJECTS[token.options.id].options.hp = hp_input.val();	
+					window.TOKEN_OBJECTS[token.options.id].options.max_hp = maxhp_input.val();	
 					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
 				}			
 				setTimeout(ct_persist(), 500);

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -118,17 +118,27 @@ function init_combat_tracker(){
 		$("#combat_area tr").first().attr('data-current','1');
 		next.removeAttr('data-current');
 		next.css('background','');
+		let tokenID = $("#combat_area tr").first().attr('data-target');
+		if(window.TOKEN_OBJECTS[tokenID].options.round != undefined){
+			delete window.TOKEN_OBJECTS[tokenID].options.round;
+			window.TOKEN_OBJECTS[tokenID].update_and_sync();
+		}
 		ct_persist();
 		ct_update_popout();
 	});
 
 	rn.find("#round_number").change(function (data) {
-		if( !isNaN(data.currentTarget.value)){
+		if(!isNaN(data.currentTarget.value)){
 			window.ROUND_NUMBER = Math.round(data.currentTarget.value);
 			ct_persist();
 		}
 		ct_update_popout();
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
+		let tokenID = $("#combat_area tr[data-current]").attr('data-target');
+		if(window.TOKEN_OBJECTS[tokenID] != undefined){
+			window.TOKEN_OBJECTS[tokenID].options.round = window.ROUND_NUMBER;
+			window.TOKEN_OBJECTS[tokenID].update_and_sync();
+		}
 	});
 	
 	ct_inside.append(rn);
@@ -179,10 +189,14 @@ function init_combat_tracker(){
 			ct_remove_token(window.all_token_objects[id], false);
 			if(window.TOKEN_OBJECTS[id] != undefined){
 				window.TOKEN_OBJECTS[id].options.ct_show = undefined;
+				if(window.TOKEN_OBJECTS[id].round != undefined){
+					delete window.TOKEN_OBJECTS[tokenID].options.round;	
+				}
 				window.TOKEN_OBJECTS[id].update_and_sync();
 			}
 			window.all_token_objects[id].options.ct_show = undefined;
 			window.all_token_objects[id].update_and_sync();
+
 		}
 		window.ROUND_NUMBER = 1;
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
@@ -195,9 +209,13 @@ function init_combat_tracker(){
 			return;
 
 		current=$("#combat_area tr[data-current=1]");
+		let currentTarget = current.attr('data-target');
 		if(current.length==0){
 			console.log('nessuno selezionato');
 			$("#combat_area tr").first().attr('data-current','1');
+			currentTarget = $("#combat_area tr[data-current=1]").attr('data-target');
+			window.TOKEN_OBJECTS[currentTarget].options.current = true;
+			window.TOKEN_OBJECTS[currentTarget].update_and_sync();
 		}
 		else{
 			current.removeAttr('data-current');
@@ -212,10 +230,21 @@ function init_combat_tracker(){
 			if($("#resizeDragMon:not(.hideMon)").length>0) {
 				$("[data-current][data-monster] button.openSheetCombatButton").click();
 			}
+			let newTarget=$("#combat_area tr[data-current=1]").attr('data-target');
+			if(window.TOKEN_OBJECTS[currentTarget] != undefined){
+				delete window.TOKEN_OBJECTS[currentTarget].options.current;
+				delete window.TOKEN_OBJECTS[newTarget].options.round;
+				window.TOKEN_OBJECTS[currentTarget].update_and_sync();
+			}
+			if(window.TOKEN_OBJECTS[newTarget] != undefined){
+				window.TOKEN_OBJECTS[newTarget].options.current = true;
+				window.TOKEN_OBJECTS[newTarget].options.round = window.ROUND_NUMBER;
+				window.TOKEN_OBJECTS[newTarget].update_and_sync();
+			}
 		}
+		
 		ct_persist();
 		ct_update_popout();
-		//var target=$("#combat_area tr[data-current=1]").attr('data-target');
 	});
 	
 	roll=$('<button class="rollInitiativeCombatButton"><svg class="rollSVG" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 339.09 383.21"><path d="M192.91,3q79.74,45.59,159.52,91.1c4.9,2.79,7.05,6,7,11.86q-.29,87.76,0,175.52c0,5.14-1.79,8.28-6.19,10.85q-78.35,45.75-156.53,91.78c-4.75,2.8-8.81,2.8-13.57,0q-77.7-45.75-155.59-91.18c-5.17-3-7.2-6.52-7.18-12.56q.31-87.39,0-174.78c0-5.5,2.06-8.64,6.7-11.28q80-45.53,159.84-91.3ZM115.66,136h3.67c12.1,0,24.19-.05,36.29,0,5.24,0,8.38,3.15,8.34,8s-3.56,8-9.73,8c-11.85.08-23.69,0-35.54,0-4.14,0-4.21.16-2.11,3.8q35.54,61.53,71.09,123.06c.59,1,.82,2.7,2.32,2.62s1.66-1.7,2.25-2.74q35.47-61.35,70.9-122.74c2.3-4,2.31-4-2.5-4-11.72,0-23.45.06-35.17,0-6.18-.05-9.6-3.08-9.59-8.1,0-5.18,3.27-7.9,9.58-7.91,11.47,0,22.94,0,34.42,0,1.27,0,2.71.54,3.93-.63a11.49,11.49,0,0,0-.69-1.36q-35.49-53-71-106c-2.15-3.22-3.2-1.77-4.7.46q-35.06,52.36-70.19,104.71C116.82,133.87,116.44,134.63,115.66,136Zm89,153.29c1.51,0,2.25.06,3,0,12.51-1.17,25-2.39,37.53-3.54,14.75-1.35,29.5-2.61,44.25-4,15.11-1.39,30.22-2.89,45.34-4.25,4.39-.39,4.47-.32,2.46-4.21q-10.79-20.94-21.61-41.87-17.31-33.56-34.64-67.11c-.49-1-.69-2.45-1.9-2.57s-1.48,1.46-2.14,2.31a9.38,9.38,0,0,0-.56,1q-27.49,47.6-55,95.2C215.87,269.75,210.42,279.24,204.62,289.31Zm-29.49.12c-1-1.84-1.57-3.05-2.24-4.22Q154,252.49,135.13,219.79,119.05,191.94,103,164.1c-.53-.91-.8-2.38-2.13-2.32-1.1.05-1.29,1.39-1.73,2.24Q70.69,219,42.3,274c-1.35,2.6-.88,3.39,2.09,3.56,6.71.38,13.4,1.06,20.09,1.68q23,2.11,46.08,4.27c12.26,1.15,24.53,2.34,36.79,3.47C156.37,287.81,165.4,288.57,175.13,289.43ZM44.49,102.78c1.34.83,2.16,1.37,3,1.86C63,113.46,78.55,122.19,94,131.17c3.21,1.88,4.7,1.46,6.75-1.63Q131,83.87,161.64,38.39c.66-1,1.64-1.84,1.8-3.6Zm172.2-67.85-.38.49c.31.53.58,1.08.93,1.59q30.94,46.15,61.84,92.33c2.12,3.18,3.67,3.68,7,1.72,15.4-9,31-17.7,46.45-26.54.8-.45,1.95-.58,2.22-2.08ZM36,250l.72.09C37.84,248,39,246,40.05,243.86Q64.23,197,88.47,150.12c1.35-2.6.68-3.58-1.6-4.86C71.21,136.48,55.62,127.56,40,118.7c-4-2.25-4-2.22-4,2.29V250Zm307.45.82a12.72,12.72,0,0,0,.35-1.55q0-64.51.06-129c0-3.33-1.17-3.17-3.5-1.85Q316.51,132,292.56,145.51c-2.11,1.18-2.42,2.21-1.29,4.38q18.11,34.83,36,69.76C332.56,229.83,337.84,240,343.46,250.84ZM64.23,295.22l-.14.56,47.09,27.59q33.88,19.86,67.78,39.7c1.11.64,3.21,3.18,3.21-.87,0-17.71,0-35.42,0-53.13,0-2.21-1-3.17-3.09-3.36q-17.29-1.51-34.59-3.07-18.22-1.63-36.45-3.29Q86.15,297.33,64.23,295.22Zm252.49,0c-11.13,1-21.24,2-31.37,2.92-12.15,1.1-24.31,2.1-36.46,3.21-15.62,1.41-31.23,3-46.86,4.26-3.38.27-4.46,1.44-4.43,4.8.14,16.84.06,33.68.07,50.52,0,4.1,0,4.1,3.73,1.93L286,313.28C296,307.43,305.91,301.56,316.72,295.2Z" transform="translate(-20.37 -3.01)"/><path d="M197.64,143.89a7.9,7.9,0,0,1-7.72,8,7.81,7.81,0,0,1-7.73-7.93,7.73,7.73,0,1,1,15.45,0Z" transform="translate(-20.37 -3.01)"/></svg></button>');
@@ -738,6 +767,17 @@ function ct_load(data=null){
 		}
 		if(data.current){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
+		}
+		else{
+			for (tokenID in window.TOKEN_OBJECTS){
+				if(window.TOKEN_OBJECTS[tokenID].options.current == true){
+					$("#combat_area tr[data-target='"+tokenID+"']").attr("data-current","1");
+					if(window.TOKEN_OBJECTS[tokenID].options.round > 1){
+						window.ROUND_NUMBER = window.TOKEN_OBJECTS[tokenID].options.round;
+						document.getElementById('round_number').value = window.ROUND_NUMBER;
+					}
+				}		
+			}
 		}
 	}
 	if(window.DM){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -695,7 +695,7 @@ function ct_load(data=null){
 					window.all_token_objects[data[i]['data-target']] = new Token(data[i]['options']);
 				}
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
-				if(window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined)
+				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined )
 				{
 					window.all_token_objects[data[i]['data-target']].sync = function(e) {				
 						window.MB.sendMessage('custom/myVTT/token', this.options);
@@ -718,7 +718,7 @@ function ct_load(data=null){
 
 	if(data == null){
 		for(tokenID in window.all_token_objects){
-			if(window.all_token_objects[tokenID].options.ct_show !== undefined)
+			if(window.all_token_objects[tokenID].options.ct_show == true || window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined ) 
 			{
 				window.all_token_objects[tokenID].sync = function(e) {				
 					window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[tokenID].options);

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -611,7 +611,7 @@ function ct_load(data=null){
 function ct_remove_token(token,persist=true) {
 
 	if (persist == true) {
-		token.sync();
+		if(token.options.id in window.TOKEN_OBJECTS) token.sync();
 		if (token.persist != null) token.persist();
 	}
 	

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -265,7 +265,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		}	
 	}
 
-	if (token.options.ct_show == true || window.DM){
+	if (token.options.ct_show == true){
 		if ((token.options.name) && (window.DM || token.isPlayer() || token.options.revealname)) {
 			entry.attr("data-name", token.options.name);
 			entry.addClass("hasTooltip");
@@ -313,12 +313,12 @@ function ct_add_token(token,persist=true,disablerolling=false){
 						window.all_token_objects[token.options.id].sync = function(e) {				
 							window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[token.options.id].options);
 						};
-						window.all_token_objects[token.options.id].sync();
+						window.all_token_objects[token.options.id].update_and_sync()
 					}
 					token.options.init = init.val();
 					if(window.TOKEN_OBJECTS[token.options.id] != undefined){
 						window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
-						window.TOKEN_OBJECTS[token.options.id].place_sync_persist()
+						window.TOKEN_OBJECTS[token.options.id].update_and_sync()
 					}
 					setTimeout(ct_reorder(), 500);
 				}
@@ -332,7 +332,12 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			window.StatHandler.rollInit(token.options.monster,function(value){
 					init.val(value);
 					token.options.init = value;
-					token.sync();
+					if(window.TOKEN_OBJECTS[token.options.id] != undefined){
+						window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+					}
+					if(window.all_token_objects[token.options.id] != undefined){		
+						window.all_token_objects[token.options.id].update_and_sync()
+					}
 					setTimeout(ct_reorder(), 500);
 				});
 		}
@@ -430,7 +435,15 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		del=$('<button class="removeTokenCombatButton" style="font-size:10px;"><svg class="delSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg></button>');
 		del.click(
 			function(){
-				token.options.ct_show = undefined;
+				if(window.TOKEN_OBJECTS[token.options.id] != undefined){
+					window.TOKEN_OBJECTS[token.options.id].options.ct_show = undefined;
+					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+				}
+				if(window.all_token_objects[token.options.id] != undefined){
+					window.all_token_objects[token.options.id].options.ct_show = undefined;
+					window.all_token_objects[token.options.id].update_and_sync()
+				}
+
 				ct_remove_token(token);
 			}
 		);
@@ -578,16 +591,6 @@ function ct_load(data=null){
 
 function ct_remove_token(token,persist=true) {
 
-	if (persist == true) {
-		if(token.options.id in window.TOKEN_OBJECTS){
-			window.TOKEN_OBJECTS[token.options.id].options.ct_show = undefined;
-		} 
-		if(token.options.id in window.all_token_objects){
-			window.all_token_objects[token.options.id].options.ct_show = undefined;
-		} 
-		if (token.persist != null) token.persist();
-	}
-	
 	let id = token.options.id;
 	if ($("#combat_area tr[data-target='" + id + "']").length > 0) {
 		if ($("#combat_area tr[data-target='" + id + "']").attr('data-current') == "1") {

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -742,7 +742,10 @@ function ct_load(data=null){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
 		}
 	}
-	ct_update_popout()
+	if(window.DM){
+		ct_reorder();
+	}
+	ct_update_popout();
 }
 
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -706,13 +706,14 @@ function ct_load(data=null){
 			else if(data[i]['data-target'] !== undefined){
 				if (window.all_token_objects[data[i]['data-target']] == undefined) {
 					window.all_token_objects[data[i]['data-target']] = new Token(data[i]['options']);
+					window.all_token_objects[data[i]['data-target']].sync = function(e) {				
+						window.MB.sendMessage('custom/myVTT/token', this.options);
+					};
 				}
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
 				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || (window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined))
 				{
-					window.all_token_objects[data[i]['data-target']].sync = function(e) {				
-						window.MB.sendMessage('custom/myVTT/token', this.options);
-					};
+
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
 					if([data[i]['data-target']] in window.TOKEN_OBJECTS){
 						window.TOKEN_OBJECTS[data[i]['data-target']].options.hp = window.all_token_objects[data[i]['data-target']].options.hp;
@@ -732,9 +733,6 @@ function ct_load(data=null){
 		for(tokenID in window.all_token_objects){
 			if(window.all_token_objects[tokenID].options.ct_show == true || (window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined)) 
 			{
-				window.all_token_objects[tokenID].sync = function(e) {				
-					window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[tokenID].options);
-				};
 				ct_add_token(window.all_token_objects[tokenID],false,true);
 			}		
 		}

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -332,10 +332,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			window.StatHandler.rollInit(token.options.monster,function(value){
 					init.val(value);
 					token.options.init = value;
-					if(window.TOKEN_OBJECTS[token.options.id] != undefined){
+					if(window.TOKEN_OBJECTS[token.options.id] != undefined){			
 						window.TOKEN_OBJECTS[token.options.id].update_and_sync()
 					}
-					if(window.all_token_objects[token.options.id] != undefined){		
+					if(window.all_token_objects[token.options.id] != undefined){				
 						window.all_token_objects[token.options.id].update_and_sync()
 					}
 					setTimeout(ct_reorder(), 500);
@@ -561,7 +561,8 @@ function ct_load(data=null){
 						window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[data[i]['data-target']].options);
 					};
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
-				}	
+				}
+
 				
 				if(data[i]['current']){
 					$("#combat_area tr[data-target='"+data[i]['data-target']+"']").attr("data-current","1");

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -473,7 +473,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.closedEye").css('display', 'block');
 						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.openEye").css('display', 'none');
 					}
-					token.update_and_sync()
+					if(token.options.id in window.TOKEN_OBJECTS) token.update_and_sync();		
 					ct_persist();
 				});
 				eye_button.append(open_eye);

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -164,9 +164,8 @@ function init_combat_tracker(){
 		});
 		ct_reorder();
 
-			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
+		setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 
-		});
 		ct_update_popout();
 		$("#combat_area tr").first().attr('data-current','1');
 	});

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -412,7 +412,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				var old = $("#tokens").find(selector);
 				old.find(".max_hp").val(maxhp_input.val().trim());
 				if(window.all_token_objects[token.options.id] != undefined){
-					window.all_token_objects[token.options.id].options.hp = hp_input.val();
+					window.all_token_objects[token.options.id].options.max_hp = maxhp_input.val();
 				}
 				window.all_token_objects[token.options.id].update_and_sync(e);
 				ct_persist();

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -695,7 +695,7 @@ function ct_load(data=null){
 					window.all_token_objects[data[i]['data-target']] = new Token(data[i]['options']);
 				}
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
-				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined )
+				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || (window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined))
 				{
 					window.all_token_objects[data[i]['data-target']].sync = function(e) {				
 						window.MB.sendMessage('custom/myVTT/token', this.options);
@@ -718,7 +718,7 @@ function ct_load(data=null){
 
 	if(data == null){
 		for(tokenID in window.all_token_objects){
-			if(window.all_token_objects[tokenID].options.ct_show == true || window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined ) 
+			if(window.all_token_objects[tokenID].options.ct_show == true || (window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined)) 
 			{
 				window.all_token_objects[tokenID].sync = function(e) {				
 					window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[tokenID].options);

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -118,6 +118,9 @@ function init_combat_tracker(){
 		$("#combat_area tr").first().attr('data-current','1');
 		next.removeAttr('data-current');
 		next.css('background','');
+		window.ScenesHandler.scene.currentCTID = $("#combat_area tr").first.attr('data-target');
+		window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
+		window.ScenesHandler.persist_current_scene(true);
 		ct_persist();
 		ct_update_popout();
 	});
@@ -128,6 +131,8 @@ function init_combat_tracker(){
 			ct_persist();
 		}
 		ct_update_popout();
+		window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
+		window.ScenesHandler.persist_current_scene(true);
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
 	});
 	
@@ -162,7 +167,7 @@ function init_combat_tracker(){
 				}
 			});
 		});
-		
+
 		setTimeout(ct_reorder,500); // quick hack to save and resync only one time
 		setTimeout(ct_update_popout,600);
 
@@ -186,6 +191,8 @@ function init_combat_tracker(){
 		}
 		window.ROUND_NUMBER = 1;
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
+		window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
+		window.ScenesHandler.persist_current_scene(true);
 		ct_persist();
 	});
 	
@@ -205,6 +212,7 @@ function init_combat_tracker(){
 			next=current.next();
 			if(next.length==0){
 				window.ROUND_NUMBER++;
+				window.ScenesHandler.scene.ROUND_NUMBER = window.ROUND_NUMBER;
 				document.getElementById('round_number').value = window.ROUND_NUMBER;
 				next=$("#combat_area tr").first()
 			}
@@ -213,6 +221,8 @@ function init_combat_tracker(){
 				$("[data-current][data-monster] button.openSheetCombatButton").click();
 			}
 		}
+		window.ScenesHandler.scene.currentCTID = $("#combat_area tr[data-current]").attr('data-target');
+		window.ScenesHandler.persist_current_scene(true);
 		ct_persist();
 		ct_update_popout();
 		//var target=$("#combat_area tr[data-current=1]").attr('data-target');
@@ -713,7 +723,6 @@ function ct_load(data=null){
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
 				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || (window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined))
 				{
-
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
 					if([data[i]['data-target']] in window.TOKEN_OBJECTS){
 						window.TOKEN_OBJECTS[data[i]['data-target']].options.hp = window.all_token_objects[data[i]['data-target']].options.hp;
@@ -738,6 +747,12 @@ function ct_load(data=null){
 		}
 		if(data.current){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
+		}
+		else if(window.CURRENT_SCENE_DATA.currentCTID != undefined){
+			$("#combat_area tr[data-target='"+window.CURRENT_SCENE_DATA.currentCTID+"']").attr("data-current","1"); 
+		}
+		if(window.ScenesHandler.scene.ROUND_NUMBER != undefined && document.getElementById('round_number').value < 2){
+			document.getElementById('round_number').value = window.ScenesHandler.scene.ROUND_NUMBER;
 		}
 	}
 	if(window.DM){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -172,11 +172,21 @@ function init_combat_tracker(){
 	
 	clear=$("<button>CLEAR</button>");
 	clear.click(function(){
-		$("#combat_area button.removeTokenCombatButton").each(function() {
-			this.click();
-		});
+		for(id in window.all_token_objects)
+		{	
+			if(window.all_token_objects[id].options.ct_show == undefined)
+				continue;
+			ct_remove_token(window.all_token_objects[id], false);
+			if(window.TOKEN_OBJECTS[id] != undefined){
+				window.TOKEN_OBJECTS[id].options.ct_show = undefined;
+				window.TOKEN_OBJECTS[id].update_and_sync();
+			}
+			window.all_token_objects[id].options.ct_show = undefined;
+			window.all_token_objects[id].update_and_sync();
+		}
 		window.ROUND_NUMBER = 1;
 		document.getElementById('round_number').value = window.ROUND_NUMBER;
+		ct_persist();
 	});
 	
 	next=$("<button id='combat_next_button'><u>N</u>EXT</button>");
@@ -732,13 +742,7 @@ function ct_load(data=null){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
 		}
 	}
-	if(window.DM){
-		setTimeout(ct_reorder(), 500);
-	}
-	else{
-		setTimeout(ct_reorder(false), 500);
-	}
-ct_update_popout()
+	ct_update_popout()
 }
 
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -501,6 +501,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		$("#combat_area").append(entry);
 		$("#combat_area td").css("vertical-align","middle");
 		
+		ct_reorder();
 		if(persist){
 			ct_persist();
 		}

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -164,7 +164,7 @@ function init_combat_tracker(){
 		});
 		ct_reorder();
 
-		setTimeout(ct_persist,5000); // quick hack to save and resync only one time
+		setTimeout(ct_persist,1000); // quick hack to save and resync only one time
 
 		ct_update_popout();
 		$("#combat_area tr").first().attr('data-current','1');
@@ -621,7 +621,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	$("#combat_area").append(entry);
 	$("#combat_area td").css("vertical-align","middle");
 
-  ct_update_popout();
+  	ct_update_popout();
 
 	if(window.DM){
 		setTimeout(ct_reorder(), 500);

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -111,11 +111,16 @@ function init_combat_tracker(){
 
 			window.StatHandler.rollInit($(this).attr('data-monster'),function(value){
 				element.find(".init").val(value);
-				setTimeout(ct_reorder(), 500);
+				if(element.attr("data-target") in window.TOKEN_OBJECTS){
+					window.TOKEN_OBJECTS[element.attr("data-target")].options.init = value;
+				}
+				if(element.attr("data-target") in window.all_token_objects){
+					window.all_token_objects[element.attr("data-target")].options.init = value;
+				}
 			});
-			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 		});
-
+		ct_reorder();
+		ct_update_popout();
 		$("#combat_area tr").first().attr('data-current','1');
 	});
 	
@@ -161,15 +166,19 @@ function init_combat_tracker(){
 		$("#combat_area tr[data-monster]").each(function(idx){
 			let element=$(this);
 			if(element.find(".init").val()!=0) // DON'T ROLL AGAIN'
-				return;
-					
+				return;			
 			window.StatHandler.rollInit($(this).attr('data-monster'),function(value){
 				element.find(".init").val(value);
-				setTimeout(ct_reorder(), 500);
+				if(element.attr("data-target") in window.TOKEN_OBJECTS){
+					window.TOKEN_OBJECTS[element.attr("data-target")].options.init = value;
+				}
+				if(element.attr("data-target") in window.all_token_objects){
+					window.all_token_objects[element.attr("data-target")].options.init = value;
+				}
 			});
-			setTimeout(ct_persist,5000); // quick hack to save and resync only one time
 		});
-		
+		ct_reorder();	
+		ct_update_popout();
 	});
 	
 	

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -317,6 +317,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			token.options.ct_show = false;
 			if(typeof window.all_token_objects != 'undefined') {
 				window.all_token_objects[token.options.id].options.ct_show = false;
+				window.all_token_objects.update_and_sync();
 			}
 		}
 		else {		
@@ -325,6 +326,8 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			}
 			else{
 				token.options.ct_show = true;
+				window.all_token_objects[token.options.id].options.ct_show = true;
+				window.all_token_objects.update_and_sync();
 			}
 		}	
 	}
@@ -683,7 +686,7 @@ function ct_update_popout(){
 function ct_load(data=null){
 	
 	
-	if(data){	
+	if(!data.loading){	
 		$("#combat_area tr[data-current]").removeAttr("data-current");
 		for(i=0;i<data.length;i++){
 			if (data[i]['data-target'] === 'round'){
@@ -715,8 +718,7 @@ function ct_load(data=null){
 			}
 		}
 	}
-
-	if(data == null){
+	else{
 		for(tokenID in window.all_token_objects){
 			if(window.all_token_objects[tokenID].options.ct_show == true || (window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined)) 
 			{
@@ -725,6 +727,9 @@ function ct_load(data=null){
 				};
 				ct_add_token(window.all_token_objects[tokenID],false,true);
 			}		
+		}
+		if(data.current){
+			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
 		}
 	}
 	if(window.DM){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -393,16 +393,20 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		
 		// bind update functions to hp inputs, same as Token.js
 		// token update logic for hp pulls hp from token hpbar, so update hp bar manually
-		if (!token.isPlayer()) {
+				if (!token.isPlayer()) {
 			hp_input.change(function(e) {
 				var selector = "div[data-id='" + token.options.id + "']";
 				var old = $("#tokens").find(selector);
 				old.find(".hp").val(hp_input.val().trim());
 				if(window.all_token_objects[token.options.id] != undefined){
 					window.all_token_objects[token.options.id].options.hp = hp_input.val();
-				}
-				window.all_token_objects[token.options.id].update_and_sync(e);
-				ct_persist();
+					window.all_token_objects[token.options.id].update_and_sync();
+				}			
+				if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
+					window.TOKEN_OBJECTS[token.options.id].options.hp = hp_input.val();	
+					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+				}			
+				setTimeout(ct_persist(), 500);
 			});
 			hp_input.click(function(e) {
 				$(e.target).select();
@@ -413,9 +417,13 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				old.find(".max_hp").val(maxhp_input.val().trim());
 				if(window.all_token_objects[token.options.id] != undefined){
 					window.all_token_objects[token.options.id].options.max_hp = maxhp_input.val();
+					window.all_token_objects[token.options.id].update_and_sync();
 				}
-				window.all_token_objects[token.options.id].update_and_sync(e);
-				ct_persist();
+				if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
+					window.TOKEN_OBJECTS[token.options.id].options.hp = hp_input.val();	
+					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+				}			
+				setTimeout(ct_persist(), 500);
 			});
 			maxhp_input.click(function(e) {
 				$(e.target).select();
@@ -573,13 +581,18 @@ function ct_load(data=null){
 				if (window.all_token_objects[data[i]['data-target']] == undefined) {
 					window.all_token_objects[data[i]['data-target']] = new Token(data[i]['options']);
 				}
-				window.all_token_objects[data[i]['data-target']].options.ct_show = data[i]['options'].ct_show;
+				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
 				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true)
 				{
 					window.all_token_objects[data[i]['data-target']].sync = function(e) {				
-						window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[data[i]['data-target']].options);
+						window.MB.sendMessage('custom/myVTT/token', this.options);
 					};
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
+					if([data[i]['data-target']] in window.TOKEN_OBJECTS){
+						window.TOKEN_OBJECTS[data[i]['data-target']].options.hp = window.all_token_objects[data[i]['data-target']].options.hp;
+						window.TOKEN_OBJECTS[data[i]['data-target']].options.max_hp = window.all_token_objects[data[i]['data-target']].options.max_hp;
+						window.TOKEN_OBJECTS[data[i]['data-target']].place();
+					}
 				}
 
 				
@@ -588,6 +601,7 @@ function ct_load(data=null){
 				}
 			}
 		}
+
 	}
 
 	if(data == null){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -421,7 +421,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		var buttons=$("<td/>");
 		
 		
-		if(token.options.id in window.TOKEN_OBJECTS){
+		if(token.options.id in window.TOKEN_OBJECTS || !window.DM){
 			find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg></button>');
 		}
 		else {

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -317,7 +317,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			token.options.ct_show = false;
 			if(typeof window.all_token_objects != 'undefined') {
 				window.all_token_objects[token.options.id].options.ct_show = false;
-				window.all_token_objects.update_and_sync();
+				window.all_token_objects[token.options.id].update_and_sync();
 			}
 		}
 		else {		
@@ -327,7 +327,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			else{
 				token.options.ct_show = true;
 				window.all_token_objects[token.options.id].options.ct_show = true;
-				window.all_token_objects.update_and_sync();
+				window.all_token_objects[token.options.id].update_and_sync();
 			}
 		}	
 	}

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -284,8 +284,8 @@ function init_combat_tracker(){
 function ct_reorder(persist=true) {
 	var items = $("#combat_area").children().sort(
 		function(a, b) {
-			var vA = parseInt($(".init", a).val());
-			var vB = parseInt($(".init", b).val());
+			var vA = (isNaN(parseInt($(".init", a).val()))) ? -1 : parseInt($(".init", a).val());
+			var vB =  (isNaN(parseInt($(".init", b).val()))) ? -1 : parseInt($(".init", b).val());
 			return (vA > vB) ? -1 : (vA < vB) ? 1 : 0;
 		});
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -389,13 +389,13 @@ function ct_add_token(token,persist=true,disablerolling=false){
 					window.all_token_objects[token.options.id].options.init = init.val()
 					window.all_token_objects[token.options.id].sync = function(e) {				
 						window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[token.options.id].options);
-					};
-					window.all_token_objects[token.options.id].update_and_sync()
+					}
+					window.all_token_objects[token.options.id].update_and_sync();
 				}
 				token.options.init = init.val();
 				if(window.TOKEN_OBJECTS[token.options.id] != undefined){
 					window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
-					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+					window.TOKEN_OBJECTS[token.options.id].update_and_sync();
 				}
 				setTimeout(ct_reorder(), 500);
 			}
@@ -623,7 +623,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 
   	ct_update_popout();
 
-	if(window.DM){
+	if(window.DM && persist == true){
 		setTimeout(ct_reorder(), 500);
 	}
 	

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -162,9 +162,9 @@ function init_combat_tracker(){
 				}
 			});
 		});
-		ct_reorder();
-
-		setTimeout(ct_persist,1000); // quick hack to save and resync only one time
+		
+		setTimeout(ct_reorder,500); // quick hack to save and resync only one time
+		setTimeout(ct_update_popout,600);
 
 		ct_update_popout();
 		$("#combat_area tr").first().attr('data-current','1');

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -421,11 +421,22 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		var buttons=$("<td/>");
 		
 		
-		find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg></button>');
+		if(token.options.id in window.TOKEN_OBJECTS){
+			find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg></button>');
+		}
+		else {
+			find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG addCTSVG" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" class=""><path fill-rule="evenodd" clip-rule="evenodd" d="M7.2 10.8V18h3.6v-7.2H18V7.2h-7.2V0H7.2v7.2H0v3.6h7.2z"></path></svg></button>');
+		}
 		find.click(function(){
 			var target=$(this).parent().parent().attr('data-target');
 			if(target in window.TOKEN_OBJECTS){
-				window.TOKEN_OBJECTS[target].highlight();
+				window.TOKEN_OBJECTS[target].highlight();	     
+			}
+			else if(target in window.all_token_objects){
+				place_token_in_center_of_view(window.all_token_objects[target].options);
+			  	$(this).find('.findSVG').remove();
+	           	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
+	            $(this).append(findSVG);
 			}
 		});
 		

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -398,7 +398,11 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				var selector = "div[data-id='" + token.options.id + "']";
 				var old = $("#tokens").find(selector);
 				old.find(".hp").val(hp_input.val().trim());
-				token.update_and_sync(e);
+				if(window.all_token_objects[token.options.id] != undefined){
+					window.all_token_objects[token.options.id].options.hp = hp_input.val();
+				}
+				window.all_token_objects[token.options.id].update_and_sync(e);
+				ct_persist();
 			});
 			hp_input.click(function(e) {
 				$(e.target).select();
@@ -407,7 +411,11 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				var selector = "div[data-id='" + token.options.id + "']";
 				var old = $("#tokens").find(selector);
 				old.find(".max_hp").val(maxhp_input.val().trim());
-				token.update_and_sync(e);
+				if(window.all_token_objects[token.options.id] != undefined){
+					window.all_token_objects[token.options.id].options.hp = hp_input.val();
+				}
+				window.all_token_objects[token.options.id].update_and_sync(e);
+				ct_persist();
 			});
 			maxhp_input.click(function(e) {
 				$(e.target).select();

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -509,9 +509,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			}
 			else if(target in window.all_token_objects){
 				place_token_in_center_of_view(window.all_token_objects[target].options);
-			  	$(this).find('.findSVG').remove();
+			  	$(`#combat_area tr[data-target='${target}'] .findSVG`).remove();
 	           	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
-	            $(this).append(findSVG);
+	            $(`#combat_area tr[data-target='${target}'] .findTokenCombatButton`).append(findSVG);
+	            ct_update_popout();
 			}
 		});
 		

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -315,299 +315,305 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	if (typeof(token.options.ct_show) == 'undefined'){
 		if(token.options.hidden) {
 			token.options.ct_show = false;
-		}
-		else {
-			token.options.ct_show = true;
-		}	
-	}
-
-	if (token.options.ct_show == true){
-		if ((token.options.name) && (window.DM || token.isPlayer() || token.options.revealname)) {
-			entry.attr("data-name", token.options.name);
-			entry.addClass("hasTooltip");
-		}
-
-		if(token.options.monster > 0)
-			entry.attr('data-monster',token.options.monster);
-		
-		img=$("<img width=35 height=35 class='Avatar_AvatarPortrait__2dP8u'>");
-		img.attr('src',token.options.imgsrc);
-		img.css('border','3px solid '+token.options.color);
-		if (token.options.hidden == true){
-			img.css('opacity','0.5');
-		}
-		entry.append($("<td/>").append(img));
-		let init=$("<input class='init' maxlength=2 style='font-size:12px;'>");
-		init.css('width','20px');
-		init.css('-webkit-appearance','none');
-		if(window.DM && typeof(token.options.init) == 'undefined'){
 			if(typeof window.all_token_objects != 'undefined') {
-				if(typeof window.all_token_objects[token.options.id] != 'undefined')	{
-					if (typeof window.all_token_objects[token.options.id].options.init != 'undefined'){
-				 		token.options.init = window.all_token_objects[token.options.id].options.init;
-				 		window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
-						init.val(token.options.init);
-					}
-				}
+				window.all_token_objects[token.options.id].options.ct_show = false;
+			}
+		}
+		else {		
+			if(typeof window.all_token_objects[token.options.id].options.ct_show != 'undefined') {
+				token.options.ct_show = window.all_token_objects[token.options.id].options.ct_show;
 			}
 			else{
-				init.val(0);
-			}
-		}
-		else if(window.DM){
-			init.val(token.options.init);
-		}
-		else{
-			init.val(token.options.init);
-			init.attr("disabled","disabled");
-		}
-		if(window.DM){
-			init.change(function(){
-					if(typeof window.all_token_objects != 'undefined') 
-					{
-						window.all_token_objects[token.options.id].options.init = init.val()
-						window.all_token_objects[token.options.id].sync = function(e) {				
-							window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[token.options.id].options);
-						};
-						window.all_token_objects[token.options.id].update_and_sync()
-					}
-					token.options.init = init.val();
-					if(window.TOKEN_OBJECTS[token.options.id] != undefined){
-						window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
-						window.TOKEN_OBJECTS[token.options.id].update_and_sync()
-					}
-					setTimeout(ct_reorder(), 500);
-				}
-			);
-		}
-		entry.append($("<td/>").append(init));
-		
-		// auto roll initiative for monsters
-		
-		if(window.DM && (token.options.monster > 0) && (!disablerolling) && token.options.init == undefined){
-			window.StatHandler.rollInit(token.options.monster,function(value){
-					init.val(value);
-					token.options.init = value;
-					if(window.TOKEN_OBJECTS[token.options.id] != undefined){			
-						window.TOKEN_OBJECTS[token.options.id].update_and_sync()
-					}
-					if(window.all_token_objects[token.options.id] != undefined){				
-						window.all_token_objects[token.options.id].update_and_sync()
-					}
-					setTimeout(ct_reorder(), 500);
-				});
-		}
-		
-		
-		
-			
-		hp=$("<div class='hp'/>");
-		var hp_input = $("<input class='hp'>");
-		if(token.isPlayer()){
-			hp_input.prop("disabled", true);
-		}
-		hp_input.val(token.options.hp);
-		hp.append(hp_input);
-		if(hp_input.val() === '0'){
-			entry.toggleClass("ct_dead", true);
-		}
-		else{
-			entry.toggleClass("ct_dead", false);
-		}
-		hp.css('font-size','11px');
-		//hp.css('width','20px');	
-			
-		var divider = $("<div style='display:inline-block;float:left'>/</>");
-			
-		max_hp=$("<div class='max_hp'/>");
-		var maxhp_input = $("<input class='max_hp'>");
-		if(token.isPlayer()){
-			maxhp_input.prop("disabled", true);
-		}
-		maxhp_input.val(token.options.max_hp);
-		max_hp.append(maxhp_input);
-		max_hp.css('font-size','11px');
-		//max_hp.css('width','20px');
-
-		if((token.options.hidestat == true && !window.DM && token.options.name != window.PLAYER_NAME) || token.options.disablestat || (!(token.options.id.startsWith("/profile")) && !window.DM && !token.options.player_owned)) {
-			divider.css('visibility', 'hidden');
-			hp.css('visibility', 'hidden');
-			max_hp.css('visibility', 'hidden');
-		}
-
-		entry.append($("<td/>").append(hp));
-		entry.append($("<td/>").append(divider));
-		entry.append($("<td/>").append(max_hp));
-
-		// bind update functions to hp inputs, same as Token.js
-		// token update logic for hp pulls hp from token hpbar, so update hp bar manually
-		if (!token.isPlayer()) {
-			hp_input.change(function(e) {
-				var selector = "div[data-id='" + token.options.id + "']";
-				var old = $("#tokens").find(selector);
-			
-				if (hp_input.val().trim().startsWith("+") || hp_input.val().trim().startsWith("-")) {
-					hp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(hp_input.val())));
-				}
-
-				old.find(".hp").val(hp_input.val().trim());	
-
-				if(window.all_token_objects[token.options.id] != undefined){
-					window.all_token_objects[token.options.id].options.hp = hp_input.val();
-					window.all_token_objects[token.options.id].update_and_sync();
-				}			
-				if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
-					window.TOKEN_OBJECTS[token.options.id].options.hp = hp_input.val();	
-					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
-				}			
-				setTimeout(ct_persist(), 500);
-			});
-			hp_input.click(function(e) {
-				$(e.target).select();
-			});
-			maxhp_input.change(function(e) {
-				var selector = "div[data-id='" + token.options.id + "']";
-				var old = $("#tokens").find(selector);
-
-				if (maxhp_input.val().trim().startsWith("+") || maxhp_input.val().trim().startsWith("-")) {
-					maxhp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(maxhp_input.val())));
-				}
-
-				old.find(".max_hp").val(maxhp_input.val().trim());
-				if(window.all_token_objects[token.options.id] != undefined){
-					window.all_token_objects[token.options.id].options.max_hp = maxhp_input.val();
-					window.all_token_objects[token.options.id].update_and_sync();
-				}
-				if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
-					window.TOKEN_OBJECTS[token.options.id].options.max_hp = maxhp_input.val();	
-					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
-				}			
-				setTimeout(ct_persist(), 500);
-			});
-			maxhp_input.click(function(e) {
-				$(e.target).select();
-			});
-		}
-		else {
-			hp_input.keydown(function(e) { if (e.keyCode == '13') token.update_from_page(); e.preventDefault(); }); // DISABLE WITHOUT MAKING IT LOOK UGLY
-			maxhp_input.keydown(function(e) { if (e.keyCode == '13') token.update_from_page(); e.preventDefault(); });
-		}
-		
-		var buttons=$("<td/>");
-		
-		
-		if(token.options.id in window.TOKEN_OBJECTS || !window.DM){
-			find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg></button>');
-		}
-		else {
-			find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG addCTSVG" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" class=""><path fill-rule="evenodd" clip-rule="evenodd" d="M7.2 10.8V18h3.6v-7.2H18V7.2h-7.2V0H7.2v7.2H0v3.6h7.2z"></path></svg></button>');
-		}
-		find.click(function(){
-			var target=$(this).parent().parent().attr('data-target');
-			if(target in window.TOKEN_OBJECTS){
-				window.TOKEN_OBJECTS[target].highlight();	     
-			}
-			else if(target in window.all_token_objects){
-				place_token_in_center_of_view(window.all_token_objects[target].options);
-			  	$(`#combat_area tr[data-target='${target}'] .findSVG`).remove();
-	           	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
-	            $(`#combat_area tr[data-target='${target}'] .findTokenCombatButton`).append(findSVG);
-	            ct_update_popout();
-			}
-		});
-		
-		
-		buttons.append(find);
-		
-		del=$('<button class="removeTokenCombatButton" style="font-size:10px;"><svg class="delSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg></button>');
-		del.click(
-			function(){
-				if(window.TOKEN_OBJECTS[token.options.id] != undefined){
-					window.TOKEN_OBJECTS[token.options.id].options.ct_show = undefined;
-					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
-				}
-				if(window.all_token_objects[token.options.id] != undefined){
-					window.all_token_objects[token.options.id].options.ct_show = undefined;
-					window.all_token_objects[token.options.id].update_and_sync()
-				}
-
-				ct_remove_token(token);
-			}
-		);
-		if(window.DM)
-			buttons.append(del);
-		
-		if(token.isMonster()){
-			stat=$('<button class="openSheetCombatButton" style="font-size:10px;"><svg class="statSVG" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/><g><path d="M19,5v14H5V5H19 M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3L19,3z"/></g><path d="M14,17H7v-2h7V17z M17,13H7v-2h10V13z M17,9H7V7h10V9z"/></g></svg></button>');
-			
-			stat.click(function(){
-				load_monster_stat(token.options.monster, token.options.id);
-			});
-			if(window.DM){
-				buttons.append(stat);
-
-				ct_show_checkbox = $(`<input id="`+token.options.id+`hideCombatTrackerInput"type='checkbox' class="combatHideFromPlayerInput" style="font-size:10px; class='hideInPlayerCombatCheck' title="Show in player's Combat Tracker?" target_id='`+token.options.id+`' checked='`+token.options.ct_show+`'/>`);
-				//ct_show_checkbox.tooltip({ show: { effect: "blind", duration: 600 } });//Make this tooltip show a little quicker
-				eye_button = $('<button class="hideFromPlayerCombatButton" style="font-size:10px;"></button>');
-				open_eye = $('<svg xmlns="http://www.w3.org/2000/svg" class="openEye" height="24" width="24" viewBox="0 0 24 24"><path xmlns="http://www.w3.org/2000/svg" d="M12 16Q13.875 16 15.188 14.688Q16.5 13.375 16.5 11.5Q16.5 9.625 15.188 8.312Q13.875 7 12 7Q10.125 7 8.812 8.312Q7.5 9.625 7.5 11.5Q7.5 13.375 8.812 14.688Q10.125 16 12 16ZM12 14.2Q10.875 14.2 10.088 13.412Q9.3 12.625 9.3 11.5Q9.3 10.375 10.088 9.587Q10.875 8.8 12 8.8Q13.125 8.8 13.913 9.587Q14.7 10.375 14.7 11.5Q14.7 12.625 13.913 13.412Q13.125 14.2 12 14.2ZM12 19Q8.35 19 5.35 16.962Q2.35 14.925 1 11.5Q2.35 8.075 5.35 6.037Q8.35 4 12 4Q15.65 4 18.65 6.037Q21.65 8.075 23 11.5Q21.65 14.925 18.65 16.962Q15.65 19 12 19ZM12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5ZM12 17Q14.825 17 17.188 15.512Q19.55 14.025 20.8 11.5Q19.55 8.975 17.188 7.487Q14.825 6 12 6Q9.175 6 6.812 7.487Q4.45 8.975 3.2 11.5Q4.45 14.025 6.812 15.512Q9.175 17 12 17Z"/></svg>');
-				closed_eye = $('<svg class="closedEye" xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24"><path xmlns="http://www.w3.org/2000/svg" d="M16.1 13.3 14.65 11.85Q14.875 10.675 13.975 9.65Q13.075 8.625 11.65 8.85L10.2 7.4Q10.625 7.2 11.062 7.1Q11.5 7 12 7Q13.875 7 15.188 8.312Q16.5 9.625 16.5 11.5Q16.5 12 16.4 12.438Q16.3 12.875 16.1 13.3ZM19.3 16.45 17.85 15.05Q18.8 14.325 19.538 13.462Q20.275 12.6 20.8 11.5Q19.55 8.975 17.212 7.487Q14.875 6 12 6Q11.275 6 10.575 6.1Q9.875 6.2 9.2 6.4L7.65 4.85Q8.675 4.425 9.75 4.212Q10.825 4 12 4Q15.775 4 18.725 6.087Q21.675 8.175 23 11.5Q22.425 12.975 21.488 14.238Q20.55 15.5 19.3 16.45ZM19.8 22.6 15.6 18.45Q14.725 18.725 13.838 18.863Q12.95 19 12 19Q8.225 19 5.275 16.913Q2.325 14.825 1 11.5Q1.525 10.175 2.325 9.037Q3.125 7.9 4.15 7L1.4 4.2L2.8 2.8L21.2 21.2ZM5.55 8.4Q4.825 9.05 4.225 9.825Q3.625 10.6 3.2 11.5Q4.45 14.025 6.787 15.512Q9.125 17 12 17Q12.5 17 12.975 16.938Q13.45 16.875 13.95 16.8L13.05 15.85Q12.775 15.925 12.525 15.962Q12.275 16 12 16Q10.125 16 8.812 14.688Q7.5 13.375 7.5 11.5Q7.5 11.225 7.537 10.975Q7.575 10.725 7.65 10.45ZM13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725ZM9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Z"/></svg>');
-				eye_button.click(function(){
-					$("#"+token.options.id+"hideCombatTrackerInput").click();
-				});
-				if(token.options.ct_show==true) {
-					open_eye.css('display', 'block');
-					closed_eye.css('display', 'none');
-				}
-				else {
-					closed_eye.css('display', 'block');
-					open_eye.css('display', 'none');
-				}
-				$(ct_show_checkbox).change(function() {
-					if($(this).is(':checked')) {
-						token.options.ct_show = true;
-						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.openEye").css('display', 'block');
-						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.closedEye").css('display', 'none');
-					}
-					else{
-						token.options.ct_show = false;
-						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.closedEye").css('display', 'block');
-						$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.openEye").css('display', 'none');
-					}
-
-					if(token.options.id in window.TOKEN_OBJECTS) token.update_and_sync();		
-					ct_update_popout();
-					ct_persist();
-				});
-				eye_button.append(open_eye);
-				eye_button.append(closed_eye);
-				buttons.prepend(eye_button);
-				buttons.prepend(ct_show_checkbox);
+				token.options.ct_show = true;
 			}
 		}	
-		else if (token.isPlayer()) {
-			stat=$('<button class="openSheetCombatButton" style="font-size:10px;"><svg class="statSVG" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/><g><path d="M19,5v14H5V5H19 M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3L19,3z"/></g><path d="M14,17H7v-2h7V17z M17,13H7v-2h10V13z M17,9H7V7h10V9z"/></g></svg></button>');
-			stat.click(function(){
-				open_player_sheet(token.options.id);
-			});
-			if(window.DM)
-				buttons.append(stat);
-		}
-		
-			entry.append(buttons);
-		
-		
-		$("#combat_area").append(entry);
-		$("#combat_area td").css("vertical-align","middle");
-    
-	  ct_update_popout();
-    
-		if(window.DM){
-			setTimeout(ct_reorder(), 500);
+	}
 
+
+	if ((token.options.name) && (window.DM || token.isPlayer() || token.options.revealname)) {
+		entry.attr("data-name", token.options.name);
+		entry.addClass("hasTooltip");
+	}
+
+	if(token.options.monster > 0)
+		entry.attr('data-monster',token.options.monster);
 	
-
+	img=$("<img width=35 height=35 class='Avatar_AvatarPortrait__2dP8u'>");
+	img.attr('src',token.options.imgsrc);
+	img.css('border','3px solid '+token.options.color);
+	if (token.options.hidden == true){
+		img.css('opacity','0.5');
+	}
+	entry.append($("<td/>").append(img));
+	let init=$("<input class='init' maxlength=2 style='font-size:12px;'>");
+	init.css('width','20px');
+	init.css('-webkit-appearance','none');
+	if(window.DM && typeof(token.options.init) == 'undefined'){
+		if(typeof window.all_token_objects != 'undefined') {
+			if(typeof window.all_token_objects[token.options.id] != 'undefined')	{
+				if (typeof window.all_token_objects[token.options.id].options.init != 'undefined'){
+			 		token.options.init = window.all_token_objects[token.options.id].options.init;
+			 		window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
+					init.val(token.options.init);
+				}
+			}
+		}
+		else{
+			init.val(0);
 		}
 	}
+	else if(window.DM){
+		init.val(token.options.init);
+	}
+	else{
+		init.val(token.options.init);
+		init.attr("disabled","disabled");
+	}
+	if(window.DM){
+		init.change(function(){
+				if(typeof window.all_token_objects != 'undefined') 
+				{
+					window.all_token_objects[token.options.id].options.init = init.val()
+					window.all_token_objects[token.options.id].sync = function(e) {				
+						window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[token.options.id].options);
+					};
+					window.all_token_objects[token.options.id].update_and_sync()
+				}
+				token.options.init = init.val();
+				if(window.TOKEN_OBJECTS[token.options.id] != undefined){
+					window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
+					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+				}
+				setTimeout(ct_reorder(), 500);
+			}
+		);
+	}
+	entry.append($("<td/>").append(init));
+	
+	// auto roll initiative for monsters
+	
+	if(window.DM && (token.options.monster > 0) && (!disablerolling) && token.options.init == undefined){
+		window.StatHandler.rollInit(token.options.monster,function(value){
+				init.val(value);
+				token.options.init = value;
+				if(window.TOKEN_OBJECTS[token.options.id] != undefined){			
+					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+				}
+				if(window.all_token_objects[token.options.id] != undefined){				
+					window.all_token_objects[token.options.id].update_and_sync()
+				}
+				setTimeout(ct_reorder(), 500);
+			});
+	}
+	
+	
+	
+		
+	hp=$("<div class='hp'/>");
+	var hp_input = $("<input class='hp'>");
+	if(token.isPlayer()){
+		hp_input.prop("disabled", true);
+	}
+	hp_input.val(token.options.hp);
+	hp.append(hp_input);
+	if(hp_input.val() === '0'){
+		entry.toggleClass("ct_dead", true);
+	}
+	else{
+		entry.toggleClass("ct_dead", false);
+	}
+	hp.css('font-size','11px');
+	//hp.css('width','20px');	
+		
+	var divider = $("<div style='display:inline-block;float:left'>/</>");
+		
+	max_hp=$("<div class='max_hp'/>");
+	var maxhp_input = $("<input class='max_hp'>");
+	if(token.isPlayer()){
+		maxhp_input.prop("disabled", true);
+	}
+	maxhp_input.val(token.options.max_hp);
+	max_hp.append(maxhp_input);
+	max_hp.css('font-size','11px');
+	//max_hp.css('width','20px');
+
+	if((token.options.hidestat == true && !window.DM && token.options.name != window.PLAYER_NAME) || token.options.disablestat || (!(token.options.id.startsWith("/profile")) && !window.DM && !token.options.player_owned)) {
+		divider.css('visibility', 'hidden');
+		hp.css('visibility', 'hidden');
+		max_hp.css('visibility', 'hidden');
+	}
+
+	entry.append($("<td/>").append(hp));
+	entry.append($("<td/>").append(divider));
+	entry.append($("<td/>").append(max_hp));
+
+	// bind update functions to hp inputs, same as Token.js
+	// token update logic for hp pulls hp from token hpbar, so update hp bar manually
+	if (!token.isPlayer()) {
+		hp_input.change(function(e) {
+			var selector = "div[data-id='" + token.options.id + "']";
+			var old = $("#tokens").find(selector);
+		
+			if (hp_input.val().trim().startsWith("+") || hp_input.val().trim().startsWith("-")) {
+				hp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(hp_input.val())));
+			}
+
+			old.find(".hp").val(hp_input.val().trim());	
+
+			if(window.all_token_objects[token.options.id] != undefined){
+				window.all_token_objects[token.options.id].options.hp = hp_input.val();
+				window.all_token_objects[token.options.id].update_and_sync();
+			}			
+			if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
+				window.TOKEN_OBJECTS[token.options.id].options.hp = hp_input.val();	
+				window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+			}			
+			setTimeout(ct_persist(), 500);
+		});
+		hp_input.click(function(e) {
+			$(e.target).select();
+		});
+		maxhp_input.change(function(e) {
+			var selector = "div[data-id='" + token.options.id + "']";
+			var old = $("#tokens").find(selector);
+
+			if (maxhp_input.val().trim().startsWith("+") || maxhp_input.val().trim().startsWith("-")) {
+				maxhp_input.val(Math.max(0, parseInt(token.options.hp) + parseInt(maxhp_input.val())));
+			}
+
+			old.find(".max_hp").val(maxhp_input.val().trim());
+			if(window.all_token_objects[token.options.id] != undefined){
+				window.all_token_objects[token.options.id].options.max_hp = maxhp_input.val();
+				window.all_token_objects[token.options.id].update_and_sync();
+			}
+			if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
+				window.TOKEN_OBJECTS[token.options.id].options.max_hp = maxhp_input.val();	
+				window.TOKEN_OBJECTS[token.options.id].update_and_sync()
+			}			
+			setTimeout(ct_persist(), 500);
+		});
+		maxhp_input.click(function(e) {
+			$(e.target).select();
+		});
+	}
+	else {
+		hp_input.keydown(function(e) { if (e.keyCode == '13') token.update_from_page(); e.preventDefault(); }); // DISABLE WITHOUT MAKING IT LOOK UGLY
+		maxhp_input.keydown(function(e) { if (e.keyCode == '13') token.update_from_page(); e.preventDefault(); });
+	}
+	
+	var buttons=$("<td/>");
+	
+	
+	if(token.options.id in window.TOKEN_OBJECTS || !window.DM){
+		find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg></button>');
+	}
+	else {
+		find=$('<button class="findTokenCombatButton" style="font-size:10px;"><svg class="findSVG addCTSVG" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" class=""><path fill-rule="evenodd" clip-rule="evenodd" d="M7.2 10.8V18h3.6v-7.2H18V7.2h-7.2V0H7.2v7.2H0v3.6h7.2z"></path></svg></button>');
+	}
+	find.click(function(){
+		var target=$(this).parent().parent().attr('data-target');
+		if(target in window.TOKEN_OBJECTS){
+			window.TOKEN_OBJECTS[target].highlight();	     
+		}
+		else if(target in window.all_token_objects){
+			place_token_in_center_of_view(window.all_token_objects[target].options);
+		  	$(`#combat_area tr[data-target='${target}'] .findSVG`).remove();
+           	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
+            $(`#combat_area tr[data-target='${target}'] .findTokenCombatButton`).append(findSVG);
+            ct_update_popout();
+		}
+	});
+	
+	
+	buttons.append(find);
+	
+	del=$('<button class="removeTokenCombatButton" style="font-size:10px;"><svg class="delSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z"/></svg></button>');
+	del.click(
+		function(){
+			if(window.TOKEN_OBJECTS[token.options.id] != undefined){
+				window.TOKEN_OBJECTS[token.options.id].options.ct_show = undefined;
+				window.TOKEN_OBJECTS[token.options.id].update_and_sync();
+			}
+			if(window.all_token_objects[token.options.id] != undefined){
+				window.all_token_objects[token.options.id].options.ct_show = undefined;
+				window.all_token_objects[token.options.id].update_and_sync();
+			}
+
+			ct_remove_token(token);
+		}
+	);
+	if(window.DM)
+		buttons.append(del);
+	
+	if(token.isMonster()){
+		stat=$('<button class="openSheetCombatButton" style="font-size:10px;"><svg class="statSVG" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/><g><path d="M19,5v14H5V5H19 M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3L19,3z"/></g><path d="M14,17H7v-2h7V17z M17,13H7v-2h10V13z M17,9H7V7h10V9z"/></g></svg></button>');
+		
+		stat.click(function(){
+			load_monster_stat(token.options.monster, token.options.id);
+		});
+		if(window.DM){
+			buttons.append(stat);
+
+			ct_show_checkbox = $(`<input id="`+token.options.id+`hideCombatTrackerInput"type='checkbox' class="combatHideFromPlayerInput" style="font-size:10px; class='hideInPlayerCombatCheck' title="Show in player's Combat Tracker?" target_id='`+token.options.id+`' checked='`+token.options.ct_show+`'/>`);
+			//ct_show_checkbox.tooltip({ show: { effect: "blind", duration: 600 } });//Make this tooltip show a little quicker
+			eye_button = $('<button class="hideFromPlayerCombatButton" style="font-size:10px;"></button>');
+			open_eye = $('<svg xmlns="http://www.w3.org/2000/svg" class="openEye" height="24" width="24" viewBox="0 0 24 24"><path xmlns="http://www.w3.org/2000/svg" d="M12 16Q13.875 16 15.188 14.688Q16.5 13.375 16.5 11.5Q16.5 9.625 15.188 8.312Q13.875 7 12 7Q10.125 7 8.812 8.312Q7.5 9.625 7.5 11.5Q7.5 13.375 8.812 14.688Q10.125 16 12 16ZM12 14.2Q10.875 14.2 10.088 13.412Q9.3 12.625 9.3 11.5Q9.3 10.375 10.088 9.587Q10.875 8.8 12 8.8Q13.125 8.8 13.913 9.587Q14.7 10.375 14.7 11.5Q14.7 12.625 13.913 13.412Q13.125 14.2 12 14.2ZM12 19Q8.35 19 5.35 16.962Q2.35 14.925 1 11.5Q2.35 8.075 5.35 6.037Q8.35 4 12 4Q15.65 4 18.65 6.037Q21.65 8.075 23 11.5Q21.65 14.925 18.65 16.962Q15.65 19 12 19ZM12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5Q12 11.5 12 11.5ZM12 17Q14.825 17 17.188 15.512Q19.55 14.025 20.8 11.5Q19.55 8.975 17.188 7.487Q14.825 6 12 6Q9.175 6 6.812 7.487Q4.45 8.975 3.2 11.5Q4.45 14.025 6.812 15.512Q9.175 17 12 17Z"/></svg>');
+			closed_eye = $('<svg class="closedEye" xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24"><path xmlns="http://www.w3.org/2000/svg" d="M16.1 13.3 14.65 11.85Q14.875 10.675 13.975 9.65Q13.075 8.625 11.65 8.85L10.2 7.4Q10.625 7.2 11.062 7.1Q11.5 7 12 7Q13.875 7 15.188 8.312Q16.5 9.625 16.5 11.5Q16.5 12 16.4 12.438Q16.3 12.875 16.1 13.3ZM19.3 16.45 17.85 15.05Q18.8 14.325 19.538 13.462Q20.275 12.6 20.8 11.5Q19.55 8.975 17.212 7.487Q14.875 6 12 6Q11.275 6 10.575 6.1Q9.875 6.2 9.2 6.4L7.65 4.85Q8.675 4.425 9.75 4.212Q10.825 4 12 4Q15.775 4 18.725 6.087Q21.675 8.175 23 11.5Q22.425 12.975 21.488 14.238Q20.55 15.5 19.3 16.45ZM19.8 22.6 15.6 18.45Q14.725 18.725 13.838 18.863Q12.95 19 12 19Q8.225 19 5.275 16.913Q2.325 14.825 1 11.5Q1.525 10.175 2.325 9.037Q3.125 7.9 4.15 7L1.4 4.2L2.8 2.8L21.2 21.2ZM5.55 8.4Q4.825 9.05 4.225 9.825Q3.625 10.6 3.2 11.5Q4.45 14.025 6.787 15.512Q9.125 17 12 17Q12.5 17 12.975 16.938Q13.45 16.875 13.95 16.8L13.05 15.85Q12.775 15.925 12.525 15.962Q12.275 16 12 16Q10.125 16 8.812 14.688Q7.5 13.375 7.5 11.5Q7.5 11.225 7.537 10.975Q7.575 10.725 7.65 10.45ZM13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725Q13.525 10.725 13.525 10.725ZM9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Q9.75 12.6 9.75 12.6Z"/></svg>');
+			eye_button.click(function(){
+				$("#"+token.options.id+"hideCombatTrackerInput").click();
+			});
+			if(token.options.ct_show==true) {
+				open_eye.css('display', 'block');
+				closed_eye.css('display', 'none');
+			}
+			else {
+				closed_eye.css('display', 'block');
+				open_eye.css('display', 'none');
+				$(ct_show_checkbox).prop('checked', false);
+			}
+			$(ct_show_checkbox).change(function() {
+				if($(this).is(':checked')) {
+					token.options.ct_show = true;
+					$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.openEye").css('display', 'block');
+					$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.closedEye").css('display', 'none');
+				}
+				else{
+					token.options.ct_show = false;
+					$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.closedEye").css('display', 'block');
+					$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.openEye").css('display', 'none');
+				}
+
+				if(token.options.id in window.TOKEN_OBJECTS) token.update_and_sync();		
+				ct_update_popout();
+				ct_persist();
+			});
+			eye_button.append(open_eye);
+			eye_button.append(closed_eye);
+			buttons.prepend(eye_button);
+			buttons.prepend(ct_show_checkbox);
+		}
+	}	
+	else if (token.isPlayer()) {
+		stat=$('<button class="openSheetCombatButton" style="font-size:10px;"><svg class="statSVG" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/><g><path d="M19,5v14H5V5H19 M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3L19,3z"/></g><path d="M14,17H7v-2h7V17z M17,13H7v-2h10V13z M17,9H7V7h10V9z"/></g></svg></button>');
+		stat.click(function(){
+			open_player_sheet(token.options.id);
+		});
+		if(window.DM)
+			buttons.append(stat);
+	}
+	
+		entry.append(buttons);
+	
+	
+	$("#combat_area").append(entry);
+	$("#combat_area td").css("vertical-align","middle");
+
+  ct_update_popout();
+
+	if(window.DM){
+		setTimeout(ct_reorder(), 500);
+	}
+	
 }
 
 function ct_list_tokens() {
@@ -689,7 +695,7 @@ function ct_load(data=null){
 					window.all_token_objects[data[i]['data-target']] = new Token(data[i]['options']);
 				}
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
-				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true)
+				if(window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined)
 				{
 					window.all_token_objects[data[i]['data-target']].sync = function(e) {				
 						window.MB.sendMessage('custom/myVTT/token', this.options);
@@ -712,7 +718,7 @@ function ct_load(data=null){
 
 	if(data == null){
 		for(tokenID in window.all_token_objects){
-			if(window.all_token_objects[tokenID].options.ct_show == true)
+			if(window.all_token_objects[tokenID].options.ct_show !== undefined)
 			{
 				window.all_token_objects[tokenID].sync = function(e) {				
 					window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[tokenID].options);

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1171,9 +1171,7 @@ class MessageBroker {
 					 window.all_token_objects[data.id].options[property] = data[property]; 
 					}
 				}
-				if(data.ct_show == undefined){
-					window.all_token_objects[data.id].options["ct_show"] = undefined;
-				}
+
 
 				if (!data.hidden)
 					delete window.all_token_objects[data.id].options.hidden;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1165,7 +1165,7 @@ class MessageBroker {
 		if(window.all_token_objects != undefined){
 			if (data.id in window.all_token_objects) {
 				for (var property in data) {
-					window.all_token_objects[data.id].options[property] = data[property];
+					data[property] = window.all_token_objects[data.id].options[property];
 				}
 				if (!data.hidden)
 					delete window.all_token_objects[data.id].options.hidden;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -949,7 +949,7 @@ class MessageBroker {
 							if(converted==entityid){
 								ct_add_token(window.TOKEN_OBJECTS[$(this).attr('data-id')]);
 								window.TOKEN_OBJECTS[$(this).attr('data-id')].options.init = total;
-								window.TOKEN_OBJECTS[$(this).attr('data-id')].place_sync_persist();
+								window.TOKEN_OBJECTS[$(this).attr('data-id')].update_and_sync();
 							}
 						}
 					);
@@ -961,10 +961,10 @@ class MessageBroker {
 						if (converted == entityid) {
 							$(this).find(".init").val(total);
 							window.TOKEN_OBJECTS[$(this).attr('data-target')].options.init = total;
-							window.TOKEN_OBJECTS[$(this).attr('data-target')].place_sync_persist();
+							window.TOKEN_OBJECTS[$(this).attr('data-target')].update_and_sync();
 						}
 					});
-					ct_persist();
+					setTimeout(ct_reorder(), 500);
 				}
 				// CHECK FOR SELF ROLLS ADD SEND TO EVERYONE BUTTON
 				if (msg.messageScope === "userId") {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1305,9 +1305,9 @@ class MessageBroker {
 			}
 			console.log("LOADING TOKENS!");
 
-			for (var i = 0; i < data.tokens.length; i++) {
+			for (let id in data.tokens) {
 				self.handleToken({
-					data: data.tokens[i],
+					data: data.tokens[id],
 					loading: true
 				});
 			}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -949,6 +949,9 @@ class MessageBroker {
 							var converted = $(this).attr('data-id').replace(/^.*\/([0-9]*)$/, "$1"); // profiles/ciccio/1234 -> 1234
 							if(converted==entityid){
 								ct_add_token(window.TOKEN_OBJECTS[$(this).attr('data-id')]);
+								window.TOKEN_OBJECTS[$(this).attr('data-id')].options.init = total;
+								window.TOKEN_OBJECTS[$(this).attr('data-id')].place_sync_persist();
+								ct_reorder();
 							}
 						}
 					);
@@ -959,6 +962,8 @@ class MessageBroker {
 						console.log(converted);
 						if (converted == entityid) {
 							$(this).find(".init").val(total);
+							window.TOKEN_OBJECTS[$(this).attr('data-target')].options.init = total;
+							window.TOKEN_OBJECTS[$(this).attr('data-target')].place_sync_persist();
 							ct_reorder();
 						}
 					});

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1165,13 +1165,17 @@ class MessageBroker {
 		if(window.all_token_objects != undefined){
 			if (data.id in window.all_token_objects) {
 				for (var property in data) {		
-					if(msg.loading && (property == 'hp' || property == 'max_hp' || property == 'init' || property == 'ac')){
+					if(msg.loading && (property == 'hp' || property == 'max_hp' || property == 'init' || property == 'ac' || property == 'ct_show')){
 						data[property] = window.all_token_objects[data.id].options[property];
 					}
 					else{
 					 window.all_token_objects[data.id].options[property] = data[property]; 
 					}
 				}
+				if(data.ct_show == undefined){
+					window.all_token_objects[data.id].options["ct_show"] = undefined;
+				}
+
 				if (!data.hidden)
 					delete window.all_token_objects[data.id].options.hidden;
 
@@ -1185,6 +1189,9 @@ class MessageBroker {
 			console.log(data.name);
 			for (var property in data) {
 				window.TOKEN_OBJECTS[data.id].options[property] = data[property];
+			}
+			if(data.ct_show == undefined){
+				window.TOKEN_OBJECTS[data.id].options["ct_show"] = undefined;
 			}
 			if (!data.hidden)
 				delete window.TOKEN_OBJECTS[data.id].options.hidden;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1157,8 +1157,7 @@ class MessageBroker {
 
 	handleToken(msg) {
 		var data = msg.data;
-		//let t=new Token($.parseJSON(msg.data));
-		let inAllTokenObjects
+
 		if(data.id == undefined)
 			return;
 
@@ -1178,8 +1177,6 @@ class MessageBroker {
 
 				if (!data.hidden)
 					delete window.all_token_objects[data.id].options.hidden;
-
-				inAllTokenObjects = true;
 			}
 		}
 		

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1255,6 +1255,13 @@ class MessageBroker {
 			}
 		}
 
+		for(i in msg.data.tokens){
+			if(i == msg.data.tokens[i].id)
+				continue;
+			msg.data.tokens[msg.data.tokens[i].id] = msg.data.tokens[i];
+			delete msg.data.tokens[i];
+		}
+		msg.data.tokens = Object.fromEntries(Object.entries(msg.data.tokens).filter(([_, v]) => v != null));
 		window.CURRENT_SCENE_DATA = msg.data;
 		if(window.CLOUD && window.DM){
 			window.ScenesHandler.scene=window.CURRENT_SCENE_DATA;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1217,10 +1217,10 @@ class MessageBroker {
 		window.ScenesHandler.persist();
 	}
 	
-	if(window.DM) {
+	if(window.DM && msg.persist != false && msg.data.ct_show != undefined) {
 		ct_reorder();
 	}
-	else{
+	else if(msg.data.ct_show != undefined){
 		ct_reorder(false);
 	}
 	
@@ -1315,7 +1315,8 @@ class MessageBroker {
 			for (let id in data.tokens) {
 				self.handleToken({
 					data: data.tokens[id],
-					loading: true
+					loading: true,
+					persist: false
 				});
 			}
 			if(!window.DM)

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1218,11 +1218,11 @@ class MessageBroker {
 		}
 
 
-		if (window.DM) {
-			console.log("**** persistoooooooooo token");
-			window.ScenesHandler.persist();
-		}
+	if (window.DM) {
+		console.log("**** persistoooooooooo token");
+		window.ScenesHandler.persist();
 	}
+	
 	if(window.DM) {
 		ct_reorder();
 	}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1164,7 +1164,7 @@ class MessageBroker {
 		if(window.all_token_objects != undefined){
 			if (data.id in window.all_token_objects) {
 				for (var property in data) {		
-					if(msg.loading && (property == 'hp' || property == 'max_hp' || property == 'init' || property == 'ac' || property == 'ct_show')){
+					if(msg.loading && property != "left" && property != "top"){
 						data[property] = window.all_token_objects[data.id].options[property];
 					}
 					else{

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1193,13 +1193,17 @@ class MessageBroker {
 			if (window.DM) {
 				console.log("ATTENZIONEEEEEEEEEEEEEEEEEEE ATTENZIONEEEEEEEEEEEEEEEEEEE");
 			}
-
+			if (data.left == undefined){
+				data.left = "0px";
+				data.top = "0px";
+			}
 			let t = new Token(data);
 			window.TOKEN_OBJECTS[data.id] = t;
 			t.sync = function(e) { // VA IN FUNZIONE SOLO SE IL TOKEN NON ESISTE GIA					
 				window.MB.sendMessage('custom/myVTT/token', t.options);
 			};
 			t.place();
+	
 			check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 
 		if (window.DM) {
@@ -1310,7 +1314,9 @@ class MessageBroker {
 
 			if(window.DM)
 				get_pclist_player_data();
-
+			else{
+			 	window.MB.sendMessage('custom/myVTT/syncmeup');
+			}
 
 
 			if (window.EncounterHandler !== undefined) {
@@ -1356,7 +1362,7 @@ class MessageBroker {
 	handleSyncMeUp(msg) {
 		if (DM) {
 			window.ScenesHandler.sync();
-	
+			ct_persist(); // force refresh of combat tracker for late users
 			if (window.CURRENT_SOUNDPAD) {
 				var data = {
 					soundpad: window.CURRENT_SOUNDPAD

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1164,13 +1164,18 @@ class MessageBroker {
 
 		if(window.all_token_objects != undefined){
 			if (data.id in window.all_token_objects) {
-				for (var property in data) {
-					data[property] = window.all_token_objects[data.id].options[property];
+				for (var property in data) {		
+					if(msg.loading && (property == 'hp' || property == 'max_hp' || property == 'init' || property == 'ac')){
+						data[property] = window.all_token_objects[data.id].options[property];
+					}
+					else{
+					 window.all_token_objects[data.id].options[property] = data[property]; 
+					}
 				}
 				if (!data.hidden)
 					delete window.all_token_objects[data.id].options.hidden;
 
-					inAllTokenObjects = true;
+				inAllTokenObjects = true;
 			}
 		}
 		
@@ -1301,7 +1306,8 @@ class MessageBroker {
 
 			for (var i = 0; i < data.tokens.length; i++) {
 				self.handleToken({
-					data: data.tokens[i]
+					data: data.tokens[i],
+					loading: true
 				});
 			}
 			if(!window.DM)

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -398,8 +398,7 @@ class MessageBroker {
 
 			if(window.CLOUD && msg.sceneId){ // WE NEED TO IGNORE CERTAIN MESSAGE IF THEY'RE NOT FROM THE CURRENT SCENE
 				if(msg.sceneId!=window.CURRENT_SCENE_DATA.id){
-					if(["custom/myVTT/token",
-						"custom/myVTT/delete_token",
+					if(["custom/myVTT/delete_token",
 						"custom/myVTT/createtoken",
 						"custom/myVTT/reveal",
 						"custom/myVTT/fogdata",
@@ -414,14 +413,15 @@ class MessageBroker {
 				}
 			}
 
-			if (msg.eventType == "custom/myVTT/token") {
+			if (msg.eventType == "custom/myVTT/token" && (msg.sceneId == window.CURRENT_SCENE_DATA.id || msg.data.id in window.TOKEN_OBJECTS)) {
 				self.handleToken(msg);
 			}
 			if(msg.eventType=="custom/myVTT/delete_token"){
 				let tokenid=msg.data.id;
-				if(tokenid in window.TOKEN_OBJECTS)
+				if(tokenid in window.TOKEN_OBJECTS){
 					window.TOKEN_OBJECTS[tokenid].options.deleteableByPlayers = true;
 					window.TOKEN_OBJECTS[tokenid].delete(false,false);
+				}
 			}
 			if(msg.eventType == "custom/myVTT/createtoken"){
 				if(window.DM){
@@ -1179,10 +1179,11 @@ class MessageBroker {
 					delete window.all_token_objects[data.id].options.hidden;
 			}
 		}
-		
-		
+			
 		if (data.id in window.TOKEN_OBJECTS) {
 			for (var property in data) {
+				if(msg.sceneId != window.CURRENT_SCENE_DATA.id && (property == "left" || property == "top"))
+					continue;				
 				window.TOKEN_OBJECTS[data.id].options[property] = data[property];
 			}
 			if(data.ct_show == undefined){
@@ -1193,9 +1194,8 @@ class MessageBroker {
 
 			window.TOKEN_OBJECTS[data.id].place();
 			check_single_token_visibility(data.id); // CHECK FOG OF WAR VISIBILITY OF TOKEN
-
-		}
-		else{
+		}	
+		else if(data.left){
 			// SOLO PLAYER. PUNTO UNICO DI CREAZIONE DEI TOKEN
 			
 			if (window.DM) {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -398,7 +398,8 @@ class MessageBroker {
 
 			if(window.CLOUD && msg.sceneId){ // WE NEED TO IGNORE CERTAIN MESSAGE IF THEY'RE NOT FROM THE CURRENT SCENE
 				if(msg.sceneId!=window.CURRENT_SCENE_DATA.id){
-					if(["custom/myVTT/delete_token",
+					if(["custom/myVTT/token",
+						"custom/myVTT/delete_token",
 						"custom/myVTT/createtoken",
 						"custom/myVTT/reveal",
 						"custom/myVTT/fogdata",

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1182,8 +1182,6 @@ class MessageBroker {
 		
 		
 		if (data.id in window.TOKEN_OBJECTS) {
-			console.log(data.init);
-			console.log(data.name);
 			for (var property in data) {
 				window.TOKEN_OBJECTS[data.id].options[property] = data[property];
 			}
@@ -1197,15 +1195,11 @@ class MessageBroker {
 			check_single_token_visibility(data.id); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 
 		}
-		else{
+		else if (data.left !== undefined){
 			// SOLO PLAYER. PUNTO UNICO DI CREAZIONE DEI TOKEN
 			
 			if (window.DM) {
 				console.log("ATTENZIONEEEEEEEEEEEEEEEEEEE ATTENZIONEEEEEEEEEEEEEEEEEEE");
-			}
-			if (data.left == undefined){
-				data.left = "0px";
-				data.top = "0px";
 			}
 			let t = new Token(data);
 			window.TOKEN_OBJECTS[data.id] = t;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1195,7 +1195,7 @@ class MessageBroker {
 			check_single_token_visibility(data.id); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 
 		}
-		else if (data.left !== undefined){
+		else{
 			// SOLO PLAYER. PUNTO UNICO DI CREAZIONE DEI TOKEN
 			
 			if (window.DM) {
@@ -1216,14 +1216,6 @@ class MessageBroker {
 		console.log("**** persistoooooooooo token");
 		window.ScenesHandler.persist();
 	}
-	
-	if(window.DM && msg.persist != false && msg.data.ct_show != undefined) {
-		ct_reorder();
-	}
-	else if(msg.data.ct_show != undefined){
-		ct_reorder(false);
-	}
-	
 }
 
 	handleScene(msg) {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1001,8 +1001,8 @@ class MessageBroker {
 		}, 4000), 15000);
 	}
 
-    	handleCT(data){
-		$("#combat_area").empty();
+  handleCT(data){
+  	$("#combat_area").empty();
 		ct_load(data);
 	}
 
@@ -1156,7 +1156,8 @@ class MessageBroker {
 		var data = msg.data;
 		//let t=new Token($.parseJSON(msg.data));
 
-
+		if(data.id == undefined)
+			return;
 		if (data.id in window.TOKEN_OBJECTS) {
 			for (var property in data) {
 				window.TOKEN_OBJECTS[data.id].options[property] = data[property];
@@ -1278,7 +1279,6 @@ class MessageBroker {
 					check_token_visibility();
 	
 			if(window.CLOUD && window.DM){
-				$("#combat_area").empty();
 				ct_load();
 			}
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1321,9 +1321,14 @@ class MessageBroker {
 					check_token_visibility();
 	
 			if(window.CLOUD){
+				let data = {
+					loading: true,
+					current: $("#combat_area [data-current]").attr('data-target')
+				}
 				$("#combat_area").empty();
-				ct_load();
+				ct_load(data);
 			}
+
 
 			if(window.DM)
 				get_pclist_player_data();

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -256,7 +256,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		data.reveals = window.REVEALED;
 		data.drawings = window.DRAWINGS;
 		for (var id in window.TOKEN_OBJECTS) {
-			data.tokens.push(window.TOKEN_OBJECTS[id].options);
+			data.tokens[id].push(window.TOKEN_OBJECTS[id].options);
 		}
 
 		window.MB.sendMessage('custom/myVTT/scene', data); // issue with message size ??
@@ -550,7 +550,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		console.log("create_update_token");
 		let self = this;
 		let id = options.id;
-		////this.scene.tokens[id]=options;
+		this.scene.tokens[id]=options;
 
 		if (!(id in window.TOKEN_OBJECTS)) {
 

--- a/Token.js
+++ b/Token.js
@@ -1358,7 +1358,18 @@ class Token {
 			if (typeof this.options.tokendataname !== "undefined") {
 				tok.attr("data-tokendataname", this.options.tokendataname);
 			}
-
+			if(window.all_token_objects == undefined){
+				window.all_token_objects = {};
+			}
+			if(window.all_token_objects[this.options.id] == undefined){
+				window.all_token_objects[this.options.id] = {};
+			}
+			if (this.options !== undefined){
+				window.all_token_objects[this.options.id] = new Token(this.options);
+			}
+			else if (typeof window.all_token_objects[this.options.id].options.init !== undefined){		
+				this.options.init = window.all_token_objects[this.options.id].options.init;
+			}
 			// CONDITIONS
 			this.build_conditions().forEach(cond_bar => {
 				tok.append(cond_bar);

--- a/Token.js
+++ b/Token.js
@@ -1975,6 +1975,14 @@ function place_token_at_map_point(tokenObject, x, y) {
 			options.size = Math.round(window.CURRENT_SCENE_DATA.hpps) * 1;
 		}
 	}
+	if(window.all_token_objects[options.id] !== undefined){
+		if(window.all_token_objects[options.id].options.ct_show == true){
+			options = window.all_token_objects[options.id].options;
+		  	$(`#combat_area tr[data-target='${options.id}'] .findSVG`).remove();
+	       	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
+	        $(`#combat_area tr[data-target='${options.id}'] .findTokenCombatButton`).append(findSVG);
+		}
+	}
 	options.left = `${x - options.size/2}px`;
 	options.top = `${y - options.size/2}px`;
 	// set reasonable defaults for any global settings that aren't already set

--- a/Token.js
+++ b/Token.js
@@ -1385,9 +1385,9 @@ class Token {
 			}
 			if(window.all_token_objects[this.options.id] == undefined){
 				window.all_token_objects[this.options.id] = {};
-				if (this.options !== undefined){
-					window.all_token_objects[this.options.id] = new Token(this.options);
-				}
+			}
+			if (this.options !== undefined){
+				window.all_token_objects[this.options.id] = new Token(this.options);
 			}
 			else if (typeof window.all_token_objects[this.options.id].options.init !== undefined && window.all_token_objects[this.options.id].options.ct_show !== undefined){		
 				this.options.init = window.all_token_objects[this.options.id].options.init;

--- a/Token.js
+++ b/Token.js
@@ -1385,11 +1385,11 @@ class Token {
 			}
 			if(window.all_token_objects[this.options.id] == undefined){
 				window.all_token_objects[this.options.id] = {};
+				if (this.options !== undefined){
+					window.all_token_objects[this.options.id] = new Token(this.options);
+				}
 			}
-			if (this.options !== undefined){
-				window.all_token_objects[this.options.id] = new Token(this.options);
-			}
-			else if (typeof window.all_token_objects[this.options.id].options.init !== undefined){		
+			else if (typeof window.all_token_objects[this.options.id].options.init !== undefined && window.all_token_objects[this.options.id].options.ct_show !== undefined){		
 				this.options.init = window.all_token_objects[this.options.id].options.init;
 			}
 			// CONDITIONS
@@ -1976,7 +1976,7 @@ function place_token_at_map_point(tokenObject, x, y) {
 		}
 	}
 	if(window.all_token_objects[options.id] !== undefined){
-		if(window.all_token_objects[options.id].options.ct_show == true){
+		if(window.all_token_objects[options.id].options.ct_show !== undefined){
 			options = window.all_token_objects[options.id].options;
 		  	$(`#combat_area tr[data-target='${options.id}'] .findSVG`).remove();
 	       	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	

--- a/Token.js
+++ b/Token.js
@@ -297,6 +297,7 @@ class Token {
 		$(selector).remove();
 		delete window.CURRENT_SCENE_DATA.tokens[id];
 		delete window.TOKEN_OBJECTS[id];
+		delete window.all_token_objects[id];
 		$("#aura_" + id.replaceAll("/", "")).remove();
 		if (persist == true) {
 			if(window.CLOUD && sync){

--- a/Token.js
+++ b/Token.js
@@ -770,6 +770,16 @@ class Token {
 			hp_input.change(function(e) {
 				hp_input.val(hp_input.val().trim());
 				self.update_and_sync(e);
+				let tokenID = $(this).parent().parent().attr("data-id");
+				if(window.all_token_objects[tokenID] != undefined){
+					window.all_token_objects[tokenID].options.hp = hp_input.val();
+					window.all_token_objects[tokenID].update_and_sync();
+				}			
+				if(window.TOKEN_OBJECTS[tokenID] != undefined){		
+					window.TOKEN_OBJECTS[tokenID].options.hp = hp_input.val();	
+					window.TOKEN_OBJECTS[tokenID].update_and_sync()
+				}
+				setTimeout(ct_persist(), 500);
 			});
 			hp_input.click(function(e) {
 				$(e.target).select();
@@ -777,6 +787,15 @@ class Token {
 			maxhp_input.change(function(e) {
 				maxhp_input.val(maxhp_input.val().trim());
 				self.update_and_sync(e);
+				if(window.all_token_objects[tokenID] != undefined){
+					window.all_token_objects[tokenID].options.max_hp = maxhp_input.val();
+					window.all_token_objects[tokenID].update_and_sync();
+				}
+				if(window.TOKEN_OBJECTS[tokenID] != undefined){		
+					window.TOKEN_OBJECTS[tokenID].options.max_hp = maxhp_input.val();	
+					window.TOKEN_OBJECTS[tokenID].update_and_sync()
+				}
+				setTimeout(ct_persist(), 500);
 			});
 			maxhp_input.click(function(e) {
 				$(e.target).select();

--- a/Token.js
+++ b/Token.js
@@ -1978,12 +1978,14 @@ function place_token_at_map_point(tokenObject, x, y) {
 			options.size = Math.round(window.CURRENT_SCENE_DATA.hpps) * 1;
 		}
 	}
-	if(window.all_token_objects[options.id] !== undefined){
-		if(window.all_token_objects[options.id].options.ct_show !== undefined){
-			options = window.all_token_objects[options.id].options;
-		  	$(`#combat_area tr[data-target='${options.id}'] .findSVG`).remove();
-	       	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
-	        $(`#combat_area tr[data-target='${options.id}'] .findTokenCombatButton`).append(findSVG);
+	if(window.all_token_objects !== undefined){
+		if(window.all_token_objects[options.id] !== undefined){
+			if(window.all_token_objects[options.id].options.ct_show !== undefined){
+				options = window.all_token_objects[options.id].options;
+			  	$(`#combat_area tr[data-target='${options.id}'] .findSVG`).remove();
+		       	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
+		        $(`#combat_area tr[data-target='${options.id}'] .findTokenCombatButton`).append(findSVG);
+			}
 		}
 	}
 	options.left = `${x - options.size/2}px`;
@@ -2619,10 +2621,14 @@ function paste_selected_tokens() {
 		let options = Object.assign({}, token.options);
 		let newId = uuid();
 		options.id = newId;
-		// TODO: figure out the location under the cursor and paste there instead of doing an offset
-		options.top = `${parseFloat(options.top) + Math.round(token.sizeHeight() / 2)}px`;
-		options.left = `${parseFloat(options.left) + Math.round(token.sizeWidth() / 2)}px`;
+		// TODO: figure out the location under the cursor and paste there instead of doing center of view
+		options.init = undefined;
+		options.ct_show = undefined;
 		options.selected = true;
+		let center = center_of_view() 
+		let mapView = convert_point_from_view_to_map(center.x, center.y, false);
+		options.top = `${mapView.y - Math.round(token.sizeHeight() / 2)}px`;
+		options.left = `${mapView.x - Math.round(token.sizeWidth() / 2) + token.sizeWidth()  * i + 5 - (token.sizeWidth() * ((window.TOKEN_PASTE_BUFFER.length/2)-1))}px`;
 		window.ScenesHandler.create_update_token(options);
 		// deselect the old and select the new so the user can easily move the new tokens around after pasting them
 		if(typeof window.TOKEN_OBJECTS[id] !== "undefined"){
@@ -2632,7 +2638,6 @@ function paste_selected_tokens() {
 		window.TOKEN_OBJECTS[newId].selected = true;
 		window.TOKEN_OBJECTS[newId].place_sync_persist();
 	}
-
 	// copy the newly selected tokens in case they paste again, we want them pasted in reference to the newly created tokens
 	copy_selected_tokens();
 	draw_selected_token_bounding_box();

--- a/Token.js
+++ b/Token.js
@@ -1386,6 +1386,9 @@ class Token {
 			if(window.all_token_objects[this.options.id] == undefined){
 				window.all_token_objects[this.options.id] = {};
 			}
+			if(window.all_token_objects[this.options.id].ct_show !== undefined){
+				this.options.ct_show = window.all_token_objects[this.options.id].ct_show 
+			}
 			if (this.options !== undefined){
 				window.all_token_objects[this.options.id] = new Token(this.options);
 			}
@@ -2611,7 +2614,7 @@ function paste_selected_tokens() {
 
 	for (let i = 0; i < window.TOKEN_PASTE_BUFFER.length; i++) {
 		let id = window.TOKEN_PASTE_BUFFER[i];
-		let token = window.TOKEN_OBJECTS[id];
+		let token = window.all_token_objects[id];
 		if (token == undefined || token.isPlayer()) continue; // only allow copy/paste for monster tokens, and protect against pasting deleted tokens
 		let options = Object.assign({}, token.options);
 		let newId = uuid();
@@ -2622,8 +2625,10 @@ function paste_selected_tokens() {
 		options.selected = true;
 		window.ScenesHandler.create_update_token(options);
 		// deselect the old and select the new so the user can easily move the new tokens around after pasting them
-		window.TOKEN_OBJECTS[id].selected = false;
-		window.TOKEN_OBJECTS[id].place_sync_persist();
+		if(typeof window.TOKEN_OBJECTS[id] !== "undefined"){
+			window.TOKEN_OBJECTS[id].selected = false;
+			window.TOKEN_OBJECTS[id].place_sync_persist();
+		}
 		window.TOKEN_OBJECTS[newId].selected = true;
 		window.TOKEN_OBJECTS[newId].place_sync_persist();
 	}

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -179,6 +179,8 @@ function token_context_menu_expanded(tokenIds, e) {
 					t.update_and_sync();
 				});
 			}
+
+			ct_reorder();
 			ct_persist();
 		});
 		

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -169,14 +169,14 @@ function token_context_menu_expanded(tokenIds, e) {
 				tokens.forEach(t =>{
 					t.options.ct_show = undefined;
 					ct_remove_token(t, false);
-					t.place_sync_persist();
+					t.update_and_sync();
 				});
 			} else {
 				clickedButton.removeClass("add-to-ct").addClass("remove-from-ct");
 				clickedButton.html(removeButtonInternals);
 				tokens.forEach(t => {
 					ct_add_token(t, false)
-					t.place_sync_persist();
+					t.update_and_sync();
 				});
 			}
 			ct_persist();

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -168,12 +168,16 @@ function token_context_menu_expanded(tokenIds, e) {
 				clickedButton.html(addButtonInternals);
 				tokens.forEach(t =>{
 					t.options.ct_show = undefined;
-					ct_remove_token(t, false)
+					ct_remove_token(t, false);
+					t.place_sync_persist();
 				});
 			} else {
 				clickedButton.removeClass("add-to-ct").addClass("remove-from-ct");
 				clickedButton.html(removeButtonInternals);
-				tokens.forEach(t => ct_add_token(t, false));
+				tokens.forEach(t => {
+					ct_add_token(t, false)
+					t.place_sync_persist();
+				});
 			}
 			ct_persist();
 		});

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3877,6 +3877,11 @@ input.max_hp[disabled]{
     position:relative;
 }
 
+.addCTSVG{
+    padding: 4px;
+    bottom: 1px;
+}
+
 #combat_tracker td button,
 #combat_tracker td button svg{
     display: inline-block;


### PR DESCRIPTION
Closes #313 
And Closes #301 

Fixed and new PR of #653 and #658 (I was test merging and fixing conflicts without making a new branch first oops) with less commits

Save combat tracker initiative per scene using token options.

Also persist the combat tracker throughout a session - this means it will bring other scenes combatants with you to the next. Easy to clear still with the clear button and won't erase the previous scenes save.

This allows for combat across scenes during a session while retaining individual scene saves using token options ct_show (existing), init, current and round. I tried round with scene but that forces a refresh for players so I swapped it to the current token.

https://www.youtube.com/watch?v=DAZ_rHMlCZ4

Edit: added an `place` button that replaces the find button when a token isn't on the current scene.

https://user-images.githubusercontent.com/65363489/186967037-1626c994-ac5d-4b1a-b7a6-34861121c496.mp4


