### PR TITLE
Significant performance increase on scaled maps 

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -194,12 +194,12 @@ class WaypointManagerClass {
 
 		// Snap to centre of current grid square
 		var gridSize = window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
-		var snapPointXStart = coord.startX;
-		var snapPointYStart = coord.startY;
+		var snapPointXStart = coord.startX/window.CURRENT_SCENE_DATA.scale_factor;
+		var snapPointYStart = coord.startY/window.CURRENT_SCENE_DATA.scale_factor;
 		this.ctx.moveTo(snapPointXStart, snapPointYStart);
 
-		var snapPointXEnd = coord.endX;
-		var snapPointYEnd = coord.endY;
+		var snapPointXEnd = coord.endX/window.CURRENT_SCENE_DATA.scale_factor;
+		var snapPointYEnd = coord.endY/window.CURRENT_SCENE_DATA.scale_factor;
 
 		// Pull the scene data for units, unless it doesn't exist (i.e. older maps)
 		if (typeof window.CURRENT_SCENE_DATA.upsq !== "undefined")

--- a/Fog.js
+++ b/Fog.js
@@ -556,21 +556,21 @@ function clear_grid(){
 function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=null, lineWidth=null, subdivide=null, dash=[]){
 	const gridCanvas = document.getElementById("grid_overlay");
 	const gridContext = gridCanvas.getContext("2d");
-	clear_grid()
+	clear_grid();
 	gridContext.setLineDash(dash);
-	let startX = offsetX || window.CURRENT_SCENE_DATA.offsetx;
-	let startY = offsetY || window.CURRENT_SCENE_DATA.offsety;
+	let startX = offsetX/window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.offsetx/window.CURRENT_SCENE_DATA.scale_factor;
+	let startY = offsetY/window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.offsety/window.CURRENT_SCENE_DATA.scale_factor;
 	startX = Math.round(startX)
 	startY = Math.round(startY)
-	const incrementX = hpps || window.CURRENT_SCENE_DATA.hpps;
-	const incrementY = vpps || window.CURRENT_SCENE_DATA.vpps;
+	const incrementX = hpps/window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
+	const incrementY = vpps/window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.vpps/window.CURRENT_SCENE_DATA.scale_factor;
 	gridContext.lineWidth = lineWidth || window.CURRENT_SCENE_DATA.grid_line_width;
 	gridContext.strokeStyle = color || window.CURRENT_SCENE_DATA.grid_color;
 	let isSubdivided = subdivide === "1" || window.CURRENT_SCENE_DATA.grid_subdivided === "1"
 	let skip = true;
 
-	gridContext.beginPath();
-	for (var i = startX; i < $("#scene_map").width()*$("#VTT").css("--scene-scale"); i = i + incrementX) {
+	gridContext.beginPath();	
+	for (var i = startX; i < $("#grid_overlay").width(); i = i + incrementX) {
 		if (isSubdivided && skip) {
 			skip = false;
 			continue;
@@ -579,13 +579,14 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 			skip = true;
 		}
 		gridContext.moveTo(i, 0);
-		gridContext.lineTo(i, $("#scene_map").height()*$("#VTT").css("--scene-scale"));
+		gridContext.lineTo(i, $("#grid_overlay").height());
 	}
 	gridContext.stroke();
 	skip = true;
 
+	
 	gridContext.beginPath();
-	for (var i = startY; i < $("#scene_map").height()*$("#VTT").css("--scene-scale"); i = i + incrementY) {
+	for (var i = startY; i < $("#grid_overlay").height(); i = i + incrementY) {
 		if (isSubdivided && skip) {
 			skip = false;
 			continue;
@@ -593,8 +594,10 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 		else {
 			skip = true;
 		}
+
 		gridContext.moveTo(0, i);
-		gridContext.lineTo($("#scene_map").width()*$("#VTT").css("--scene-scale"), i);
+		gridContext.lineTo($("#grid_overlay").width(), i);
+
 	}
 	gridContext.stroke();
 }
@@ -683,8 +686,8 @@ function reset_canvas() {
 		else{
 			$("#VTT").css("--scene-scale", window.CURRENT_SCENE_DATA.scale_factor);
 		}
-		canvas_grid.width = $("#scene_map").width()*$("#VTT").css("--scene-scale");
-		canvas_grid.height = $("#scene_map").height()*$("#VTT").css("--scene-scale");
+		canvas_grid.width = $("#scene_map").width();
+		canvas_grid.height = $("#scene_map").height();
 
 		startX = Math.round(window.CURRENT_SCENE_DATA.offsetx);
 		startY = Math.round(window.CURRENT_SCENE_DATA.offsety);

--- a/Fog.js
+++ b/Fog.js
@@ -864,10 +864,10 @@ function get_event_cursor_position(event){
  */
 function drawing_mousedown(e) {
 	// perform some cleanup of the canvas/objects
-	clear_temp_canvas()
-	WaypointManager.resetDefaultDrawStyle()
-	WaypointManager.cancelFadeout()
-	if(e.button !== 2){
+	if(e.button !== 2 && !window.MOUSEDOWN){
+		clear_temp_canvas()
+		WaypointManager.resetDefaultDrawStyle()
+		WaypointManager.cancelFadeout()
 		WaypointManager.clearWaypoints()
 	}
 
@@ -1005,7 +1005,7 @@ function drawing_mousemove(e) {
 	const context = canvas.getContext("2d");
 
 	const isFilled = window.DRAWTYPE === "filled"
-	const mouseMoveFps = Math.round((1000.0 / 60.0));
+	const mouseMoveFps = Math.round((1000.0 / 24.0));
 
 
 	window.MOUSEMOVEWAIT = true;

--- a/Fog.js
+++ b/Fog.js
@@ -636,18 +636,17 @@ function draw_wizarding_box() {
 }
 
 function reset_canvas() {
-	$('#temp_overlay').get(0).width =$("#scene_map").width();
-	$('#temp_overlay').get(0).height =$("#scene_map").height();
+	$('#temp_overlay').get(0).width =($("#scene_map").width());
+	$('#temp_overlay').get(0).height =($("#scene_map").height());
 
+	$('#fog_overlay').get(0).width =($("#scene_map").width());
+	$('#fog_overlay').get(0).height =($("#scene_map").height());
 
-	$('#fog_overlay').get(0).width =$("#scene_map").width();
-	$('#fog_overlay').get(0).height =$("#scene_map").height();
+	$('#grid_overlay').get(0).width =($("#scene_map").width());
+	$('#grid_overlay').get(0).height =($("#scene_map").height());
 
-	$('#grid_overlay').get(0).width =$("#scene_map").width();
-	$('#grid_overlay').get(0).height =$("#scene_map").height();
-
-	$('#text_overlay').get(0).width= $("#scene_map").width();
-	$('#text_overlay').get(0).height = $("#scene_map").height();
+	$('#text_overlay').get(0).width= ($("#scene_map").width());
+	$('#text_overlay').get(0).height = ($("#scene_map").height());
 
 	$('#draw_overlay').get(0).width = $("#scene_map").width();
 	$('#draw_overlay').get(0).height = $("#scene_map").height();
@@ -1285,20 +1284,13 @@ function drawing_mouseup(e) {
 			var curr = window.TOKEN_OBJECTS[id];
 
 
-			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();	
-			let size = window.TOKEN_OBJECTS[curr.options.id].options.size;	
+			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();			
 			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM);
 			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
 			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM);
 			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
-			let scaledRemainderTop = (tokbottom-toktop-size)/2;
-			let scaledRemainderLeft = (tokright-tokleft-size)/2;
-			if(window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'circle' || window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'square' || $("#tokens>div[data-id='" + curr.options.id + "']").hasClass("isAoe")){
-				scaledRemainderTop = 0;
-				scaledRemainderLeft = 0;
-			}
-			if (Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom-scaledRemainderTop) == tokbottom-scaledRemainderTop || Math.max(window.BEGIN_MOUSEY, mouseY, toktop+scaledRemainderTop) == toktop+scaledRemainderTop)
 
+			if ((Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom)) == tokbottom || (Math.max(window.BEGIN_MOUSEY, mouseY, toktop) == toktop))
 				continue;
 			if ((Math.min(window.BEGIN_MOUSEX, mouseX, tokright)) == tokright || (Math.max(window.BEGIN_MOUSEX, mouseX, tokleft) == tokleft))
 				continue;

--- a/Fog.js
+++ b/Fog.js
@@ -158,7 +158,7 @@ class WaypointManagerClass {
 		x -= window.CURRENT_SCENE_DATA.offsetx;
 		y -= window.CURRENT_SCENE_DATA.offsety;
 
-		var gridSize = window.CURRENT_SCENE_DATA.hpps;
+		var gridSize = window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
 		var currGridX = Math.floor(x / gridSize);
 		var currGridY = Math.floor(y / gridSize);
 		var snapPointXStart = (currGridX * gridSize) + (gridSize / 2);

--- a/Fog.js
+++ b/Fog.js
@@ -210,7 +210,7 @@ class WaypointManagerClass {
 			var unitSymbol = 'ft'
 
 		// Calculate the distance and set into the waypoint object
-		var distance = Math.max(Math.abs(snapPointXStart - snapPointXEnd), Math.abs(snapPointYStart - snapPointYEnd));
+		var distance = Math.max(Math.abs(snapPointXStart - snapPointXEnd), Math.abs(snapPointYStart - snapPointYEnd))*window.CURRENT_SCENE_DATA.scale_factor;
 		distance = Math.round(distance / gridSize);
 		distance = distance * window.CURRENT_SCENE_DATA.fpsq;
 		coord.distance = distance;

--- a/Fog.js
+++ b/Fog.js
@@ -106,12 +106,12 @@ class WaypointManagerClass {
 	drawBobble(x, y, radius) {
 
 		if(radius == undefined) {
-			radius = Math.max(15 * Math.max((1 - window.ZOOM), 0), 3);
+			radius = Math.max(15 * Math.max((1 - window.ZOOM), 0), 3)/window.CURRENT_SCENE_DATA.scale_factor;
 		}
 
 		this.ctx.beginPath();
 		this.ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
-		this.ctx.lineWidth = this.drawStyle.lineWidth
+		this.ctx.lineWidth = this.drawStyle.lineWidth/window.CURRENT_SCENE_DATA.scale_factor
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.stroke();
 		this.ctx.fillStyle =  this.drawStyle.color
@@ -222,7 +222,7 @@ class WaypointManagerClass {
 		var slopeModifier = 0;
 
 		// Setup text metrics
-		this.ctx.font = Math.max(150 * Math.max((1 - window.ZOOM), 0), 30) + "px Arial";
+		this.ctx.font = Math.max(150 * Math.max((1 - window.ZOOM), 0), 12)/window.CURRENT_SCENE_DATA.scale_factor + "px Arial";
 		const totalDistance = Number.isInteger(distance + cumulativeDistance)
 			? (distance + cumulativeDistance)
 			: (distance + cumulativeDistance).toFixed(1)
@@ -257,7 +257,7 @@ class WaypointManagerClass {
 			// Calculate our coords and dimensions
 			contrastRect.x = labelX - margin + slopeModifier;
 			contrastRect.y = labelY - margin + slopeModifier;
-			contrastRect.width = textMetrics.width + (margin * 4);
+			contrastRect.width = (textMetrics.width + (margin * 4));
 			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 30) + (margin * 3);
 
 			textRect.x = labelX + slopeModifier;
@@ -266,8 +266,8 @@ class WaypointManagerClass {
 			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 30) + margin;
 
 			textRect.x -= (textRect.width / 2);
-			textX = labelX + margin + slopeModifier - (textRect.width / 2);
-			textY = labelY + (margin * 2) + slopeModifier;
+			textX = (labelX + margin + slopeModifier - (textRect.width / 2));
+			textY = (labelY + (margin * 2) + slopeModifier);
 		} else {
 			// Calculate slope modifier so we can float the rectangle away from the line end, all a bit magic number-y
 			if (snapPointYStart <= snapPointYEnd) {
@@ -301,22 +301,22 @@ class WaypointManagerClass {
 
 		// Draw our 'contrast line'
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
-		this.ctx.lineWidth = Math.round(Math.max(25 * Math.max((1 - window.ZOOM), 0), 5));
+		this.ctx.lineWidth = Math.round(Math.max(25 * Math.max((1 - window.ZOOM), 0), 5))/window.CURRENT_SCENE_DATA.scale_factor;
 		this.ctx.lineTo(snapPointXEnd, snapPointYEnd);
 		this.ctx.stroke();
 
 		// Draw our centre line
 		this.ctx.strokeStyle = this.drawStyle.color
-		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0), 3));
+		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0), 3))/window.CURRENT_SCENE_DATA.scale_factor;
 		this.ctx.lineTo(snapPointXEnd, snapPointYEnd);
 		this.ctx.stroke();
 
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.fillStyle = this.drawStyle.backgroundColor
-		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0), 3));
-		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, true);
+		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0), 3))/window.CURRENT_SCENE_DATA.scale_factor;
+		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height/window.CURRENT_SCENE_DATA.scale_factor, 10, true);
 		// draw the outline of the text box
