### PR TITLE
Fix - some issues with beta combat tracker persisting through scenes where tokens had been placed during prep or removed from the CT previously on that scene + a few other sync issues/ QoL add hide button for all non-player tokens in the CT

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -601,6 +601,9 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		});
 		if(window.DM){
 			buttons.append(stat);
+			if(!token.isMonster()){
+				stat.css("visibility", "hidden");
+			}
 
 			ct_show_checkbox = $(`<input id="`+token.options.id+`hideCombatTrackerInput"type='checkbox' class="combatHideFromPlayerInput" style="font-size:10px; class='hideInPlayerCombatCheck' title="Show in player's Combat Tracker?" target_id='`+token.options.id+`' checked='`+token.options.ct_show+`'/>`);
 			//ct_show_checkbox.tooltip({ show: { effect: "blind", duration: 600 } });//Make this tooltip show a little quicker

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -747,6 +747,7 @@ function ct_load(data=null){
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
 				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || (window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined))
 				{
+
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
 					if([data[i]['data-target']] in window.TOKEN_OBJECTS){
 						window.TOKEN_OBJECTS[data[i]['data-target']].options.hp = window.all_token_objects[data[i]['data-target']].options.hp;
@@ -767,7 +768,7 @@ function ct_load(data=null){
 			if(window.all_token_objects[tokenID].options.ct_show == true || (window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined)) 
 			{
 				ct_add_token(window.all_token_objects[tokenID],false,true);
-			}
+			}		
 		}
 		if(data.current){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -634,7 +634,9 @@ function ct_add_token(token,persist=true,disablerolling=false){
 					$("#"+token.options.id+"hideCombatTrackerInput ~ button svg.openEye").css('display', 'none');
 				}
 
-				if(token.options.id in window.TOKEN_OBJECTS) token.update_and_sync();		
+				if(token.options.id in window.TOKEN_OBJECTS) {
+					window.TOKEN_OBJECTS[token.options.id].update_and_sync();
+				}	
 				ct_update_popout();
 				ct_persist();
 			});

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -593,7 +593,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	if(window.DM)
 		buttons.append(del);
 	
-	if(token.isMonster()){
+	if(!token.isPlayer()){
 		stat=$('<button class="openSheetCombatButton" style="font-size:10px;"><svg class="statSVG" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/><g><path d="M19,5v14H5V5H19 M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3L19,3z"/></g><path d="M14,17H7v-2h7V17z M17,13H7v-2h10V13z M17,9H7V7h10V9z"/></g></svg></button>');
 		
 		stat.click(function(){
@@ -747,7 +747,6 @@ function ct_load(data=null){
 				window.all_token_objects[data[i]['data-target']].options = data[i]['options'];
 				if(window.all_token_objects[data[i]['data-target']].options.ct_show == true || (window.DM && window.all_token_objects[data[i]['data-target']].options.ct_show !== undefined))
 				{
-
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
 					if([data[i]['data-target']] in window.TOKEN_OBJECTS){
 						window.TOKEN_OBJECTS[data[i]['data-target']].options.hp = window.all_token_objects[data[i]['data-target']].options.hp;
@@ -768,7 +767,7 @@ function ct_load(data=null){
 			if(window.all_token_objects[tokenID].options.ct_show == true || (window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined)) 
 			{
 				ct_add_token(window.all_token_objects[tokenID],false,true);
-			}		
+			}
 		}
 		if(data.current){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -201,7 +201,6 @@ function init_combat_tracker(){
 				window.TOKEN_OBJECTS[id].update_and_sync();
 			}
 			window.all_token_objects[id].options.ct_show = undefined;
-			window.all_token_objects[id].update_and_sync();
 
 		}
 		window.ROUND_NUMBER = 1;
@@ -220,8 +219,14 @@ function init_combat_tracker(){
 			console.log('nessuno selezionato');
 			$("#combat_area tr").first().attr('data-current','1');
 			currentTarget = $("#combat_area tr[data-current=1]").attr('data-target');
-			window.TOKEN_OBJECTS[currentTarget].options.current = true;
-			window.TOKEN_OBJECTS[currentTarget].update_and_sync();
+
+			if(window.TOKEN_OBJECTS[currentTarget] != undefined){
+				window.TOKEN_OBJECTS[currentTarget].options.current = true;
+				window.TOKEN_OBJECTS[currentTarget].update_and_sync();
+			}
+			window.all_token_objects[currentTarget].options.current = true;
+
+
 		}
 		else{
 			current.removeAttr('data-current');
@@ -425,7 +430,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 					window.all_token_objects[token.options.id].sync = function(e) {				
 						window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[token.options.id].options);
 					}
-					window.all_token_objects[token.options.id].update_and_sync();
 				}
 				token.options.init = init.val();
 				if(window.TOKEN_OBJECTS[token.options.id] != undefined){
@@ -446,9 +450,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				token.options.init = value;
 				if(window.TOKEN_OBJECTS[token.options.id] != undefined){			
 					window.TOKEN_OBJECTS[token.options.id].update_and_sync()
-				}
-				if(window.all_token_objects[token.options.id] != undefined){				
-					window.all_token_objects[token.options.id].update_and_sync()
 				}
 				setTimeout(ct_reorder(), 500);
 			});
@@ -510,7 +511,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 
 			if(window.all_token_objects[token.options.id] != undefined){
 				window.all_token_objects[token.options.id].options.hp = hp_input.val();
-				window.all_token_objects[token.options.id].update_and_sync();
 			}			
 			if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
 				window.TOKEN_OBJECTS[token.options.id].options.hp = hp_input.val();	
@@ -532,7 +532,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			old.find(".max_hp").val(maxhp_input.val().trim());
 			if(window.all_token_objects[token.options.id] != undefined){
 				window.all_token_objects[token.options.id].options.max_hp = maxhp_input.val();
-				window.all_token_objects[token.options.id].update_and_sync();
 			}
 			if(window.TOKEN_OBJECTS[token.options.id] != undefined){		
 				window.TOKEN_OBJECTS[token.options.id].options.max_hp = maxhp_input.val();	
@@ -584,7 +583,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			}
 			if(window.all_token_objects[token.options.id] != undefined){
 				window.all_token_objects[token.options.id].options.ct_show = undefined;
-				window.all_token_objects[token.options.id].update_and_sync();
 			}
 
 			ct_remove_token(token);

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1192,7 +1192,7 @@ class MessageBroker {
 			if(data.ct_show == undefined){
 				delete window.TOKEN_OBJECTS[data.id].options.ct_show;
 			}
-			if (!data.hidden)
+			if (!data.hidden && msg.sceneId == window.CURRENT_SCENE_DATA.id)
 				delete window.TOKEN_OBJECTS[data.id].options.hidden;
 
 			window.TOKEN_OBJECTS[data.id].place();

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1161,8 +1161,6 @@ class MessageBroker {
 		if(data.id == undefined)
 			return;
 
-
-
 		if(msg.sceneId != window.CURRENT_SCENE_DATA.id || msg.loading){
 			data.size = window.CURRENT_SCENE_DATA.hpps * data.gridSquares;
 			if(window.all_token_objects != undefined){
@@ -1183,7 +1181,7 @@ class MessageBroker {
 						delete window.all_token_objects[data.id].options.hidden;
 				}
 			}
-		}		
+		}
 			
 		if (data.id in window.TOKEN_OBJECTS) {
 			for (var property in data) {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1163,11 +1163,11 @@ class MessageBroker {
 
 		if(window.all_token_objects != undefined){
 			if (data.id in window.all_token_objects) {
-				for (var property in data) {		
+				for (var property in window.all_token_objects[data.id].options) {		
 					if(msg.loading && property != "left" && property != "top"){
 						data[property] = window.all_token_objects[data.id].options[property];
 					}
-					else{
+					else if(property in data){
 					 window.all_token_objects[data.id].options[property] = data[property]; 
 					}
 				}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1190,12 +1190,16 @@ class MessageBroker {
 				window.TOKEN_OBJECTS[data.id].options[property] = data[property];
 			}
 			if(data.ct_show == undefined){
-				window.TOKEN_OBJECTS[data.id].options["ct_show"] = undefined;
+				delete window.TOKEN_OBJECTS[data.id].options.ct_show;
 			}
 			if (!data.hidden)
 				delete window.TOKEN_OBJECTS[data.id].options.hidden;
 
 			window.TOKEN_OBJECTS[data.id].place();
+
+			if(window.DM && msg.loading){
+				window.TOKEN_OBJECTS[data.id].update_and_sync();
+			}
 			check_single_token_visibility(data.id); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 		}	
 		else if(data.left){

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1164,7 +1164,7 @@ class MessageBroker {
 		if(window.all_token_objects != undefined){
 			if (data.id in window.all_token_objects) {
 				for (var property in window.all_token_objects[data.id].options) {		
-					if(msg.loading && property != "left" && property != "top"){
+					if(msg.loading && property != "left" && property != "top" && property != "hidden"){
 						data[property] = window.all_token_objects[data.id].options[property];
 					}
 					else if(property in data){

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1161,26 +1161,33 @@ class MessageBroker {
 		if(data.id == undefined)
 			return;
 
-		if(window.all_token_objects != undefined){
-			if (data.id in window.all_token_objects) {
-				for (var property in window.all_token_objects[data.id].options) {		
-					if(msg.loading && property != "left" && property != "top" && property != "hidden"){
-						data[property] = window.all_token_objects[data.id].options[property];
+
+
+		if(msg.sceneId != window.CURRENT_SCENE_DATA.id || msg.loading){
+			data.size = window.CURRENT_SCENE_DATA.hpps * data.gridSquares;
+			if(window.all_token_objects != undefined){
+				if (data.id in window.all_token_objects) {
+					for (var property in window.all_token_objects[data.id].options) {		
+						if(property == "left" || property == "top" || property == "hidden")
+							continue;
+						if(msg.loading){
+							data[property] = window.all_token_objects[data.id].options[property];
+						}
+						else if(property in data){
+						 window.all_token_objects[data.id].options[property] = data[property]; 
+						}
 					}
-					else if(property in data){
-					 window.all_token_objects[data.id].options[property] = data[property]; 
-					}
+
+
+					if (!data.hidden)
+						delete window.all_token_objects[data.id].options.hidden;
 				}
-
-
-				if (!data.hidden)
-					delete window.all_token_objects[data.id].options.hidden;
 			}
-		}
+		}		
 			
 		if (data.id in window.TOKEN_OBJECTS) {
 			for (var property in data) {
-				if(msg.sceneId != window.CURRENT_SCENE_DATA.id && (property == "left" || property == "top"))
+				if(msg.sceneId != window.CURRENT_SCENE_DATA.id && (property == "left" || property == "top" || property == "hidden"))
 					continue;				
 				window.TOKEN_OBJECTS[data.id].options[property] = data[property];
 			}

--- a/Token.js
+++ b/Token.js
@@ -777,7 +777,6 @@ class Token {
 				let tokenID = $(this).parent().parent().attr("data-id");
 				if(window.all_token_objects[tokenID] != undefined){
 					window.all_token_objects[tokenID].options.hp = hp_input.val();
-					window.all_token_objects[tokenID].update_and_sync();
 				}			
 				if(window.TOKEN_OBJECTS[tokenID] != undefined){		
 					window.TOKEN_OBJECTS[tokenID].options.hp = hp_input.val();	
@@ -793,7 +792,6 @@ class Token {
 				self.update_and_sync(e);
 				if(window.all_token_objects[tokenID] != undefined){
 					window.all_token_objects[tokenID].options.max_hp = maxhp_input.val();
-					window.all_token_objects[tokenID].update_and_sync();
 				}
 				if(window.TOKEN_OBJECTS[tokenID] != undefined){		
 					window.TOKEN_OBJECTS[tokenID].options.max_hp = maxhp_input.val();	


### PR DESCRIPTION
Reported by Natemoonlife in discord.

This also now checks `all_token_objects` for property's not in `data` when loading in tokens. Since ct_show was undefined in `data` it wasn't pulling it from `all_token_objects`. Also fixes other undefined issues like `init` on preplaced player tokens.

This affects both players tokens added to the map during prep and any tokens with the same id removed from the CT previously.

Edit: Added a few other sync issues to this fix and 1 line change QoL of having the hide button on all tokens that aren't players. Can pull out the hide button if necessary - I was using it to test stuff and thought it would be nice to leave/have on custom tokens.