### PR TITLE
Add names to combat tracker - players will only see visible names outside PCs

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -51,6 +51,10 @@ function init_combat_tracker(){
 			'width': '100%',
 			'height': '100%'
 		});
+		if(window.DM){
+			$(childWindows['Combat Tracker'].document).find("body").toggleClass('encounter-details-page', true);
+			$(childWindows['Combat Tracker'].document).find("body").attr("id", "site");
+		}
 		$(childWindows['Combat Tracker'].document).find("#combat_tracker_inside #combat_footer").css('bottom', '-5px');
 		$(childWindows['Combat Tracker'].document).find("body").css('overflow', 'hidden');
 		if(!window.DM){
@@ -660,7 +664,6 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	
 	
 	$("#combat_area").append(entry);
-	$("#combat_area td").css("vertical-align","middle");
 
   	ct_update_popout();
 

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -51,10 +51,12 @@ function init_combat_tracker(){
 			'width': '100%',
 			'height': '100%'
 		});
-		if(window.DM){
-			$(childWindows['Combat Tracker'].document).find("body").toggleClass('encounter-details-page', true);
-			$(childWindows['Combat Tracker'].document).find("body").attr("id", "site");
+		if(!window.DM){
+			$(childWindows['Combat Tracker'].document).find("body").toggleClass('body-rpgcharacter-sheet', true);
 		}
+		
+		$(childWindows['Combat Tracker'].document).find("body").attr("id", "site");
+
 		$(childWindows['Combat Tracker'].document).find("#combat_tracker_inside #combat_footer").css('bottom', '-5px');
 		$(childWindows['Combat Tracker'].document).find("body").css('overflow', 'hidden');
 		if(!window.DM){

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3749,10 +3749,10 @@ button.avtt-roll-button {
     border: 1px solid #ddd;
 }
 
-#site.encounter-details-page #combat_area td button{
+#combat_area td button{
     margin: 0px 2px;
 }
-#site.encounter-details-page #combat_area tr td{
+#site #combat_area tr td{
     padding-bottom: 4px;
 }
 
@@ -3790,20 +3790,18 @@ button.avtt-roll-button {
     box-shadow: inset 0px 0px 0px 1px var(--token-temp-hpbar), 0px 0px 3px 1px var(--token-temp-hpbar);
 }
 
-.encounter-builder-app #combat_area td [class*="AvatarPortrait"]{
+#combat_area td [class*="AvatarPortrait"]{
     border-radius: 5px;
     top:2px;
     left: 2px;
     position: relative;
     vertical-align: bottom;
 }
-#combat_area td [class*="AvatarPortrait"]{
-    border-radius: 5px;
-}
-#combat_area td{
+
+#combat_area tr td{
     vertical-align: middle
 }
-.encounter-details-page #combat_area td{
+#combat_area tr td{
     vertical-align: bottom
 }
 
@@ -4542,8 +4540,8 @@ input.max_hp[disabled]{
 .sp-container {
     position: fixed !important;
 }
-.encounter-details-page #combat_area tr.CTToken.hasTooltip:before {
-    content: attr(data-name);
+#combat_area tr.CTToken:before{
+    content:  '???';
     font-size: 12px;
     position: absolute;
     left: 42px;
@@ -4552,8 +4550,16 @@ input.max_hp[disabled]{
     overflow: hidden;
     text-overflow: ellipsis;
     font-weight: 600;
+    color: #4443;
+}
+#combat_area tr[data-name].CTToken:before{
+    content: attr(data-name);
     color: #444d;
 }
+body.body-rpgcharacter-sheet #combat_area tr.CTToken:before{
+    width: calc(100% - 80px);
+}
+
 .text-option{
     width:20px;
     height:20px;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3303,6 +3303,9 @@ button.avtt-roll-button {
 #combat_area td:last-of-type {
     padding: 0px 5px 0px 0px;
 }
+#combat_area tr{
+    position: relative;
+}
 
 #text_controller_title_bar,
 .text-input-title-bar,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3301,7 +3301,7 @@ button.avtt-roll-button {
 #combat_area tr td:nth-of-type(2),
 #combat_area tr td:nth-of-type(3)
 #combat_area td:last-of-type {
-        padding: 0px 5px 0px 0px;
+    padding: 0px 5px 0px 0px;
 }
 
 #text_controller_title_bar,
@@ -3749,6 +3749,12 @@ button.avtt-roll-button {
     border: 1px solid #ddd;
 }
 
+#site.encounter-details-page #combat_area td button{
+    margin: 0px 2px;
+}
+#site.encounter-details-page #combat_area tr td{
+    padding-bottom: 4px;
+}
 
 #combat_area tr td div,
 #combat_area tr td input.hp,
@@ -3789,10 +3795,18 @@ button.avtt-roll-button {
     top:2px;
     left: 2px;
     position: relative;
+    vertical-align: bottom;
 }
 #combat_area td [class*="AvatarPortrait"]{
     border-radius: 5px;
 }
+#combat_area td{
+    vertical-align: middle
+}
+.encounter-details-page #combat_area td{
+    vertical-align: bottom
+}
+
 #round_number_label button{
     margin-left: 6px;
 }
@@ -4528,7 +4542,18 @@ input.max_hp[disabled]{
 .sp-container {
     position: fixed !important;
 }
-
+.encounter-details-page #combat_area tr.CTToken.hasTooltip:before {
+    content: attr(data-name);
+    font-size: 12px;
+    position: absolute;
+    left: 42px;
+    width: calc(100% - 140px);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: 600;
+    color: #444d;
+}
 .text-option{
     width:20px;
     height:20px;


### PR DESCRIPTION
This adds names to the combat tracker as seen #704. Requested by Garret is discord and myself as I find I hover over the CT a lot for names.

https://user-images.githubusercontent.com/65363489/197122912-dd9487f1-9437-4a1f-8f26-8ca2859490a0.mp4



Pretty much had done the work when making a mock up so just throwing up a PR with it. Not much time lost if we decide not to go with it.

This closes #704.