### PR TITLE
Fix - missing subchapter maps, 'Maps / Poster Maps' maps, Appendices maps/handouts and Fix import button layout

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -403,6 +403,31 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			callback();
 			return;
 		}
+		if(/\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(chapter_url)){
+			var dm_map = '';
+			var player_map = chapter_url;
+			var header = self.sources[source_keyword].chapters[chapter_keyword].title;
+			var thumb = chapter_url;
+			var id = self.sources[source_keyword].chapters[chapter_keyword].title;
+			var title = self.sources[source_keyword].chapters[chapter_keyword].title;
+
+			self.sources[source_keyword].chapters[chapter_keyword].scenes.push({
+				id: id,
+				uuid: source_keyword + "/" + chapter_keyword + "/" + id,
+				title: title,
+				dm_map: dm_map,
+				player_map: player_map,
+				player_map_is_video: "0",
+				dm_map_is_video: "0",
+				scale: "100",
+				dm_map_usable: "0",
+				fog_of_war: "0",
+				thumb: thumb,
+				tokens: {},
+				reveals: [],
+			});
+			
+		}
 
 		var f = $("<iframe src='" + chapter_url + "'></iframe>");
 
@@ -457,7 +482,6 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			// COMPENDIUM IMAGES
 			let compendiumWithSubtitle = iframe.contents().find(".compendium-image-with-subtitle-center,.compendium-image-with-subtitle-right,.compendium-image-with-subtitle-left");
 			let compendiumWithoutSubtitle = iframe.contents().find(".compendium-image-center");
-			let individualMapsFromMapChapters = iframe.contents().find("body > img");
 
 			if (compendiumWithSubtitle.length > 0) {
 				compendiumWithSubtitle.each(function(idx) {
@@ -540,33 +564,6 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 						reveals: [],
 					});
 
-				});
-			}
-			else if(individualMapsFromMapChapters.length > 0){
-				individualMapsFromMapChapters.each(function(idx) {
-
-					var dm_map = '';
-					var player_map = $(this).attr("src");
-					var header = self.sources[source_keyword].chapters[chapter_keyword].title;
-					var thumb = $(this).attr('src');
-					var id = self.sources[source_keyword].chapters[chapter_keyword].title;
-					var title = self.sources[source_keyword].chapters[chapter_keyword].title;
-
-					self.sources[source_keyword].chapters[chapter_keyword].scenes.push({
-						id: id,
-						uuid: source_keyword + "/" + chapter_keyword + "/" + id,
-						title: title,
-						dm_map: dm_map,
-						player_map: player_map,
-						player_map_is_video: "0",
-						dm_map_is_video: "0",
-						scale: "100",
-						dm_map_usable: "0",
-						fog_of_war: "0",
-						thumb: thumb,
-						tokens: {},
-						reveals: [],
-					});
 				});
 			}
 

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -404,6 +404,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			return;
 		}
 		if(/\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(chapter_url)){
+			//'Maps' chapter maps at the end of books - individual images
 			var dm_map = '';
 			var player_map = chapter_url;
 			var header = self.sources[source_keyword].chapters[chapter_keyword].title;
@@ -533,11 +534,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 					} else if ($(this).parent().next().find(".compendium-image-center a").length > 0) {
 						playerMapContainer = $(this).parent().next().find(".compendium-image-center a");
 					}
