### PR TITLE
QoL - Vertical positioning of token images with a larger height then width.

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4079,6 +4079,7 @@ input.max_hp[disabled]{
     object-fit: cover;
     width: 100%;
     height: 100%;
+    object-position: top;
 } 
 
 .base:after{


### PR DESCRIPTION
I've run into this a lot but also mentioned on reddit.


Lots of character art images are taller then they are wide. Currently the way the images fill the token is they zoom towards the center. This works great for wider tokens.

But a lot of character art is taller than wide and has the characters face near the top. 

This should be better in most all cases for `circle` or `square` styles token art that use taller images. It shouldn't effect wider images.


https://user-images.githubusercontent.com/65363489/198838262-2f3047ae-d250-4b2c-a4c3-b81655ccd345.mp4



