### PR TITLE
Fix player sheet background positioning from removed menus in DM view

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1731,12 +1731,21 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 			.MuiButtonBase-root {
 				width: 100%;
 			}
-      #site #site-main{
-        padding-top: 0px !important;
-      }
-      .ct-character-sheet-mobile__header{
-        top: 0px !important; 
-      }
+			html body#site.body-rpgcharacter-sheet{
+				background-position: center 93px !important;
+			}
+			#site #site-main{
+				padding-top: 0px !important;
+			}
+			.ct-character-sheet-mobile__header{
+				top: 0px !important; 
+			}
+
+			@media (min-width: 1200px){
+				html body#site.body-rpgcharacter-sheet{
+					background-position: center 116px !important
+				}
+			}
 			</style>
 		`);
 		console.log("removing headers");


### PR DESCRIPTION
We remove the player sheet's menu's in the iframe. This leaves the background position too low across various @media sizes. This should fix that

Example Video:
https://www.youtube.com/watch?v=FwA6Oh6GoO0