### PR TITLE
Fix - Zoom in/out when already out of min/max zoom

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1117,7 +1117,7 @@ function init_mouse_zoom() {
 				newScale = window.ZOOM - 0.01 * e.deltaY;
 			}
 
-			if (newScale > MIN_ZOOM && newScale < MAX_ZOOM) {
+			if ((newScale > MIN_ZOOM || newScale > window.ZOOM) && (newScale < MAX_ZOOM || newScale < window.ZOOM)) {
 				change_zoom(newScale, e.clientX, e.clientY);
 			}
 		}


### PR DESCRIPTION
When on large maps were it's at default zoom or zoom to fit has been clicked sometimes the zoom is set outside the min/max for the mousewheel Zoom. This allows it to zoom in from there with the mouse instead of having to use the button.