### PR TITLE
Fix - Beta on scene load white flash

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -344,6 +344,7 @@ function remove_loading_overlay() {
  */
 function load_scenemap(url, is_video = false, width = null, height = null, callback = null) {
 
+	$("#darkness_layer").hide();
 	remove_loading_overlay();
 
 	$("#scene_map").remove();
@@ -408,7 +409,10 @@ function load_scenemap(url, is_video = false, width = null, height = null, callb
 		}
 
 		newmap.css("opacity","0");
-		newmap.on("load", () => newmap.animate({opacity:1},2000));
+		newmap.on("load", () => {
+			newmap.css('opacity', 1);
+			$("#darkness_layer").show();
+		});
 		if (callback != null) {	
 			newmap.on("load", callback);
 		}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1365,9 +1365,11 @@ class MessageBroker {
 				$("#scene_map").css("opacity","0");
 				console.log("switching back to player map");
 				$("#scene_map").off("load");
-				$("#scene_map").on("load", () => $("#scene_map").animate({opacity:1},2000));
-				$("#scene_map").attr("src",data.player_map);
-				
+				$("#scene_map").on("load", () => {
+					$("#scene_map").css('opacity', 1)
+					$("#darkness_layer").show();
+				});
+				$("#scene_map").attr("src",data.player_map);		
 			}
 			console.log("LOADING TOKENS!");
 


### PR DESCRIPTION
Reported on Discord

On scene swap the map currently fades in. Since the darkness layer is white behind it it looks like a white flash. This should resolve that by hiding the darkness layer and showing it again when the map is loaded in.