### PR TITLE
Stat modifiers in dice rolls formula and custom dice roll buttons on items

### DIFF
--- a/ChatObserver.js
+++ b/ChatObserver.js
@@ -63,31 +63,13 @@ class ChatObserver {
     }
 
     #parseSlashCommand(text) {
-        let slashCommand = text.match(slashCommandRegex)?.[0];
-        let expression = text.replace(slashCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
-        let action = text.replace(slashCommandRegex, "").replace(allowedExpressionCharactersRegex, "");
-        console.debug("ChatObserver#parseSlashCommand text: ", text, ", slashCommand:", slashCommand, ", expression: ", expression, ", action: ", action);
-        let rollType = undefined;
-        if (slashCommand.startsWith("/r")) {
-            // /r and /roll allow users to set both the action and the rollType by separating them with `:` so try to parse that out
-            [action, rollType] = action.split(":") || [undefined, undefined];
-        } else if (slashCommand.startsWith("/hit")) {
-            rollType = "to hit";
-        } else if (slashCommand.startsWith("/dmg")) {
-            rollType = "damage";
-        } else if (slashCommand.startsWith("/skill")) {
-            rollType = "check";
-        } else if (slashCommand.startsWith("/save")) {
-            rollType = "save";
-        }
-
-        let diceRoll = new DiceRoll(expression, action, rollType);
+        let diceRoll = DiceRoll.fromSlashCommand(text);
         let didSend = window.diceRoller.roll(diceRoll);
         if (didSend === false) {
             // it was too complex so try to send it through rpgDiceRoller
+            let expression = text.replace(slashCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
             didSend = send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
         }
-
         return didSend;
     }
 

--- a/ChatObserver.js
+++ b/ChatObserver.js
@@ -1,6 +1,3 @@
-const slashCommandRegex = /\/(r|roll|save|hit|dmg|skill|w)\s/;
-const allowedExpressionCharactersRegex = /^(\d+d\d+|kh\d+|kl\d+|\+|-|\d+|\s+)*/; // this is explicitly different from validExpressionRegex. This matches an expression at the beginning of a string while validExpressionRegex requires the entire string to match.
-
 class ChatObserver {
 
     //#region PUBLIC

--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -189,6 +189,35 @@ class DiceRoll {
             }
         });
     }
+
+    /**
+     * @param slashCommandText {string} the slash command to parse and roll. EG: "/hit 2d20kh1+4 Shortsword". This is the only required value
+     * @param name {string|undefined} the name of the creature/player associated with this roll. This is displayed above the roll box in the gamelog. The character sheet defaults to the PC.name, the encounters page defaults to ""
+     * @param avatarUrl {string|undefined} the url for the image to be displayed in the gamelog. This is displayed to the left of the roll box in the gamelog. The character sheet defaults to the PC.avatar, the encounters page defaults to ""
+     * @param entityType {string|undefined} the type of entity associated with this roll. EG: "character", "monster", "user" etc. Generic rolls from the character sheet defaults to "character", generic rolls from the encounters page defaults to "user"
+     * @param entityId {string|undefined} the id of the entity associated with this roll. If {entityType} is "character" this should be the id for that character. If {entityType} is "monster" this should be the id for that monster. If {entityType} is "user" this should be the id for that user.
+     * @param sendToOverride {string|undefined} if undefined, the roll will go to whatever the gamelog is set to.
+     */
+    static fromSlashCommand(slashCommandText, name = undefined, avatarUrl = undefined, entityType = undefined, entityId = undefined, sendToOverride = undefined) {
+        let slashCommand = slashCommandText.match(slashCommandRegex)?.[0];
+        let expression = slashCommandText.replace(slashCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
+        let action = slashCommandText.replace(slashCommandRegex, "").replace(allowedExpressionCharactersRegex, "");
+        console.debug("DiceRoll.fromSlashCommand text: ", slashCommandText, ", slashCommand:", slashCommand, ", expression: ", expression, ", action: ", action);
+        let rollType = undefined;
+        if (slashCommand.startsWith("/r")) {
+            // /r and /roll allow users to set both the action and the rollType by separating them with `:` so try to parse that out
+            [action, rollType] = action.split(":") || [undefined, undefined];
+        } else if (slashCommand.startsWith("/hit")) {
+            rollType = "to hit";
+        } else if (slashCommand.startsWith("/dmg")) {
+            rollType = "damage";
+        } else if (slashCommand.startsWith("/skill")) {
+            rollType = "check";
+        } else if (slashCommand.startsWith("/save")) {
+            rollType = "save";
+        }
+        return new DiceRoll(expression, action, rollType, name, avatarUrl, entityType, entityId, sendToOverride);
+    }
 }
 
 class DiceRoller {

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -115,7 +115,7 @@ function list_item_from_monster_id(monsterId) {
 }
 
 function list_item_from_player_id(playerId) {
-    let pc = window.pcs.find(p => p.sheet = playerId);
+    let pc = window.pcs.find(p => p.sheet === playerId);
     if (pc === undefined) return undefined;
     let fullPath = sanitize_folder_path(`${RootFolder.Players.path}/${pc.name}`);
     return find_sidebar_list_item_from_path(fullPath);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3209,7 +3209,13 @@ button.avtt-roll-button {
     line-height: 18px;
     letter-spacing: 1px;
     padding: 1px 4px 0;
-}			
+}
+button.avtt-roll-formula-button {
+    font-size: 14px;
+    cursor: default;
+    color: #394B59;
+    padding: 9px;
+}
 .MuiPaper-root {
     padding: 0px 16px;
     width: 100px;


### PR DESCRIPTION
This does 2 things for PCs. First, it adds the ability for slash commands to parse stat modifiers for players. Second, it allows players to add slash commands to item customization notes which adds buttons to their sheet.

## Stat modifiers in slash commands
This allows slash commands to be more than just static numbers like `/r 1d20+5`. This allows the slash command to dynamically parse stat modifiers like `/r 1d20+DEX+PB`. 
<img width="340" alt="Screen Shot 2022-11-11 at 6 10 54 PM" src="https://user-images.githubusercontent.com/584771/201446812-49046d77-1742-4ae3-abf6-d78d61d74b1a.png">



## Slash Commands in action notes
This allows players to add custom dice roll commands as buttons to their character sheet. This is useful for things like the Savage Attacker Feat where you roll the damage dice twice and take the larger of the two rolls. To accomplish that, a player can type `/dmg 2d8kh1+DEX Savage Attack` into the chat box and hit enter. Instead of having to type that out every time, they can now add a button to the item that does it for them.

To add a slash command as a button, customize an item then type the slash command in the "Notes" field like this
<img width="339" alt="Screen Shot 2022-11-11 at 6 11 22 PM" src="https://user-images.githubusercontent.com/584771/201446762-2e0691b1-b9c1-498d-bc76-d4b82072ee50.png">


A new button will be added to the notes field of the item as seen on the right side here
<img width="631" alt="Screen Shot 2022-11-11 at 6 11 36 PM" src="https://user-images.githubusercontent.com/584771/201446774-58a32c96-4bcf-4b3d-b4e1-ef4ea1695c68.png">


Pressing that button will execute the command.
<img width="341" alt="Screen Shot 2022-11-11 at 6 11 52 PM" src="https://user-images.githubusercontent.com/584771/201446789-7238fdeb-f0d0-4a5b-9096-9a0d2ab8e71e.png">