-		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, false, true);
+		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height/window.CURRENT_SCENE_DATA.scale_factor, 10, false, true);
 
 		// Finally draw our text
 		this.ctx.fillStyle = this.drawStyle.textColor
@@ -572,7 +572,7 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 	let skip = true;
 
 	gridContext.beginPath();
-	for (var i = startX; i < $("#scene_map").width(); i = i + incrementX) {
+	for (var i = startX; i < $("#scene_map").width()*$("#VTT").css("--scene-scale"); i = i + incrementX) {
 		if (isSubdivided && skip) {
 			skip = false;
 			continue;
@@ -581,13 +581,13 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 			skip = true;
 		}
 		gridContext.moveTo(i, 0);
-		gridContext.lineTo(i, $("#scene_map").height());
+		gridContext.lineTo(i, $("#scene_map").height()*$("#VTT").css("--scene-scale"));
 	}
 	gridContext.stroke();
 	skip = true;
 
 	gridContext.beginPath();
-	for (var i = startY; i < $("#scene_map").height(); i = i + incrementY) {
+	for (var i = startY; i < $("#scene_map").height()*$("#VTT").css("--scene-scale"); i = i + incrementY) {
 		if (isSubdivided && skip) {
 			skip = false;
 			continue;
@@ -596,7 +596,7 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 			skip = true;
 		}
 		gridContext.moveTo(0, i);
-		gridContext.lineTo($("#scene_map").width(), i);
+		gridContext.lineTo($("#scene_map").width()*$("#VTT").css("--scene-scale"), i);
 	}
 	gridContext.stroke();
 }
@@ -638,20 +638,23 @@ function draw_wizarding_box() {
 }
 
 function reset_canvas() {
-	$('#temp_overlay').get(0).width =($("#scene_map").width());
-	$('#temp_overlay').get(0).height =($("#scene_map").height());
+	$('#temp_overlay').get(0).width =$("#scene_map").width();
+	$('#temp_overlay').get(0).height =$("#scene_map").height();
 
-	$('#fog_overlay').get(0).width =($("#scene_map").width());
-	$('#fog_overlay').get(0).height =($("#scene_map").height());
 
-	$('#grid_overlay').get(0).width =($("#scene_map").width());
-	$('#grid_overlay').get(0).height =($("#scene_map").height());
+	$('#fog_overlay').get(0).width =$("#scene_map").width();
+	$('#fog_overlay').get(0).height =$("#scene_map").height();
 
-	$('#text_overlay').get(0).width= ($("#scene_map").width());
-	$('#text_overlay').get(0).height = ($("#scene_map").height());
+	$('#grid_overlay').get(0).width =$("#scene_map").width();
+	$('#grid_overlay').get(0).height =$("#scene_map").height();
+
+	$('#text_overlay').get(0).width= $("#scene_map").width();
+	$('#text_overlay').get(0).height = $("#scene_map").height();
 
 	$('#draw_overlay').get(0).width = $("#scene_map").width();
 	$('#draw_overlay').get(0).height = $("#scene_map").height();
+
+
 	var canvas = document.getElementById("fog_overlay");
 	var ctx = canvas.getContext("2d");
 
@@ -677,15 +680,21 @@ function reset_canvas() {
 	var ctx_grid = canvas_grid.getContext("2d");
 	if (window.CURRENT_SCENE_DATA && (window.CURRENT_SCENE_DATA.grid == "1" || window.WIZARDING) && window.CURRENT_SCENE_DATA.hpps > 10 && window.CURRENT_SCENE_DATA.vpps > 10) {
 		//alert(window.CURRENT_SCENE_DATA.hpps + " "+ window.CURRENT_SCENE_DATA.vpps);
-		canvas_grid.width = $("#scene_map").width();
-		canvas_grid.height = $("#scene_map").height();
+		if(window.WIZARDING){
+			$("#VTT").css("--scene-scale", 1)
+		}
+		else{
+			$("#VTT").css("--scene-scale", window.CURRENT_SCENE_DATA.scale_factor);
+		}
+		canvas_grid.width = $("#scene_map").width()*$("#VTT").css("--scene-scale");
+		canvas_grid.height = $("#scene_map").height()*$("#VTT").css("--scene-scale");
 
 		startX = Math.round(window.CURRENT_SCENE_DATA.offsetx);
 		startY = Math.round(window.CURRENT_SCENE_DATA.offsety);
 
 		//alert(startX+ " "+startY);
 		if (window.WIZARDING) {
-			draw_wizarding_box()
+			draw_wizarding_box();
 		}
 		//alert('inizio 1');
 
@@ -844,8 +853,8 @@ function is_rgba_fully_transparent(rgba){
 }
 
 function get_event_cursor_position(event){
-	const pointX = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM)));
-	const pointY = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM)));
+	const pointX = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM)))/window.CURRENT_SCENE_DATA.scale_factor;
+	const pointY = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM)))/window.CURRENT_SCENE_DATA.scale_factor;
 	return [pointX, pointY]
 }
 
