### PR TITLE
QoL - HP token inputs visual adjustment (minor visual changes for visibility and scale on hover/focus based on zoom)

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -739,14 +739,14 @@ class Token {
 		hpbar.css('height', bar_height);
 		hpbar.css('top', Math.floor(this.sizeHeight() - bar_height));
 
-		hpbar.toggleClass('large-or-smaller', false);
+		hpbar.toggleClass('medium-or-smaller', false);
 		hpbar.toggleClass('tiny-or-smaller', false);
 		
 		let tokenWidth = this.sizeWidth() / window.CURRENT_SCENE_DATA.hpps;
-		if(tokenWidth < 3 && tokenWidth >= 1)
-			hpbar.toggleClass('large-or-smaller', true);
+		if(tokenWidth < 2 && tokenWidth >= 1)
+			hpbar.toggleClass('medium', true);
 		if(tokenWidth < 1)
-			hpbar.toggleClass('tiny-or-smaller', true);
+			hpbar.toggleClass('smaller-than-medium', true);
 		
 
 		var fs = Math.floor(bar_height / 1.2) + "px";

--- a/Token.js
+++ b/Token.js
@@ -729,7 +729,7 @@ class Token {
 
 	build_hp() {
 		var self = this;
-		var bar_height = Math.floor(this.sizeHeight() * 0.2);
+		var bar_height = this.sizeHeight() * 0.2;
 
 		if (bar_height > 60)
 			bar_height = 60;
@@ -737,11 +737,10 @@ class Token {
 		var hpbar = $("<div class='hpbar'/>");
 		hpbar.css("position", 'absolute');
 		hpbar.css('height', bar_height);
-		hpbar.css('left', (Math.floor(this.sizeWidth() * 0.35) / 2));
-		hpbar.css('top', this.sizeHeight() - bar_height);
+		hpbar.css('top', Math.floor(this.sizeHeight() - bar_height));
 		hpbar.width("max-width: 100%");
 
-		var fs = Math.floor(bar_height / 1.3) + "px";
+		var fs = Math.floor(bar_height / 1.2) + "px";
 
 		$("<div class='token'/>").css("font-size",fs);
 
@@ -749,21 +748,20 @@ class Token {
 		if (input_width > 90)
 			input_width = 90;
 
-		var hp_input = $("<input class='hp'>").css("height", bar_height).css('font-weight', 'bold').css('float', 'left').css('background', 'rgba(0,0,0,0)').css('text-align', 'center').css('width', input_width).css("border", '0').css("padding", 0).css('font-size', fs);
+		var hp_input = $("<input class='hp'>").css('width', input_width);
 		hp_input.val(this.options.hp);
 
-		var maxhp_input = $("<input class='max_hp'>").css("height", bar_height).css('font-weight', 'bold').css('float', 'left').css('background', 'rgba(0,0,0,0)').css('text-align', 'center').css('width', input_width).css("border", '0').css("padding", 0).css('font-size', fs);
+		var maxhp_input = $("<input class='max_hp'>").css('width', input_width);
 		maxhp_input.val(this.options.max_hp);
 
 		if (this.options.disableaura){
 			console.log("building hp bar", this.options)
 			this.options.temp_hp && this.options.temp_hp > 0 ?
 				hpbar.css('background', '#77a2ff')
-				: hpbar.css('background', '#ff7777');
+				: hpbar.css('background', '');
 		}
 
-		var divider = $("<div style='display:inline-block;float:left'>/</>");
-		divider.css('font-size', fs);
+		var divider = $("<div>/</>");
 
 
 		hpbar.append(hp_input);

--- a/Token.js
+++ b/Token.js
@@ -739,7 +739,6 @@ class Token {
 		hpbar.css('height', bar_height);
 		hpbar.css('left', (Math.floor(this.sizeWidth() * 0.35) / 2));
 		hpbar.css('top', this.sizeHeight() - bar_height);
-		hpbar.css('background', '#ff7777');
 		hpbar.width("max-width: 100%");
 
 		var fs = Math.floor(bar_height / 1.3) + "px";

--- a/Token.js
+++ b/Token.js
@@ -738,7 +738,16 @@ class Token {
 		hpbar.css("position", 'absolute');
 		hpbar.css('height', bar_height);
 		hpbar.css('top', Math.floor(this.sizeHeight() - bar_height));
-		hpbar.width("max-width: 100%");
+
+		hpbar.toggleClass('large-or-smaller', false);
+		hpbar.toggleClass('tiny-or-smaller', false);
+		
+		let tokenWidth = this.sizeWidth() / window.CURRENT_SCENE_DATA.hpps;
+		if(tokenWidth < 3 && tokenWidth >= 1)
+			hpbar.toggleClass('large-or-smaller', true);
+		if(tokenWidth < 1)
+			hpbar.toggleClass('tiny-or-smaller', true);
+		
 
 		var fs = Math.floor(bar_height / 1.2) + "px";
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1268,18 +1268,37 @@ div#combat_button{
 .hpbar {
     z-index: 3;
     background: #fd9696;
-    filter: drop-shadow(1px 1px 1px #0007);
     border: 1px solid black;
     border-radius: 5px;
     display: block;
-    width: max-content;
     left: 50%;
+    max-width: 100%;
     transform: translateX(-50%);
+    width: max-content;
 }
+.hpbar.tiny-or-smaller{
+    border-radius: 2px;
+}
+.hpbar{
+    transition: 250ms transform 500ms;
+}
+.hpbar:focus-within,
+.hpbar:hover{
+    transform: translateX(-50%) scale(max(1, 0.4/var(--window-zoom)));
+}
+.hpbar.large-or-smaller:focus-within,
+.hpbar.large-or-smaller:hover{
+    transform: translateX(-50%) scale(max(1, 0.8/var(--window-zoom)));
+}
+.hpbar.tiny-or-smaller:focus-within,
+.hpbar.tiny-or-smaller:hover{
+    transform: translateX(-50%) scale(max(1, 1.5/var(--window-zoom)));
+}
+
 .hpbar input,
 .hpbar div{
     float: left;
-    max-height: 100%;
+    height: 100%;
     line-height: normal;
 }
 .hpbar input{
@@ -1289,6 +1308,9 @@ div#combat_button{
     border: 0;
     padding: 0;
     font-size: 110%;
+    outline: none;
+    outline-offset: 0;
+    filter: none;
 }
 /* Classes for main buttons on campaign page */
 .above-vtt-content-div {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1284,16 +1284,16 @@ div#combat_button{
 }
 .hpbar:focus-within,
 .hpbar:hover{
-    transform: translateX(-50%) scale(max(1, 0.4/var(--window-zoom)));
+    transform: translateX(-50%) scale(max(1, 0.3/var(--window-zoom)*var(--scene-scale, 1)));
     transition: 250ms transform linear 500ms;
 }
 .hpbar.large-or-smaller:focus-within,
 .hpbar.large-or-smaller:hover{
-    transform: translateX(-50%) scale(max(1, 0.8/var(--window-zoom)));
+    transform: translateX(-50%) scale(max(1, 0.6/var(--window-zoom)*var(--scene-scale, 1)));
 }
 .hpbar.tiny-or-smaller:focus-within,
 .hpbar.tiny-or-smaller:hover{
-    transform: translateX(-50%) scale(max(1, 1.5/var(--window-zoom)));
+    transform: translateX(-50%) scale(max(1, 1.2/var(--window-zoom)*var(--scene-scale, 1)));
 }
 
 .hpbar input,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1267,6 +1267,10 @@ div#combat_button{
 
 .hpbar {
     z-index: 3;
+    background: #fd9696;
+    filter: drop-shadow(1px 1px 1px #0007);
+    border: 1px solid black;
+    border-radius: 5px;
 }
 /* Classes for main buttons on campaign page */
 .above-vtt-content-div {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1271,6 +1271,27 @@ div#combat_button{
     filter: drop-shadow(1px 1px 1px #0007);
     border: 1px solid black;
     border-radius: 5px;
+    display: block;
+    width: max-content;
+    left: 50%;
+    transform: translateX(-50%);
+}
+.hpbar input,
+.hpbar div{
+    vertical-align: middle;
+    float: left;
+    height: 100%;
+    font-size: 100%;
+}
+.hpbar input{
+    font-weight: bold;
+    background: transparent;
+    text-align: center;
+    border: 0;
+    padding: 0;
+    line-height: 100%;
+    height: 100%;
+    font-size: 110%;
 }
 /* Classes for main buttons on campaign page */
 .above-vtt-content-div {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1289,11 +1289,11 @@ div#combat_button{
 }
 .hpbar.large-or-smaller:focus-within,
 .hpbar.large-or-smaller:hover{
-    transform: translateX(-50%) scale(max(1, 0.6/var(--window-zoom)*var(--scene-scale, 1)));
+    transform: translateX(-50%) scale(max(1, 0.8/var(--window-zoom)*var(--scene-scale, 1)));
 }
 .hpbar.tiny-or-smaller:focus-within,
 .hpbar.tiny-or-smaller:hover{
-    transform: translateX(-50%) scale(max(1, 1.2/var(--window-zoom)*var(--scene-scale, 1)));
+    transform: translateX(-50%) scale(max(1, 1.4/var(--window-zoom)*var(--scene-scale, 1)));
 }
 
 .hpbar input,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1280,11 +1280,12 @@ div#combat_button{
     border-radius: 2px;
 }
 .hpbar{
-    transition: 250ms transform 500ms;
+    transition: 250ms transform linear 0ms;
 }
 .hpbar:focus-within,
 .hpbar:hover{
     transform: translateX(-50%) scale(max(1, 0.4/var(--window-zoom)));
+    transition: 250ms transform linear 500ms;
 }
 .hpbar.large-or-smaller:focus-within,
 .hpbar.large-or-smaller:hover{

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1278,10 +1278,9 @@ div#combat_button{
 }
 .hpbar input,
 .hpbar div{
-    vertical-align: middle;
     float: left;
-    height: 100%;
-    font-size: 100%;
+    max-height: 100%;
+    line-height: normal;
 }
 .hpbar input{
     font-weight: bold;
@@ -1289,8 +1288,6 @@ div#combat_button{
     text-align: center;
     border: 0;
     padding: 0;
-    line-height: 100%;
-    height: 100%;
     font-size: 110%;
 }
 /* Classes for main buttons on campaign page */

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1284,16 +1284,16 @@ div#combat_button{
 }
 .hpbar:focus-within,
 .hpbar:hover{
-    transform: translateX(-50%) scale(min(max(1, 0.3/var(--window-zoom)*var(--scene-scale, 1)), 3));
+    transform: translateX(-50%) scale(min(max(1, 0.5/var(--window-zoom)), 3));
     transition: 250ms transform linear 500ms;
 }
 .hpbar.medium:focus-within,
 .hpbar.medium:hover{
-    transform: translateX(-50%) scale(min(max(1, 0.7/var(--window-zoom)*var(--scene-scale, 1)), 5));
+    transform: translateX(-50%) scale(min(max(1, 1/var(--window-zoom)), 5));
 }
 .hpbar.smaller-than-medium:focus-within,
 .hpbar.smaller-than-medium:hover{
-    transform: translateX(-50%) scale(min(max(1, 1.4/var(--window-zoom)*var(--scene-scale, 1)), 6));
+    transform: translateX(-50%) scale(min(max(1, 1.5/var(--window-zoom)), 6));
 }
 
 .hpbar input,

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1284,16 +1284,16 @@ div#combat_button{
 }
 .hpbar:focus-within,
 .hpbar:hover{
-    transform: translateX(-50%) scale(max(1, 0.3/var(--window-zoom)*var(--scene-scale, 1)));
+    transform: translateX(-50%) scale(min(max(1, 0.3/var(--window-zoom)*var(--scene-scale, 1)), 3));
     transition: 250ms transform linear 500ms;
 }
-.hpbar.large-or-smaller:focus-within,
-.hpbar.large-or-smaller:hover{
-    transform: translateX(-50%) scale(max(1, 0.8/var(--window-zoom)*var(--scene-scale, 1)));
+.hpbar.medium:focus-within,
+.hpbar.medium:hover{
+    transform: translateX(-50%) scale(min(max(1, 0.7/var(--window-zoom)*var(--scene-scale, 1)), 5));
 }
-.hpbar.tiny-or-smaller:focus-within,
-.hpbar.tiny-or-smaller:hover{
-    transform: translateX(-50%) scale(max(1, 1.4/var(--window-zoom)*var(--scene-scale, 1)));
+.hpbar.smaller-than-medium:focus-within,
+.hpbar.smaller-than-medium:hover{
+    transform: translateX(-50%) scale(min(max(1, 1.4/var(--window-zoom)*var(--scene-scale, 1)), 6));
 }
 
 .hpbar input,


### PR DESCRIPTION
I'd like to soften the hp bars a bit and have them styled a little more like other elements we make. 

I find it helps with visibility (at least for me) slightly and it fits a little better. I kept it roughly the same color just a tad lighter for visibility/reduction in harshness. Slight font size adjustments and remove half pixel positioning that causes some visual glitchyness/blurryness.

____
Edit: Added scale with zoom based on token size example:
https://youtu.be/B_70Z2WOkKw

Made a tutorial video for if this gets approved - better to have and not need. https://youtube.com/watch?v=hW94rT3eOtU

Examples new on left - old on right using the same zoom levels:
![image](https://user-images.githubusercontent.com/65363489/197325637-5cb07466-531e-4df0-ac44-9fa4b9c18f9b.png)
![image](https://user-images.githubusercontent.com/65363489/197325558-20f9504b-f8b0-4c9d-91fa-3b2f159669d7.png)





