### PR TITLE
fix: token customizations with numbers for names break the tokens panel

### DIFF
--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -773,7 +773,7 @@ class SidebarListItem {
 
   /** @returns {boolean} true if the name partially matches the searchTerm or if the containing folder name partially matches the searchTerm */
   nameOrContainingFolderMatches(searchTerm) {
-    if (!this.name) return false;
+    if (typeof this.name !== "string") return false;
     return this.name.toLowerCase().includes(searchTerm.toLowerCase()) // any item with a partially matching name
     || this.containingFolderName().toLowerCase().includes(searchTerm.toLowerCase()) // all items within a folder with a partially matching name
   }

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -161,6 +161,12 @@ class TokenCustomization {
         console.debug("setTokenOption", key, value);
         if (value === undefined) {
             delete this.tokenOptions[key];
+        } else if (key === "name") { // we want to special case "name" because we want to guarantee that it's a string
+            if (typeof value === "string") {
+                this.tokenOptions[key] = value;
+            } else {
+                this.tokenOptions[key] = `${value}`;
+            }
         } else if (value === true || value === "true") {
             this.tokenOptions[key] = true;
         } else if (value === false || value === "false") {


### PR DESCRIPTION
I worked through this bug with @IanPK on Discord. If you name a custom token with a number, it gets parsed as a number instead of a string. Down the line, it breaks trying to parse a string on a number. This fixes both places.