@@ -1276,14 +1285,22 @@ function drawing_mouseup(e) {
 		var c = 0;
 		for (id in window.TOKEN_OBJECTS) {
 			var curr = window.TOKEN_OBJECTS[id];
-			
-			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();			
-			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM);
-			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
-			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM);
-			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
-			
-			if ((Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom)) == tokbottom || (Math.max(window.BEGIN_MOUSEY, mouseY, toktop) == toktop))
+
+
+			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();	
+			let size = window.TOKEN_OBJECTS[curr.options.id].options.size;	
+			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
+			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
+			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
+			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
+			let scaledRemainderTop = (tokbottom-toktop-size)/2;
+			let scaledRemainderLeft = (tokright-tokleft-size)/2;
+			if(window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'circle' || window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'square' || $("#tokens>div[data-id='" + curr.options.id + "']").hasClass("isAoe")){
+				scaledRemainderTop = 0;
+				scaledRemainderLeft = 0;
+			}
+			if (Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom-scaledRemainderTop) == tokbottom-scaledRemainderTop || Math.max(window.BEGIN_MOUSEY, mouseY, toktop+scaledRemainderTop) == toktop+scaledRemainderTop)
+
 				continue;
 			if ((Math.min(window.BEGIN_MOUSEX, mouseX, tokright)) == tokright || (Math.max(window.BEGIN_MOUSEX, mouseX, tokleft) == tokleft))
 				continue;

--- a/Fog.js
+++ b/Fog.js
@@ -194,12 +194,12 @@ class WaypointManagerClass {
 
 		// Snap to centre of current grid square
 		var gridSize = window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
-		var snapPointXStart = coord.startX/window.CURRENT_SCENE_DATA.scale_factor;
-		var snapPointYStart = coord.startY/window.CURRENT_SCENE_DATA.scale_factor;
+		var snapPointXStart = coord.startX;
+		var snapPointYStart = coord.startY;
 		this.ctx.moveTo(snapPointXStart, snapPointYStart);
 
-		var snapPointXEnd = coord.endX/window.CURRENT_SCENE_DATA.scale_factor;
-		var snapPointYEnd = coord.endY/window.CURRENT_SCENE_DATA.scale_factor;
+		var snapPointXEnd = coord.endX;
+		var snapPointYEnd = coord.endY;
 
 		// Pull the scene data for units, unless it doesn't exist (i.e. older maps)
 		if (typeof window.CURRENT_SCENE_DATA.upsq !== "undefined")
@@ -1086,7 +1086,7 @@ function drawing_mousemove(e) {
 					WaypointManager.setCanvas(canvas);
 					WaypointManager.cancelFadeout()
 					WaypointManager.registerMouseMove(mouseX, mouseY);
-					WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, mouseX, mouseY);
+					WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX/window.CURRENT_SCENE_DATA.scale_factor, window.BEGIN_MOUSEY/window.CURRENT_SCENE_DATA.scale_factor, mouseX/window.CURRENT_SCENE_DATA.scale_factor, mouseY/window.CURRENT_SCENE_DATA.scale_factor);
 					WaypointManager.draw(false);
 					context.fillStyle = '#f50';
 				}

--- a/Fog.js
+++ b/Fog.js
@@ -125,7 +125,7 @@ class WaypointManagerClass {
 
 			// Draw an indicator for cosmetic niceness
 			var snapCoords = this.getSnapPointCoords(mousex, mousey);
-			this.drawBobble(snapCoords.x, snapCoords.y, Math.max(15 * Math.max((1 - window.ZOOM), 0), 3));
+			this.drawBobble(snapCoords.x, snapCoords.y, Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
 	}
 
 	// Track mouse moving
@@ -220,7 +220,7 @@ class WaypointManagerClass {
 		var slopeModifier = 0;
 
 		// Setup text metrics
-		this.ctx.font = Math.max(150 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 14) + "px Arial";
+		this.ctx.font = Math.max(150 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 26) + "px Arial";
 		const totalDistance = Number.isInteger(distance + cumulativeDistance)
 			? (distance + cumulativeDistance)
 			: (distance + cumulativeDistance).toFixed(1)
@@ -256,12 +256,12 @@ class WaypointManagerClass {
 			contrastRect.x = labelX - margin + slopeModifier;
 			contrastRect.y = labelY - margin + slopeModifier;
 			contrastRect.width = textMetrics.width + (margin * 4);
-			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + (margin * 3);
+			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 30) + (margin * 3);
 
 			textRect.x = labelX + slopeModifier;
 			textRect.y = labelY + slopeModifier;
 			textRect.width = textMetrics.width + (margin * 3);
-			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + margin;
+			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 30) + margin;
 
 			textRect.x -= (textRect.width / 2);
 			textX = (labelX + margin + slopeModifier - (textRect.width / 2));
@@ -286,12 +286,12 @@ class WaypointManagerClass {
 			contrastRect.x = snapPointXEnd - margin + slopeModifier;
 			contrastRect.y = snapPointYEnd - margin + slopeModifier;
 			contrastRect.width = textMetrics.width + (margin * 4);
-			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + (margin * 3);
+			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 30) + (margin * 3);
 
 			textRect.x = snapPointXEnd + slopeModifier;
 			textRect.y = snapPointYEnd + slopeModifier;
 			textRect.width = textMetrics.width + (margin * 3);
-			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + margin;
+			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 30) + margin;
 
 			textX = snapPointXEnd + margin + slopeModifier;
 			textY = snapPointYEnd + (margin * 2) + slopeModifier;
