### PR TITLE
Fix - `send to gamelog` button no longer appearing after resize of player view

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2264,7 +2264,6 @@ function init_character_page_sidebar() {
 			inject_chat_buttons();
 			init_zoom_buttons();
 			monitor_character_sidebar_changes();
-			window.MB.sendMessage('custom/myVTT/syncmeup');
 		}
 	}, 1000);
 }

--- a/Main.js
+++ b/Main.js
@@ -2263,6 +2263,8 @@ function init_character_page_sidebar() {
 			init_sheet();	
 			inject_chat_buttons();
 			init_zoom_buttons();
+			monitor_character_sidebar_changes();
+			window.MB.sendMessage('custom/myVTT/syncmeup');
 		}
 	}, 1000);
 }


### PR DESCRIPTION
Reported on discord by shannon

When player view is resize it doesn't start to monitor sidebar changes again. This fixes that and allows the gamelog button to show up again.