### PR TITLE
Fix - PC go to builder button

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2248,6 +2248,15 @@ function init_character_page_sidebar() {
 				});
 			}, 1000)
 		});
+		$(".ct-character-header-info__content").on("click", function(){ 
+			setTimeout(function(){
+				$(".ct-pane-menu__item:contains('Manage Character & Levels')").replaceWith($(".ct-pane-menu__item:contains('Manage Character & Levels')").clone());
+				$(".ct-pane-menu__item:contains('Manage Character & Levels')").off().on("click", function(){
+					$("a.ct-character-header-desktop__builder-link")[0].click();
+				});
+			}, 1000)		
+		});
+		
 		if (needs_ui) {
 			needs_ui = false;
 			window.PLAYER_NAME = $(".ddb-character-app-sn0l9p").text();

--- a/Main.js
+++ b/Main.js
@@ -2241,6 +2241,13 @@ function init_character_page_sidebar() {
 		  	$(`#switch_gamelog`).click();
 
 		});
+		$("a.ct-character-header-desktop__builder-link").on("click", function(){
+			setTimeout(function(){
+				$(".builder-sections-sheet-icon").off().on("click", function(){
+					window.location.href = `https://www.dndbeyond.com${$(".builder-sections-sheet-icon").attr("href")}?cs=${window.CAMPAIGN_SECRET}&cid=${get_campaign_id()}&abovevtt=true`;
+				});
+			}, 1000)
+		});
 		if (needs_ui) {
 			needs_ui = false;
 			window.PLAYER_NAME = $(".ddb-character-app-sn0l9p").text();

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4594,7 +4594,13 @@ div.ddbc-tab-options--layout-pill>button{
     100% {-webkit-transform: rotate(360deg);}
 }
 
-
+.body-rpgcharacterbuilder #black_layer,
+.body-rpgcharacterbuilder #VTTWRAPPER,
+.body-rpgcharacterbuilder .site-bar,
+.body-rpgcharacterbuilder #combat_button,
+.body-rpgcharacterbuilder #VTTWRAPPER ~ .ddbc-tab-options--layout-pill{
+    display: none !important;
+}
 
 [id^="streamer-"].hidden {
     display: none;


### PR DESCRIPTION
Reported by Pedrus
https://discord.com/channels/815028457851191326/815028804103307354/1034611587954262026

Since dndbeyond now loads the builder on top of the character sheet it doesn't force a load somewhere else. It ends up with the builder behind the map and a bunch of the ui breaking.

This hides above stuff so the builder is viewable. Then adds the link info to the character sheet button in the builder to force a reload into abovevtt when it's clicked.