@@ -312,9 +312,9 @@ class WaypointManagerClass {
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.fillStyle = this.drawStyle.backgroundColor
 		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
-		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height/window.CURRENT_SCENE_DATA.scale_factor, 10, true);
+		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, true);
 		// draw the outline of the text box
-		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height/window.CURRENT_SCENE_DATA.scale_factor, 10, false, true);
+		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, false, true);
 
 		// Finally draw our text
 		this.ctx.fillStyle = this.drawStyle.textColor

--- a/Fog.js
+++ b/Fog.js
@@ -725,19 +725,19 @@ function redraw_fog() {
 	for (var i = 0; i < window.REVEALED.length; i++) {
 		var d = window.REVEALED[i];
 		if (d.length == 4) { // SIMPLE CASE OF RECT TO REVEAL
-			ctx.clearRect(d[0], d[1], d[2], d[3]);
+			ctx.clearRect(d[0]/window.CURRENT_SCENE_DATA.scale_factor, d[1]/window.CURRENT_SCENE_DATA.scale_factor, d[2]/window.CURRENT_SCENE_DATA.scale_factor, d[3]/window.CURRENT_SCENE_DATA.scale_factor);
 			continue;
 		}
 		if (d[5] == 0) { //REVEAL
 			if (d[4] == 0) { // REVEAL SQUARE
-				ctx.clearRect(d[0], d[1], d[2], d[3]);
+				ctx.clearRect(d[0]/window.CURRENT_SCENE_DATA.scale_factor, d[1]/window.CURRENT_SCENE_DATA.scale_factor, d[2]/window.CURRENT_SCENE_DATA.scale_factor, d[3]/window.CURRENT_SCENE_DATA.scale_factor);
 			}
 			if (d[4] == 1) { // REVEAL CIRCLE
 				clearCircle(ctx, d[0], d[1], d[2]);
 			}
 			if (d[4] == 2) {
 				// reveal ALL!!!!!!!!!!
-				ctx.clearRect(0, 0, $("#scene_map").width(), $("#scene_map").height());
+				ctx.clearRect(0, 0, $("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor, $("#scene_map").height()*window.CURRENT_SCENE_DATA.scale_factor);
 			}
 			if (d[4] == 3) {
 				// REVEAL POLYGON
@@ -746,9 +746,9 @@ function redraw_fog() {
 		}
 		if (d[5] == 1) { // HIDE
 			if (d[4] == 0) { // HIDE SQUARE
-				ctx.clearRect(d[0], d[1], d[2], d[3]);
+				ctx.clearRect(d[0]/window.CURRENT_SCENE_DATA.scale_factor, d[1]/window.CURRENT_SCENE_DATA.scale_factor, d[2]/window.CURRENT_SCENE_DATA.scale_factor, d[3]/window.CURRENT_SCENE_DATA.scale_factor);
 				ctx.fillStyle = fogStyle;
-				ctx.fillRect(d[0], d[1], d[2], d[3]);
+				ctx.fillRect(d[0]/window.CURRENT_SCENE_DATA.scale_factor, d[1]/window.CURRENT_SCENE_DATA.scale_factor, d[2]/window.CURRENT_SCENE_DATA.scale_factor, d[3]/window.CURRENT_SCENE_DATA.scale_factor);
 			}
 			if (d[4] == 1) { // HIDE CIRCLE
 				clearCircle(ctx, d[0], d[1], d[2]);
@@ -851,8 +851,8 @@ function is_rgba_fully_transparent(rgba){
 }
 
 function get_event_cursor_position(event){
-	const pointX = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM))/window.CURRENT_SCENE_DATA.scale_factor);
-	const pointY = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM))/window.CURRENT_SCENE_DATA.scale_factor);
+	const pointX = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM)));
+	const pointY = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM)));
 	return [pointX, pointY]
 }
 
