### PR TITLE
Fix - super mega wizard when map is already scaled

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -582,12 +582,11 @@ function edit_scene_dialog(scene_id) {
 
 	let align_grid = function(square = false, just_rescaling = true) {
 
-
+		window.ScenesHandler.scenes[scene_id].scale_factor=1;
 		/*window.ScenesHandler.persist();*/
 		window.ScenesHandler.switch_scene(scene_id, function() {
 			$("#tokens").hide();
 			window.CURRENT_SCENE_DATA.grid_subdivided = "0";
-			window.CURRENT_SCENE_DATA.scale_factor=1;
 			var aligner1 = $("<canvas id='aligner1'/>");
 			aligner1.width(59);
 			aligner1.height(59);


### PR DESCRIPTION
Related to #717 - it's hard to fix maps that are scaled.

When a map is scaled and you load into the super mega wizard it doesn't set the scale until after the map loads. This causes the grid to be the wrong size when you click good enough.

This fix moves the scale change to before the scene load call.