### PR TITLE
store token measurement setting value

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -214,7 +214,6 @@ function get_avtt_setting_default_value(name) {
 }
 function get_avtt_setting_value(name) {
 	switch (name) {
-		case "allowTokenMeasurement": return window.ALLOWTOKENMEASURING;
 		case "iframeStatBlocks": return should_use_iframes_for_monsters();
 		default:
 			const setValue = window.EXPERIMENTAL_SETTINGS[name];
@@ -227,13 +226,6 @@ function get_avtt_setting_value(name) {
 function set_avtt_setting_value(name, newValue) {
 	console.log(`set_avtt_setting_value ${name} is now ${newValue}`);
 	switch (name) {
-		case "allowTokenMeasurement":
-			if (newValue === true || newValue === false) {
-				window.ALLOWTOKENMEASURING = newValue;
-			} else {
-				window.ALLOWTOKENMEASURING = get_avtt_setting_default_value(name);
-			}
-			break;
 		case "iframeStatBlocks":
 			if (newValue === true) {
 				use_iframes_for_monsters();

--- a/Token.js
+++ b/Token.js
@@ -1460,7 +1460,7 @@ class Token {
 						// finish measuring
 						// drop the temp overlay back down so selection works correctly
 						$("#temp_overlay").css("z-index", "25")
-						if (window.ALLOWTOKENMEASURING){
+						if (get_avtt_setting_value("allowTokenMeasurement")){
 							WaypointManager.fadeoutMeasuring()
 						}	
 						self.update_and_sync(event, false);
@@ -1483,8 +1483,9 @@ class Token {
 
 				start: function (event) {
 					event.stopImmediatePropagation();
-					if(window.ALLOWTOKENMEASURING)
+					if (get_avtt_setting_value("allowTokenMeasurement")) {
 						$("#temp_overlay").css("z-index", "50");
+					}
 					window.DRAWFUNCTION = "select"
 					window.DRAGGING = true;
 					click.x = event.pageX;
@@ -1533,7 +1534,7 @@ class Token {
 						el.attr("data-top", el.css("top").replace("px", ""));
 					}
 
-					if (window.ALLOWTOKENMEASURING){
+					if (get_avtt_setting_value("allowTokenMeasurement")) {
 							// Setup waypoint manager
 							// reset measuring when a new token is picked up
 							if(window.previous_measured_token != self.options.id){
@@ -1598,7 +1599,7 @@ class Token {
 						top: tokenPosition.y
 					};
 
-					if (window.ALLOWTOKENMEASURING) {
+					if (get_avtt_setting_value("allowTokenMeasurement")) {
 						const tokenMidX = tokenPosition.x + Math.round(self.options.size / 2);
 						const tokenMidY = tokenPosition.y + Math.round(self.options.size / 2);
 


### PR DESCRIPTION
Instead of storing the token measurement setting in `window.ALLOWTOKENMEASURING` (which doesn't get persisted anywhere), this treats it as an experimental setting which naturally gets stored in localStorage. The result is that the setting will persist across sessions so users won't have to re-enable it every time.