-					else if (iframe.contents().find("body > img").length > 0){
+					else{
 						playerMapContainer = $(this);
-					}
-					if (playerMapContainer === undefined || playerMapContainer.length === 0) {
-						return;
 					}
 
 

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -369,7 +369,20 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				}
 			}
 			else {
-				iframe.contents().find("h3 > a, h3 ~ ul strong a, h4 > a, h3.adventure-chapter-header:contains('Maps') ~ ul a").each(function(idx) {
+				iframe.contents().find("h3 > a, h3 ~ ul strong a, h4 > a").each(function(idx) {
+					var title = $(this).html();
+					var url = $(this).attr('href');
+					var ch_keyword = url.replace('https://www.dndbeyond.com', '').replace('/sources/' + keyword + "/", '');
+					self.sources[keyword].chapters[ch_keyword] = {
+						type: 'dnb',
+						title: title,
+						url: url,
+						scenes: [],
+					};
+				});
+				iframe.contents().find("h3.adventure-chapter-header:contains('Maps') ~ ul a").each(function(idx) {
+					if(!(/\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test($(this).attr('href'))))
+						return;
 					var title = $(this).html();
 					var url = $(this).attr('href');
 					var ch_keyword = url.replace('https://www.dndbeyond.com', '').replace('/sources/' + keyword + "/", '');

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -369,7 +369,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				}
 			}
 			else {
-				iframe.contents().find("h3 > a, h3 ~ ul strong a, h4 > a").each(function(idx) {
+				iframe.contents().find("h3 > a, h3 ~ ul strong a, h4 > a, h3.adventure-chapter-header:contains('Maps') ~ ul a").each(function(idx) {
 					var title = $(this).html();
 					var url = $(this).attr('href');
 					var ch_keyword = url.replace('https://www.dndbeyond.com', '').replace('/sources/' + keyword + "/", '');
@@ -457,6 +457,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			// COMPENDIUM IMAGES
 			let compendiumWithSubtitle = iframe.contents().find(".compendium-image-with-subtitle-center,.compendium-image-with-subtitle-right,.compendium-image-with-subtitle-left");
 			let compendiumWithoutSubtitle = iframe.contents().find(".compendium-image-center");
+			let individualMapsFromMapChapters = iframe.contents().find("body > img");
 
 			if (compendiumWithSubtitle.length > 0) {
 				compendiumWithSubtitle.each(function(idx) {
@@ -508,6 +509,9 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 					} else if ($(this).parent().next().find(".compendium-image-center a").length > 0) {
 						playerMapContainer = $(this).parent().next().find(".compendium-image-center a");
 					}
+					else if (iframe.contents().find("body > img").length > 0){
+						playerMapContainer = $(this);
+					}
 					if (playerMapContainer === undefined || playerMapContainer.length === 0) {
 						return;
 					}
@@ -536,6 +540,33 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 						reveals: [],
 					});
 
+				});
+			}
+			else if(individualMapsFromMapChapters.length > 0){
+				individualMapsFromMapChapters.each(function(idx) {
+
+					var dm_map = '';
+					var player_map = $(this).attr("src");
+					var header = self.sources[source_keyword].chapters[chapter_keyword].title;
+					var thumb = $(this).attr('src');
+					var id = self.sources[source_keyword].chapters[chapter_keyword].title;
+					var title = self.sources[source_keyword].chapters[chapter_keyword].title;
+
+					self.sources[source_keyword].chapters[chapter_keyword].scenes.push({
+						id: id,
+						uuid: source_keyword + "/" + chapter_keyword + "/" + id,
+						title: title,
+						dm_map: dm_map,
+						player_map: player_map,
+						player_map_is_video: "0",
+						dm_map_is_video: "0",
+						scale: "100",
+						dm_map_usable: "0",
+						fog_of_war: "0",
+						thumb: thumb,
+						tokens: {},
+						reveals: [],
+					});
 				});
 			}
 

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -549,7 +549,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 						playerMapContainer = $(this).parent().next().find(".compendium-image-center");
 					} else if ($(this).parent().next().find(".compendium-image-center a").length > 0) {
 						playerMapContainer = $(this).parent().next().find(".compendium-image-center a");
-					} else{
+					} else if($(this).parent().not('.compendium-image-view-player').length > 0){
 						playerMapContainer = $(this);
 					}
 					if (playerMapContainer === undefined || playerMapContainer.length === 0) {

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -369,7 +369,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				}
 			}
 			else {
-				iframe.contents().find("h3 >a").each(function(idx) {
+				iframe.contents().find("h3 >a, h3 ~ ul strong a").each(function(idx) {
 					var title = $(this).html();
 					var url = $(this).attr('href');
 					var ch_keyword = url.replace('https://www.dndbeyond.com', '').replace('/sources/' + keyword + "/", '');

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -369,7 +369,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				}
 			}
 			else {
-				iframe.contents().find("h3 > a, h3 ~ ul strong a, h4 > a").each(function(idx) {
+				//chapter, subchapter (eg icewind), chapter, handouts and maps (eg. Curse of Strahd)
+				iframe.contents().find("h3 > a, h3 ~ ul strong a, h4 > a, h3.adventure-chapter-header:contains('Appendices') ~ ul a").each(function(idx) {
 					var title = $(this).html();
 					var url = $(this).attr('href');
 					var ch_keyword = url.replace('https://www.dndbeyond.com', '').replace('/sources/' + keyword + "/", '');
@@ -380,7 +381,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 						scenes: [],
 					};
 				});
-				iframe.contents().find("h3.adventure-chapter-header:contains('Maps') ~ ul a").each(function(idx) {
+				//map sections that are just links to maps not always found in other chapters (eg wildemount/eberron)
+				iframe.contents().find("h3.adventure-chapter-header:contains('Map') ~ ul a").each(function(idx) {
 					if(!(/\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test($(this).attr('href'))))
 						return;
 					var title = $(this).html();

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -369,7 +369,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				}
 			}
 			else {
-				iframe.contents().find("h3 >a, h3 ~ ul strong a").each(function(idx) {
+				iframe.contents().find("h3 > a, h3 ~ ul strong a, h4 > a").each(function(idx) {
 					var title = $(this).html();
 					var url = $(this).attr('href');
 					var ch_keyword = url.replace('https://www.dndbeyond.com', '').replace('/sources/' + keyword + "/", '');

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -498,7 +498,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 			if (compendiumWithSubtitle.length > 0) {
 				compendiumWithSubtitle.each(function(idx) {
-					if ($(this).parent().is('figure'))
+					if ($(this).parent().is('figure') || $(this).is('figure'))
 						return;
 					var id = $(this).attr('id');
 					if (typeof id == typeof undefined) {
@@ -542,7 +542,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				compendiumWithoutSubtitle.each(function(idx) {
 					// import it only if there's a player version
 
-					if ($(this).parent().is('figure'))
+					if ($(this).parent().is('figure') || $(this).is('figure'))
 						return;
 					let playerMapContainer;
 					if ($(this).parent().next().is(".compendium-image-view-player")) {

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -402,7 +402,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		if (Object.keys(self.sources[source_keyword].chapters[chapter_keyword].scenes).length > 0) { // EVITO DI SCANSIONARE DI NUOVO OGGETTI CHE HO GIA
 			callback();
 			return;
-		}
+		}	
 		if(/\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(chapter_url)){
 			//'Maps' chapter maps at the end of books - individual images
 			var dm_map = '';
@@ -426,8 +426,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				thumb: thumb,
 				tokens: {},
 				reveals: [],
-			});
-			
+			});		
 		}
 
 		var f = $("<iframe src='" + chapter_url + "'></iframe>");
@@ -486,6 +485,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 			if (compendiumWithSubtitle.length > 0) {
 				compendiumWithSubtitle.each(function(idx) {
+					if ($(this).parent().is('figure'))
+						return;
 					var id = $(this).attr('id');
 					if (typeof id == typeof undefined) {
 						id = $(this).attr('data-content-chunk-id');
@@ -528,14 +529,18 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				compendiumWithoutSubtitle.each(function(idx) {
 					// import it only if there's a player version
 
+					if ($(this).parent().is('figure'))
+						return;
 					let playerMapContainer;
 					if ($(this).parent().next().is(".compendium-image-view-player")) {
 						playerMapContainer = $(this).parent().next().find(".compendium-image-center");
 					} else if ($(this).parent().next().find(".compendium-image-center a").length > 0) {
 						playerMapContainer = $(this).parent().next().find(".compendium-image-center a");
-					}
-					else{
+					} else{
 						playerMapContainer = $(this);
+					}
+					if (playerMapContainer === undefined || playerMapContainer.length === 0) {
+						return;
 					}
 
 

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1359,7 +1359,7 @@ function fill_importer(scene_set, start) {
 		}
 		entry.append(stats);
 
-		b = $("<button class='import_scene_button'>Import</button>");
+		b = $("<button>Import</button>");
 
 		b.click(function() {
 			var scene = current_scene;

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1359,7 +1359,7 @@ function fill_importer(scene_set, start) {
 		}
 		entry.append(stats);
 
-		b = $("<button>Import</button>");
+		b = $("<button class='import_scene_button'>Import</button>");
 
 		b.click(function() {
 			var scene = current_scene;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2557,6 +2557,12 @@ h5.token-image-modal-footer-title:after {
     padding: 4px;
     margin: 10px;
 }
+div#importer_area>div>div:first-of-type {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0px 5px;
+}
 .sidebar-panel-footer-button {
     appearance: none;
     font-weight: 700;


### PR DESCRIPTION
This should fix missing subchapter maps. This makes sense for me because often these subchapters are meant to be run separately - see icewind dale. 

Edit: I went through a bunch of the books and had to make some more fixes as there is quite a few combinations but I think I've caught most/all of them now. 

Eg. missing sub chapters
![image](https://user-images.githubusercontent.com/65363489/197840318-2fdf562b-a1d5-43c5-852e-f7dd17375922.png)



Live vs Fix for import positioning:

![image](https://user-images.githubusercontent.com/65363489/197840163-74e29509-1884-415d-a752-403df04f5e8f.png)
vs
![image](https://user-images.githubusercontent.com/65363489/197840046-62c6bdad-60dc-47ba-856e-a00919e2b907.png)


Maps glossary Maps:

![image](https://user-images.githubusercontent.com/65363489/197850972-4ff595dd-99c1-4892-8902-59c16693ed2b.png)



