### PR TITLE
Fix: Player view combat tracker hiding/displaying hp based on token settings - including My Tokens. "Hide Player HP/AC" should now properly display your own tokens HP as per the description.

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -335,7 +335,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		max_hp.css('font-size','11px');
 		//max_hp.css('width','20px');
 
-		if((token.options.hidestat == true && !window.DM) || token.options.disablestat || (!(token.options.id.startsWith("/profile")) && !window.DM && !token.options.player_owned)) {
+		if((token.options.hidestat == true && !window.DM && token.options.name != window.PLAYER_NAME) || token.options.disablestat || (!(token.options.id.startsWith("/profile")) && !window.DM && !token.options.player_owned)) {
 			divider.css('visibility', 'hidden');
 			hp.css('visibility', 'hidden');
 			max_hp.css('visibility', 'hidden');

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -306,6 +306,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		
 		
 		
+			
 		hp=$("<div class='hp'/>");
 		var hp_input = $("<input class='hp'>");
 		if(token.isPlayer()){
@@ -320,20 +321,9 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			entry.toggleClass("ct_dead", false);
 		}
 		hp.css('font-size','11px');
-		//hp.css('width','20px');
-		if(window.DM || !(token.options.monster > 0) )
-			entry.append($("<td/>").append(hp));
-		else
-			entry.append($("<td/>"))
+		//hp.css('width','20px');	
 			
 		var divider = $("<div style='display:inline-block;float:left'>/</>");
-		if((token.options.hidestat == true && !window.DM) || token.options.disablestat) {
-			divider.css('visibility', 'hidden');
-		}
-		if(window.DM || !(token.options.monster > 0))
-			entry.append($("<td/>").append(divider));
-		else
-			entry.append($("<td/>"));
 			
 		max_hp=$("<div class='max_hp'/>");
 		var maxhp_input = $("<input class='max_hp'>");
@@ -344,15 +334,17 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		max_hp.append(maxhp_input);
 		max_hp.css('font-size','11px');
 		//max_hp.css('width','20px');
-		if((token.options.hidestat == true && !window.DM) || token.options.disablestat) {
+
+		if((token.options.hidestat == true && !window.DM) || token.options.disablestat || (!(token.options.id.startsWith("/profile")) && !window.DM && !token.options.player_owned)) {
+			divider.css('visibility', 'hidden');
 			hp.css('visibility', 'hidden');
 			max_hp.css('visibility', 'hidden');
 		}
-		if(window.DM || !(token.options.monster > 0) )
-			entry.append($("<td/>").append(max_hp));
-		else
-			entry.append($("<td/>"));
-		
+
+		entry.append($("<td/>").append(hp));
+		entry.append($("<td/>").append(divider));
+		entry.append($("<td/>").append(max_hp));
+
 		// bind update functions to hp inputs, same as Token.js
 		// token update logic for hp pulls hp from token hpbar, so update hp bar manually
 		if (!token.isPlayer()) {

--- a/Token.js
+++ b/Token.js
@@ -697,13 +697,15 @@ class Token {
 		$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").val(this.options.max_hp);
 
 
-		if((!window.DM && this.options.hidestat == true) || this.options.disablestat == true) {
+		if((!window.DM && this.options.hidestat == true) || this.options.disablestat == true || (!window.DM && !this.options.player_owned)) {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'hidden');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'hidden');
+			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']>td:nth-of-type(4)>div").css('visibility', 'hidden');
 		}	
 		else {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'visible');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'visible');
+			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']>td:nth-of-type(4)>div").css('visibility', 'visible');
 		}
 		if($("#combat_tracker_inside tr[data-target='" + this.options.id + "'] input.hp").val() === '0'){
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']").toggleClass("ct_dead", true);

--- a/Token.js
+++ b/Token.js
@@ -697,7 +697,7 @@ class Token {
 		$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").val(this.options.max_hp);
 
 
-		if((!window.DM && this.options.hidestat == true) || this.options.disablestat == true || (!window.DM && !this.options.player_owned)) {
+		if((!window.DM && this.options.hidestat == true && this.options.name != window.PLAYER_NAME) || this.options.disablestat == true || (!(this.options.id.startsWith("/profile")) && !window.DM && !this.options.player_owned)) {
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .hp").css('visibility', 'hidden');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "'] .max_hp").css('visibility', 'hidden');
 			$("#combat_tracker_inside tr[data-target='" + this.options.id + "']>td:nth-of-type(4)>div").css('visibility', 'hidden');
@@ -867,7 +867,7 @@ class Token {
 		else if(window.DM){ // in all the other cases.. the DM should always see HP/AC
 			showthem=true;
 		}
-		else if(this.options.player_owned){ // if it's player_owned.. always showthem
+		else if(this.options.player_owned || this.options.name == window.PLAYER_NAME){ // if it's player_owned.. always showthem
 			showthem=true;
 		}
 		else if(this.isPlayer() && (!this.options.hidestat)){

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -911,22 +911,22 @@ td:nth-of-type(4){
     background: none;
     border-width: 0;
 }
-#combat_area [data-monster] input.hp{
+#combat_area tr:not([data-target*="characters"]) input.hp{
     text-decoration: underline solid 0.5px #1b9af033;
 }
-#combat_area [data-monster].ct_dead input.hp{
+#combat_area tr:not([data-target*="characters"]).ct_dead input.hp{
     text-decoration-color: #bc0f0f33;
 }
 
-#combat_area [data-monster] input:not(.init){
+#combat_area tr input:not(.init){
     border-width: 0;
     background: none;
 }
 
-#combat_area [data-monster] input.hp:focus{
+#combat_area tr:not([data-target*="characters"]) input.hp:focus{
     text-decoration: underline;
 }
-#combat_area [data-monster] input:not(.init):focus{
+#combat_area tr:not([data-target*="characters"]) input:not(.init):focus{
     border-width: 1px;
 }
 


### PR DESCRIPTION
Currently, in the player view - the token settings for displaying health in the CT for both monsters and My Tokens isn't working corrently. This should correct it.

Also fixes `My Token` styling in the CT.

Disable HP - Hides it for DM and PC, otherwise hides only from PC
Player accessible stats -  Allows PC to see HP if not disabled

Player HP should now display in both the CT and VTT as per the description of `hide player hp/ac`. Eg. if the token is the character they've launched above with they will still see their own hp.