### PR TITLE
Fix - Beta hp inputs font size when scene loads with a different scale

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -744,6 +744,7 @@ class Token {
 		if (bar_height > 60)
 			bar_height = 60;
 
+		bar_height = Math.ceil(bar_height);
 		var hpbar = $("<div class='hpbar'/>");
 		hpbar.css("position", 'absolute');
 		hpbar.css('height', bar_height);
@@ -761,13 +762,13 @@ class Token {
 
 		var fs = Math.floor(bar_height / 1.2) + "px";
 
-		$("<div class='token'/>").css("font-size",fs);
+		hpbar.css("--font-size",fs);
 
 		var input_width = Math.floor(this.sizeWidth() * 0.3);
 		if (input_width > 90)
 			input_width = 90;
 
-		var hp_input = $("<input class='hp'>").css('width', input_width);
+		var hp_input = $("<input class='hp'>").css('width', input_width)
 		hp_input.val(this.options.hp);
 
 		var maxhp_input = $("<input class='max_hp'>").css('width', input_width);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1294,7 +1294,10 @@ div#combat_button{
 .hpbar div{
     float: left;
     height: 100%;
-    line-height: normal;
+    font-size: var(--font-size);
+    line-height: var(--font-size);
+    display: flex;
+    align-items: center;
 }
 .hpbar input{
     font-weight: bold;
@@ -1302,7 +1305,6 @@ div#combat_button{
     text-align: center;
     border: 0;
     padding: 0;
-    font-size: 110%;
     outline: none;
     outline-offset: 0;
     filter: none;


### PR DESCRIPTION
When a scene loads with a different scale. The hpbar font size doesn't update on tokens with how I had done it. Reverting back to using  `fs` variable and adjusting positioning to match centering.

To replicate put a player token on a map, then load a different map with a larger/smaller scale - occasionally the font-size won't update and it will be too small/large until the token is moved and then the hpbar interacted with.
