### PR TITLE
Load in the Combat Tracker local storage on first load of 0.80 and save it to tokens/cloud

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -729,7 +729,9 @@ function ct_update_popout(){
 }
 
 function ct_load(data=null){
-	
+
+
+
 	
 	if(!data.loading){	
 		$("#combat_area tr[data-current]").removeAttr("data-current");
@@ -786,6 +788,31 @@ function ct_load(data=null){
 			}
 		}
 	}
+
+//load in local data on first load after 0.80
+	var itemkey="CombatTracker"+find_game_id();
+	data=$.parseJSON(localStorage.getItem(itemkey));
+	if(!(data[0]['already-loaded'])){
+		for(i in data){
+			if (data[i]['data-target'] === 'round'){
+				window.ROUND_NUMBER = data[i]['round_number'];
+				document.getElementById('round_number').value = window.ROUND_NUMBER;
+			}
+		    if(window.TOKEN_OBJECTS[data[i]['data-target']] != undefined){
+		        window.TOKEN_OBJECTS[data[i]['data-target']].options.init = data[i]['init']
+		        window.TOKEN_OBJECTS[data[i]['data-target']].update_and_sync();
+		        if(window.TOKEN_OBJECTS[data[i]['data-target']].ct_show == undefined){
+		        	window.TOKEN_OBJECTS[data[i]['data-target']].ct_show = data[i]['data-ct-show'];
+		        }
+		        window.TOKEN_OBJECTS[data[i]['data-target']].ct_show = data[i]['data-ct-show'];   
+		        $("#combat_area tr[data-target='"+data[i]['data-target']+"']").find(".init").val(data[i]['init']);
+		   		}   
+		}
+		data.unshift({'already-loaded': true})
+		localStorage.setItem(itemkey,JSON.stringify(data));
+	}
+	
+	
 	if(window.DM){
 		ct_reorder();
 	}

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -729,9 +729,6 @@ function ct_update_popout(){
 }
 
 function ct_load(data=null){
-
-
-
 	
 	if(!data.loading){	
 		$("#combat_area tr[data-current]").removeAttr("data-current");


### PR DESCRIPTION
As natemoonlife pointed out currently the beta doesn't load in local storage from the CT. This could be frustrating for users who ended mid combat.

This will load in the local storage people currently have on the first load. Next version I think we can delete the local storage but this allows people to go back to 0.79 and keep their local CT if there is a problem with the beta. Can always change this to delete the local storage instead if you would prefer.