@@ -1551,7 +1551,7 @@ function handle_drawing_button_click() {
 function drawCircle(ctx, centerX, centerY, radius, style, fill=true, lineWidth = 6)
 {
 	ctx.beginPath();
-	ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI, false);
+	ctx.arc(centerX/window.CURRENT_SCENE_DATA.scale_factor, centerY/window.CURRENT_SCENE_DATA.scale_factor, radius/window.CURRENT_SCENE_DATA.scale_factor, 0, 2 * Math.PI, false);
 	if(fill){
 		ctx.fillStyle = style;
 		ctx.fill();
@@ -1570,14 +1570,14 @@ function drawRect(ctx, startx, starty, width, height, style, fill=true, lineWidt
 	if(fill)
 	{
 		ctx.fillStyle = style;
-		ctx.fillRect(startx, starty, width, height);
+		ctx.fillRect(startx/window.CURRENT_SCENE_DATA.scale_factor, starty/window.CURRENT_SCENE_DATA.scale_factor, width/window.CURRENT_SCENE_DATA.scale_factor, height/window.CURRENT_SCENE_DATA.scale_factor);
 	}
 	else
 	{
 		ctx.lineWidth = lineWidth;
 		ctx.strokeStyle = style;
 		ctx.beginPath();
-		ctx.rect(startx, starty, width, height);
+		ctx.rect(startx/window.CURRENT_SCENE_DATA.scale_factor, starty/window.CURRENT_SCENE_DATA.scale_factor, width/window.CURRENT_SCENE_DATA.scale_factor, height/window.CURRENT_SCENE_DATA.scale_factor);
 		ctx.stroke();
 	}
 
@@ -1589,9 +1589,9 @@ function drawCone(ctx, startx, starty, endx, endy, style, fill=true, lineWidth =
 	var T = Math.sqrt(Math.pow(L, 2) + Math.pow(L / 2, 2));
 	var res = circle_intersection(startx, starty, T, endx, endy, L / 2);
 	ctx.beginPath();
-	ctx.moveTo(startx, starty);
-	ctx.lineTo(res[0], res[2]);
-	ctx.lineTo(res[1], res[3]);
+	ctx.moveTo(startx/window.CURRENT_SCENE_DATA.scale_factor, starty/window.CURRENT_SCENE_DATA.scale_factor);
+	ctx.lineTo(res[0]/window.CURRENT_SCENE_DATA.scale_factor, res[2]/window.CURRENT_SCENE_DATA.scale_factor);
+	ctx.lineTo(res[1]/window.CURRENT_SCENE_DATA.scale_factor, res[3]/window.CURRENT_SCENE_DATA.scale_factor);
 	ctx.closePath();
 	if(fill){
 		ctx.fillStyle = style;
@@ -1610,8 +1610,8 @@ function drawLine(ctx, startx, starty, endx, endy, style, lineWidth = 6)
 	ctx.beginPath();
 	ctx.strokeStyle = style;
 	ctx.lineWidth = lineWidth;
-	ctx.moveTo(startx, starty);
-	ctx.lineTo(endx, endy);
+	ctx.moveTo(startx/window.CURRENT_SCENE_DATA.scale_factor, starty/window.CURRENT_SCENE_DATA.scale_factor);
+	ctx.lineTo(endx/window.CURRENT_SCENE_DATA.scale_factor, endy/window.CURRENT_SCENE_DATA.scale_factor);
 	ctx.stroke();
 }
 
@@ -1626,18 +1626,18 @@ function drawBrushstroke(ctx, points, style, lineWidth=6)
 	ctx.strokeStyle = style;
 	ctx.lineWidth = lineWidth;
 	ctx.beginPath();
-	ctx.moveTo(p1.x, p1.y);
+	ctx.moveTo(p1.x/window.CURRENT_SCENE_DATA.scale_factor, p1.y/window.CURRENT_SCENE_DATA.scale_factor);
 
 	for (var i = 1, len = points.length; i < len; i++) {
 	// we pick the point between pi+1 & pi+2 as the
 	// end point and p1 as our control point
 	var midPoint = midPointBtw(p1, p2);
-	ctx.quadraticCurveTo(p1.x, p1.y, midPoint.x, midPoint.y);
+	ctx.quadraticCurveTo(p1.x/window.CURRENT_SCENE_DATA.scale_factor, p1.y/window.CURRENT_SCENE_DATA.scale_factor, midPoint.x/window.CURRENT_SCENE_DATA.scale_factor, midPoint.y/window.CURRENT_SCENE_DATA.scale_factor);
 	p1 = points[i];
 	p2 = points[i+1];
 	}
 	// Draw last line as a straight line
-	ctx.lineTo(p1.x, p1.y);
+	ctx.lineTo(p1.x/window.CURRENT_SCENE_DATA.scale_factor, p1.y/window.CURRENT_SCENE_DATA.scale_factor);
 	ctx.stroke();
 }
 
@@ -1652,15 +1652,15 @@ function drawPolygon (
 ) {
 	ctx.save();
 	ctx.beginPath();
-	ctx.moveTo(points[0].x, points[0].y);
+	ctx.moveTo(points[0].x/window.CURRENT_SCENE_DATA.scale_factor, points[0].y/window.CURRENT_SCENE_DATA.scale_factor);
 	ctx.lineWidth = lineWidth;
 
 	points.forEach((vertice) => {
-		ctx.lineTo(vertice.x, vertice.y);
+		ctx.lineTo(vertice.x/window.CURRENT_SCENE_DATA.scale_factor, vertice.y/window.CURRENT_SCENE_DATA.scale_factor);
 	})
 
 	if (mouseX !== null && mouseY !== null) {
-		ctx.lineTo(mouseX, mouseY);
+		ctx.lineTo(mouseX/window.CURRENT_SCENE_DATA.scale_factor, mouseY/window.CURRENT_SCENE_DATA.scale_factor);
 	}
 
 	ctx.closePath();
@@ -1760,9 +1760,9 @@ function clearPolygon (ctx, points) {
 	ctx.fillStyle = "#000";
 	ctx.globalCompositeOperation = 'destination-out';
 	ctx.beginPath();
-	ctx.moveTo(points[0].x, points[0].y);
+	ctx.moveTo(points[0].x/window.CURRENT_SCENE_DATA.scale_factor, points[0].y/window.CURRENT_SCENE_DATA.scale_factor);
 	points.forEach((vertice) => {
-		ctx.lineTo(vertice.x, vertice.y);
+		ctx.lineTo(vertice.x/window.CURRENT_SCENE_DATA.scale_factor, vertice.y/window.CURRENT_SCENE_DATA.scale_factor);
 	})
 	ctx.closePath();
 	ctx.fill();
@@ -1776,9 +1776,9 @@ function clearCircle(ctx, centerX, centerY, radius)
 	ctx.save();
 	ctx.beginPath();
 	ctx.fillStyle = "rgba(0,0,0,0);"
-	ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI, false);
+	ctx.arc(centerX/window.CURRENT_SCENE_DATA.scale_factor, centerY/window.CURRENT_SCENE_DATA.scale_factor, radius/window.CURRENT_SCENE_DATA.scale_factor, 0, 2 * Math.PI, false);
 	ctx.clip();
-	ctx.clearRect(centerX - radius, centerY - radius, radius * 2, radius * 2);
+	ctx.clearRect(centerX/window.CURRENT_SCENE_DATA.scale_factor - radius/window.CURRENT_SCENE_DATA.scale_factor, centerY/window.CURRENT_SCENE_DATA.scale_factor - radius/window.CURRENT_SCENE_DATA.scale_factor, radius * 2/window.CURRENT_SCENE_DATA.scale_factor, radius * 2/window.CURRENT_SCENE_DATA.scale_factor);
 	ctx.restore();
 }
 
@@ -1787,8 +1787,8 @@ function drawClosingArea(ctx, pointX, pointY) {
 	ctx.lineWidth = "2";
 	ctx.beginPath();
 	ctx.rect(
-		pointX - POLYGON_CLOSE_DISTANCE,
-		pointY - POLYGON_CLOSE_DISTANCE,
+		pointX/window.CURRENT_SCENE_DATA.scale_factor - POLYGON_CLOSE_DISTANCE,
+		pointY/window.CURRENT_SCENE_DATA.scale_factor - POLYGON_CLOSE_DISTANCE,
 		POLYGON_CLOSE_DISTANCE * 2,
 		POLYGON_CLOSE_DISTANCE * 2);
 	ctx.stroke();

--- a/Fog.js
+++ b/Fog.js
@@ -1287,10 +1287,10 @@ function drawing_mouseup(e) {
 
 			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();	
 			let size = window.TOKEN_OBJECTS[curr.options.id].options.size;	
-			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
-			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
-			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
-			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM)/window.CURRENT_SCENE_DATA.scale_factor;
+			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM);
+			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
+			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM);
+			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
 			let scaledRemainderTop = (tokbottom-toktop-size)/2;
 			let scaledRemainderLeft = (tokright-tokleft-size)/2;
 			if(window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'circle' || window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'square' || $("#tokens>div[data-id='" + curr.options.id + "']").hasClass("isAoe")){

--- a/Fog.js
+++ b/Fog.js
@@ -106,12 +106,12 @@ class WaypointManagerClass {
 	drawBobble(x, y, radius) {
 
 		if(radius == undefined) {
-			radius = Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3);
+			radius = Math.floor(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 2));
 		}
 
 		this.ctx.beginPath();
 		this.ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
-		this.ctx.lineWidth = this.drawStyle.lineWidth/window.CURRENT_SCENE_DATA.scale_factor
+		this.ctx.lineWidth = radius
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.stroke();
 		this.ctx.fillStyle =  this.drawStyle.color
@@ -299,22 +299,22 @@ class WaypointManagerClass {
 
 		// Draw our 'contrast line'
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
-		this.ctx.lineWidth = Math.round(Math.max(25 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 5));
+		this.ctx.lineWidth = Math.floor(Math.max(25 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
 		this.ctx.lineTo(snapPointXEnd, snapPointYEnd);
 		this.ctx.stroke();
 
 		// Draw our centre line
 		this.ctx.strokeStyle = this.drawStyle.color
-		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
+		this.ctx.lineWidth = Math.floor(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 2));
 		this.ctx.lineTo(snapPointXEnd, snapPointYEnd);
 		this.ctx.stroke();
 
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.fillStyle = this.drawStyle.backgroundColor
-		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
-		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, true);
+		this.ctx.lineWidth = Math.floor(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
+		roundRect(this.ctx, Math.floor(textRect.x), Math.floor(textRect.y), Math.floor(textRect.width), Math.floor(textRect.height), 10, true);
 		// draw the outline of the text box
-		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height, 10, false, true);
+		roundRect(this.ctx, Math.floor(textRect.x), Math.floor(textRect.y), Math.floor(textRect.width), Math.floor(textRect.height), 10, false, true);
 
 		// Finally draw our text
 		this.ctx.fillStyle = this.drawStyle.textColor

--- a/Fog.js
+++ b/Fog.js
@@ -106,7 +106,7 @@ class WaypointManagerClass {
 	drawBobble(x, y, radius) {
 
 		if(radius == undefined) {
-			radius = Math.max(15 * Math.max((1 - window.ZOOM), 0), 3)/window.CURRENT_SCENE_DATA.scale_factor;
+			radius = Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3);
 		}
 
 		this.ctx.beginPath();
@@ -161,11 +161,11 @@ class WaypointManagerClass {
 		var gridSize = window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
 		var currGridX = Math.floor(x / gridSize);
 		var currGridY = Math.floor(y / gridSize);
-		var snapPointXStart = (currGridX * gridSize) + (gridSize / 2);
-		var snapPointYStart = (currGridY * gridSize) + (gridSize / 2);
+		var snapPointXStart = (currGridX * gridSize) + (gridSize/2);
+		var snapPointYStart = (currGridY * gridSize);
 
 		// Add in scene offset
-		snapPointXStart += window.window.CURRENT_SCENE_DATA.offsetx;
+		snapPointXStart += window.window.CURRENT_SCENE_DATA.offsetx/window.CURRENT_SCENE_DATA.scale_factor;
 		snapPointYStart += window.window.CURRENT_SCENE_DATA.offsety;
 
 		return { x: snapPointXStart, y: snapPointYStart }
@@ -193,15 +193,13 @@ class WaypointManagerClass {
 	drawWaypointSegment(coord, cumulativeDistance, midlineLabels, labelX, labelY) {
 
 		// Snap to centre of current grid square
-		var gridSize = window.CURRENT_SCENE_DATA.hpps;
-		var snapCoords = this.getSnapPointCoords(coord.startX, coord.startY);
-		var snapPointXStart = snapCoords.x;
-		var snapPointYStart = snapCoords.y;
+		var gridSize = window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
+		var snapPointXStart = coord.startX;
+		var snapPointYStart = coord.startY;
 		this.ctx.moveTo(snapPointXStart, snapPointYStart);
 
-		snapCoords = this.getSnapPointCoords(coord.endX, coord.endY);
-		var snapPointXEnd = snapCoords.x;
-		var snapPointYEnd = snapCoords.y;
+		var snapPointXEnd = coord.endX;
+		var snapPointYEnd = coord.endY;
 
 		// Pull the scene data for units, unless it doesn't exist (i.e. older maps)
 		if (typeof window.CURRENT_SCENE_DATA.upsq !== "undefined")
@@ -210,7 +208,7 @@ class WaypointManagerClass {
 			var unitSymbol = 'ft'
 
 		// Calculate the distance and set into the waypoint object
-		var distance = Math.max(Math.abs(snapPointXStart - snapPointXEnd), Math.abs(snapPointYStart - snapPointYEnd))*window.CURRENT_SCENE_DATA.scale_factor;
+		var distance = Math.max(Math.abs(snapPointXStart - snapPointXEnd), Math.abs(snapPointYStart - snapPointYEnd));
 		distance = Math.round(distance / gridSize);
 		distance = distance * window.CURRENT_SCENE_DATA.fpsq;
 		coord.distance = distance;
@@ -222,7 +220,7 @@ class WaypointManagerClass {
 		var slopeModifier = 0;
 
 		// Setup text metrics
-		this.ctx.font = Math.max(150 * Math.max((1 - window.ZOOM), 0), 12)/window.CURRENT_SCENE_DATA.scale_factor + "px Arial";
+		this.ctx.font = Math.max(150 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 14) + "px Arial";
 		const totalDistance = Number.isInteger(distance + cumulativeDistance)
 			? (distance + cumulativeDistance)
 			: (distance + cumulativeDistance).toFixed(1)
@@ -257,13 +255,13 @@ class WaypointManagerClass {
 			// Calculate our coords and dimensions
 			contrastRect.x = labelX - margin + slopeModifier;
 			contrastRect.y = labelY - margin + slopeModifier;
-			contrastRect.width = (textMetrics.width + (margin * 4));
-			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 30) + (margin * 3);
+			contrastRect.width = textMetrics.width + (margin * 4);
+			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + (margin * 3);
 
 			textRect.x = labelX + slopeModifier;
 			textRect.y = labelY + slopeModifier;
 			textRect.width = textMetrics.width + (margin * 3);
-			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 30) + margin;
+			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + margin;
 
 			textRect.x -= (textRect.width / 2);
 			textX = (labelX + margin + slopeModifier - (textRect.width / 2));
@@ -288,12 +286,12 @@ class WaypointManagerClass {
 			contrastRect.x = snapPointXEnd - margin + slopeModifier;
 			contrastRect.y = snapPointYEnd - margin + slopeModifier;
 			contrastRect.width = textMetrics.width + (margin * 4);
-			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 30) + (margin * 3);
+			contrastRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + (margin * 3);
 
 			textRect.x = snapPointXEnd + slopeModifier;
 			textRect.y = snapPointYEnd + slopeModifier;
 			textRect.width = textMetrics.width + (margin * 3);
-			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 30) + margin;
+			textRect.height =  Math.max(150 * Math.max((1 - window.ZOOM), 0), 40) + margin;
 
 			textX = snapPointXEnd + margin + slopeModifier;
 			textY = snapPointYEnd + (margin * 2) + slopeModifier;
@@ -301,19 +299,19 @@ class WaypointManagerClass {
 
 		// Draw our 'contrast line'
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
-		this.ctx.lineWidth = Math.round(Math.max(25 * Math.max((1 - window.ZOOM), 0), 5))/window.CURRENT_SCENE_DATA.scale_factor;
+		this.ctx.lineWidth = Math.round(Math.max(25 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 5));
 		this.ctx.lineTo(snapPointXEnd, snapPointYEnd);
 		this.ctx.stroke();
 
 		// Draw our centre line
 		this.ctx.strokeStyle = this.drawStyle.color
-		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0), 3))/window.CURRENT_SCENE_DATA.scale_factor;
+		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
 		this.ctx.lineTo(snapPointXEnd, snapPointYEnd);
 		this.ctx.stroke();
 
 		this.ctx.strokeStyle = this.drawStyle.outlineColor
 		this.ctx.fillStyle = this.drawStyle.backgroundColor
-		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0), 3))/window.CURRENT_SCENE_DATA.scale_factor;
+		this.ctx.lineWidth = Math.round(Math.max(15 * Math.max((1 - window.ZOOM), 0)/window.CURRENT_SCENE_DATA.scale_factor, 3));
 		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height/window.CURRENT_SCENE_DATA.scale_factor, 10, true);
 		// draw the outline of the text box
 		roundRect(this.ctx, textRect.x, textRect.y, textRect.width, textRect.height/window.CURRENT_SCENE_DATA.scale_factor, 10, false, true);
@@ -853,8 +851,8 @@ function is_rgba_fully_transparent(rgba){
 }
 
 function get_event_cursor_position(event){
-	const pointX = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM)))/window.CURRENT_SCENE_DATA.scale_factor;
-	const pointY = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM)))/window.CURRENT_SCENE_DATA.scale_factor;
+	const pointX = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM))/window.CURRENT_SCENE_DATA.scale_factor);
+	const pointY = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM))/window.CURRENT_SCENE_DATA.scale_factor);
 	return [pointX, pointY]
 }
 
