### PR TITLE
Fix - Allow firefox to change volume by increasing audio element width

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2107,12 +2107,12 @@ ul.context-menu-list > li {
 
 .soundpad-section audio{
 	height:20px;
-	width: 200px;
+	width: 270px;
 }
 
 .soundpad-line-title{
 	display: inline-block;
-	width: 70px;
+	width: 100%;
 }
 
 #hide_rightpanel {


### PR DESCRIPTION
Pointed out by Addison on discord
https://discord.com/channels/815028457851191326/852495991227809802/1017914465183866940

In firefox we can't access the volume slider due to it not showing up if the width of the audio element isn't large enough.
This is just a quick fix until we get the audio rework in.