### PR TITLE
Fix audio sync on player resize window

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2263,6 +2263,7 @@ function init_character_page_sidebar() {
 			init_sheet();	
 			inject_chat_buttons();
 			init_zoom_buttons();
+			window.MB.sendMessage('custom/myVTT/syncmeup');
 		}
 	}, 1000);
 }


### PR DESCRIPTION
Fixes #700 

This is a quick simple fix for this if we want to include it. Request a sync when resizing is triggering a rebuild of the sidebar.