@@ -1007,7 +1005,7 @@ function drawing_mousemove(e) {
 	const context = canvas.getContext("2d");
 
 	const isFilled = window.DRAWTYPE === "filled"
-	const mouseMoveFps = Math.round((1000.0 / 16.0));
+	const mouseMoveFps = Math.round((1000.0 / 60.0));
 
 
 	window.MOUSEMOVEWAIT = true;

--- a/Main.js
+++ b/Main.js
@@ -179,10 +179,10 @@ function add_zoom_to_storage() {
 * Sets default values for VTTWRAPPER and black_layer based off zoom.
 */
 function set_default_vttwrapper_size() {
-	$("#VTTWRAPPER").width($("#scene_map").width() * window.ZOOM + 1400);
-	$("#VTTWRAPPER").height($("#scene_map").height() * window.ZOOM + 1400);
-	$("#black_layer").width($("#scene_map").width() * window.ZOOM + 2000);
-	$("#black_layer").height($("#scene_map").height() * window.ZOOM + 2000);
+	$("#VTTWRAPPER").width($("#scene_map").width() * window.CURRENT_SCENE_DATA.scale_factor * window.ZOOM + 1400);
+	$("#VTTWRAPPER").height($("#scene_map").height() * window.CURRENT_SCENE_DATA.scale_factor * window.ZOOM + 1400);
+	$("#black_layer").width($("#scene_map").width() * window.CURRENT_SCENE_DATA.scale_factor * window.ZOOM + 2000);
+	$("#black_layer").height($("#scene_map").height() * window.CURRENT_SCENE_DATA.scale_factor * window.ZOOM + 2000);
 }
 
 /**

--- a/Main.js
+++ b/Main.js
@@ -248,9 +248,9 @@ function decrease_zoom() {
 */
 function get_reset_zoom() {
 	const wH = $(window).height();
-	const mH = $("#scene_map").height();
+	const mH = $("#scene_map").height()*window.CURRENT_SCENE_DATA.scale_factor;
 	const wW = $(window).width();
-	const mW = $("#scene_map").width();
+	const mW = $("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor;
 
 	console.log(wH, mH, wW, mW);
 	return Math.min((wH / mH), (wW / mW));

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1283,7 +1283,9 @@ class MessageBroker {
 
 		load_scenemap(data.map, data.is_video, data.width, data.height, function() {
 			console.group("load_scenemap callback")
-			const scaleFactor = window.CURRENT_SCENE_DATA.scale_factor || 1;
+			if(!window.CURRENT_SCENE_DATA.scale_factor)
+				window.CURRENT_SCENE_DATA.scale_factor = 1;
+			const scaleFactor = window.CURRENT_SCENE_DATA.scale_factor;
 			// Store current scene width and height
 			window.CURRENT_SCENE_DATA.width = $("#scene_map").width();
 			window.CURRENT_SCENE_DATA.height = $("#scene_map").height();

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1289,15 +1289,8 @@ class MessageBroker {
 			// Store current scene width and height
 			window.CURRENT_SCENE_DATA.width = $("#scene_map").width();
 			window.CURRENT_SCENE_DATA.height = $("#scene_map").height();
-			// Scale map according to scaleFactor
-			$("#scene_map").width(window.CURRENT_SCENE_DATA.width);
-			$("#scene_map").height(window.CURRENT_SCENE_DATA.height);
-			window.CURRENT_SCENE_DATA.vpps=parseFloat(window.CURRENT_SCENE_DATA.vpps);
-			window.CURRENT_SCENE_DATA.hpps=parseFloat(window.CURRENT_SCENE_DATA.hpps);
-			
+			// Scale map according to scaleFactor			
 			$("#VTT").css("--scene-scale", scaleFactor)
-			$("#VTT").css("--scene-width", window.CURRENT_SCENE_DATA.width*scaleFactor + 'px');
-			$("#VTT").css("--scene-height", window.CURRENT_SCENE_DATA.height*scaleFactor + 'px')
 
 
 			reset_canvas();

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1289,10 +1289,9 @@ class MessageBroker {
 			// Store current scene width and height
 			window.CURRENT_SCENE_DATA.width = $("#scene_map").width();
 			window.CURRENT_SCENE_DATA.height = $("#scene_map").height();
-			// Scale map according to scaleFactor			
+			// Scale map according to scaleFactor
 			$("#VTT").css("--scene-scale", scaleFactor)
-
-
+			
 			reset_canvas();
 			redraw_fog();
 			redraw_drawings();

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1285,12 +1285,19 @@ class MessageBroker {
 			console.group("load_scenemap callback")
 			const scaleFactor = window.CURRENT_SCENE_DATA.scale_factor || 1;
 			// Store current scene width and height
-			window.CURRENT_SCENE_DATA.width = $("#scene_map").width() * scaleFactor;
-			window.CURRENT_SCENE_DATA.height = $("#scene_map").height() * scaleFactor;
+			window.CURRENT_SCENE_DATA.width = $("#scene_map").width();
+			window.CURRENT_SCENE_DATA.height = $("#scene_map").height();
 			// Scale map according to scaleFactor
 			$("#scene_map").width(window.CURRENT_SCENE_DATA.width);
 			$("#scene_map").height(window.CURRENT_SCENE_DATA.height);
+			window.CURRENT_SCENE_DATA.vpps=parseFloat(window.CURRENT_SCENE_DATA.vpps);
+			window.CURRENT_SCENE_DATA.hpps=parseFloat(window.CURRENT_SCENE_DATA.hpps);
 			
+			$("#VTT").css("--scene-scale", scaleFactor)
+			$("#VTT").css("--scene-width", window.CURRENT_SCENE_DATA.width*scaleFactor + 'px');
+			$("#VTT").css("--scene-height", window.CURRENT_SCENE_DATA.height*scaleFactor + 'px')
+
+
 			reset_canvas();
 			redraw_fog();
 			redraw_drawings();

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -582,12 +582,12 @@ function edit_scene_dialog(scene_id) {
 
 	let align_grid = function(square = false, just_rescaling = true) {
 
+		window.ScenesHandler.scenes[scene_id].scale_factor=1;		
 
 		/*window.ScenesHandler.persist();*/
 		window.ScenesHandler.switch_scene(scene_id, function() {
 			$("#tokens").hide();
 			window.CURRENT_SCENE_DATA.grid_subdivided = "0";
-			window.CURRENT_SCENE_DATA.scale_factor=1;
 			$("#VTT").css("--scene-scale", window.CURRENT_SCENE_DATA.scale_factor)
 			$("#VTT").css("--scene-width", window.CURRENT_SCENE_DATA.width + 'px');
 			$("#VTT").css("--scene-height", window.CURRENT_SCENE_DATA.height + 'px')

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -588,6 +588,9 @@ function edit_scene_dialog(scene_id) {
 			$("#tokens").hide();
 			window.CURRENT_SCENE_DATA.grid_subdivided = "0";
 			window.CURRENT_SCENE_DATA.scale_factor=1;
+			$("#VTT").css("--scene-scale", window.CURRENT_SCENE_DATA.scale_factor)
+			$("#VTT").css("--scene-width", window.CURRENT_SCENE_DATA.width + 'px');
+			$("#VTT").css("--scene-height", window.CURRENT_SCENE_DATA.height + 'px')
 			var aligner1 = $("<canvas id='aligner1'/>");
 			aligner1.width(59);
 			aligner1.height(59);
@@ -861,7 +864,9 @@ function edit_scene_dialog(scene_id) {
 				window.ScenesHandler.switch_scene(scene_id);
 			}
 				
-
+			$("#VTT").css("--scene-scale", 1)
+			$("#VTT").css("--scene-width", window.CURRENT_SCENE_DATA.width + 'px');
+			$("#VTT").css("--scene-height", window.CURRENT_SCENE_DATA.height + 'px')
 
 			$("#edit_dialog").remove();
 			$("#scene_selector").removeAttr("disabled");

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -589,8 +589,6 @@ function edit_scene_dialog(scene_id) {
 			$("#tokens").hide();
 			window.CURRENT_SCENE_DATA.grid_subdivided = "0";
 			$("#VTT").css("--scene-scale", window.CURRENT_SCENE_DATA.scale_factor)
-			$("#VTT").css("--scene-width", window.CURRENT_SCENE_DATA.width + 'px');
-			$("#VTT").css("--scene-height", window.CURRENT_SCENE_DATA.height + 'px')
 			var aligner1 = $("<canvas id='aligner1'/>");
 			aligner1.width(59);
 			aligner1.height(59);
@@ -865,8 +863,6 @@ function edit_scene_dialog(scene_id) {
 			}
 				
 			$("#VTT").css("--scene-scale", 1)
-			$("#VTT").css("--scene-width", window.CURRENT_SCENE_DATA.width + 'px');
-			$("#VTT").css("--scene-height", window.CURRENT_SCENE_DATA.height + 'px')
 
 			$("#edit_dialog").remove();
 			$("#scene_selector").removeAttr("disabled");

--- a/Text.js
+++ b/Text.js
@@ -587,16 +587,16 @@ function draw_text(
     font,
     stroke,
 ) {
-    context.font = `${font.weight} ${font.style} ${font.size}px ${font.font}`;
+    context.font = `${font.weight} ${font.style} ${font.size/window.CURRENT_SCENE_DATA.scale_factor}px ${font.font}`;
     context.strokeStyle = stroke.color;
-    context.lineWidth = stroke.size;
+    context.lineWidth = stroke.size/window.CURRENT_SCENE_DATA.scale_factor;
     context.fillStyle = font.color;
 
     const lines = text.split(/\r?\n/);
     // these values are modified per line depending on the line width
     // and the alignment used
-    let x = startingX;
-    let y = startingY;
+    let x = startingX/window.CURRENT_SCENE_DATA.scale_factor;
+    let y = startingY/window.CURRENT_SCENE_DATA.scale_factor;
     // draw stroke text first
     if (font.shadow && font.shadow !== "none"){
         const shadowRegex = /(rgb\(.*\))\s(\d+px)\s(\d+px)\s(\d+px)/
@@ -633,8 +633,8 @@ function draw_text(
     });
     // loop the lines again as large stroke size will overlap the fill text
     // so add fill text in last
-    x = startingX;
-    y = startingY;
+    x = startingX/window.CURRENT_SCENE_DATA.scale_factor;
+    y = startingY/window.CURRENT_SCENE_DATA.scale_factor;
   
     context.filter = "none"
     lines.forEach((line) => {

--- a/Token.js
+++ b/Token.js
@@ -1578,7 +1578,7 @@ class Token {
 							const tokenMidY = parseInt(self.orig_top) + Math.round(self.options.size / 2);
 
 							if(WaypointManager.numWaypoints > 0){
-								WaypointManager.checkNewWaypoint(tokenMidX, tokenMidY)
+								WaypointManager.checkNewWaypoint(tokenMidX/window.CURRENT_SCENE_DATA.scale_factor, tokenMidY/window.CURRENT_SCENE_DATA.scale_factor)
 								WaypointManager.cancelFadeout()
 							}
 							window.BEGIN_MOUSEX = tokenMidX;
@@ -1636,8 +1636,8 @@ class Token {
 						const tokenMidY = tokenPosition.y + Math.round(self.options.size / 2);
 
 						clear_temp_canvas();
-						WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, tokenMidX, tokenMidY);
-						WaypointManager.draw(false, Math.round(tokenPosition.x + (self.options.size / 2)), Math.round(tokenPosition.y + self.options.size + 10));
+						WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX/window.CURRENT_SCENE_DATA.scale_factor, window.BEGIN_MOUSEY/window.CURRENT_SCENE_DATA.scale_factor, tokenMidX/window.CURRENT_SCENE_DATA.scale_factor, tokenMidY/window.CURRENT_SCENE_DATA.scale_factor);
+						WaypointManager.draw(false, Math.round(tokenPosition.x + (self.options.size / 2))/window.CURRENT_SCENE_DATA.scale_factor, Math.round(tokenPosition.y + self.options.size + 10)/window.CURRENT_SCENE_DATA.scale_factor);
 					}
 
 					//console.log("Changing to " +ui.position.left+ " "+ui.position.top);
@@ -1797,8 +1797,8 @@ class Token {
 		this.walkableArea = {
 			top:  0 - (sizeOnGrid.y * multi),
 			left: 0 - (sizeOnGrid.x * multi),
-			right:  window.CURRENT_SCENE_DATA.width  + (sizeOnGrid.x * (multi -1)), // We need to remove 1 token size because tokens are anchored in the top left
-			bottom: window.CURRENT_SCENE_DATA.height + (sizeOnGrid.y * (multi -1)), // ... same as above
+			right:  window.CURRENT_SCENE_DATA.width * window.CURRENT_SCENE_DATA.scale_factor  + (sizeOnGrid.x * (multi -1)), // We need to remove 1 token size because tokens are anchored in the top left
+			bottom: window.CURRENT_SCENE_DATA.height * window.CURRENT_SCENE_DATA.scale_factor + (sizeOnGrid.y * (multi -1)), // ... same as above
 		};	
 	}
 	

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4625,7 +4625,8 @@ div.ddbc-tab-options--layout-pill>button{
 #draw_overlay,
 #darkness_layer,
 #scene_map_container,
-#scene_map{
+#scene_map,
+#grid_overlay{
     transform: scale(var(--scene-scale));
     transform-origin: top left;
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4618,6 +4618,17 @@ div.ddbc-tab-options--layout-pill>button{
 .aura-element{
 }
 
+
+#temp_overlay,
+#fog_overlay,
+#text_overlay,
+#draw_overlay,
+#darkness_layer,
+#scene_map_container,
+#scene_map{
+    transform: scale(var(--scene-scale));
+    transform-origin: top left;
+}
 @keyframes aurafx-flicker{
     0%  {filter: blur(10px);transform:scale(1);}
     10% {filter: blur(15px);transform:scale(1.005);}


### PR DESCRIPTION
Changing how the map scales, using css transform, instead of making the actual image and canvas larger significantly improves performance. It seems the majority of the performance problem is in the canvas being too large - especially noticeable with measure while dragging on. Basically any drawing/clearing action performed on a really large canvas is really slow, this includes the measuring tool, fog, drawing, text. By making the canvas scaled instead it performs those functions much better.

~~A nice side effect of this is drawings, fog, all the canvas stuff will scale with the map if scale changes after doing it.~~ This isn't true anymore - in order to make it work between versions I had to eliminate this. 

Example: https://youtu.be/qCRbt4SiaxY  - this is from Rise of Tiamat, Well of Dragons scale 4 as is preconfigured.

This probably needs some pretty good testing although I think I've caught most everything since this changes how the map is scaled/sized things might be out of place if I missed them

May also eliminate the need for #364  - as far as I don't think it needs to be limited with this I went up to 20, it loaded just as quickly. Of course 20 was way too big to be a useable map but it doesn't cause any issues - easily changed to an appropriate size.

Known issues / to fix:

- [x] Some minimum sizes for things like ruler - due to reduced resolutions look at minimum sizes that keep it from being blurry.
- [x] Ruler tool snapping location. (while dragging a token is fine)
- [x] Ruler distance
- [x] different versions of above not synced for drawings, fog etc.
