### PR TITLE
Add page number and a message when there are no maps/handouts in a chapter to the importer

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1310,6 +1310,8 @@ function fill_importer(scene_set, start) {
 	area.animate({ opacity: "1" }, 300);
 
 	var ddb_extra_found=false;
+	totalPages = Math.max(1, Math.ceil(scene_set.length / 8));
+	pageNumber = 1 + Math.ceil(start / 8)
 	for (var i = start; i < Math.min(start + 8, scene_set.length); i++) {
 		let current_scene = scene_set[i];
 
@@ -1448,6 +1450,12 @@ function fill_importer(scene_set, start) {
 	buttons.append(next);
 	footer.append(buttons);
 
+	pageNumbersDiv = $(`<div class='page-number'>${pageNumber} / ${totalPages}</div>`)
+	footer.append(pageNumbersDiv);
+
+	if(scene_set.length == 0){
+		area.append(`<div style='border:none !important;'>There were no maps/handouts found in this chapter</div>`)
+	}
 
 
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2334,7 +2334,11 @@ body {
   .tabs-content div:not(:first-child) {
     display: none;
   }
-
+.page-number {
+    position: absolute;
+    bottom: 41px;
+    font-weight: bold;
+}
 .tabs-content dt {
     display: inline-block;
     text-align: center;


### PR DESCRIPTION
This adds a page number in the bottom right of the importer. And a message letting them people know no maps or handouts were found in a chapter if it is empty. 