### PR TITLE
Fix - Beta light only when darkness is set and auras are enabled

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -424,8 +424,9 @@ function check_single_token_visibility(id){
 			let auraSelector = ".aura-element[id='aura_" + auraSelectorId + "']";
 			let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 			let playerTokenAuraIsLight = (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
-			
-			if (is_token_under_fog(id) || (playerTokenAuraIsLight && window.TOKEN_OBJECTS[playerTokenId].options.auraVisible && window.CURRENT_SCENE_DATA.darkness_filter > 0 && !is_token_under_light_aura(id))) {
+			let playerAuraIsVisible =  (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraVisible;
+
+			if (is_token_under_fog(id) || (playerTokenAuraIsLight && playerAuraIsVisible && window.CURRENT_SCENE_DATA.darkness_filter > 0 && !is_token_under_light_aura(id))) {
 				$(selector).hide();
 				if(window.TOKEN_OBJECTS[id].options.hideaurafog)
 				{
@@ -482,8 +483,9 @@ function do_check_token_visibility() {
 		let auraSelector = ".aura-element[id='aura_" + auraSelectorId + "']";
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 		let playerTokenAuraIsLight = (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+		let playerAuraIsVisible =  (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraVisible;
 			
-		if (pixeldata[3] == 255 || (playerTokenAuraIsLight && window.TOKEN_OBJECTS[playerTokenId].options.auraVisible && window.CURRENT_SCENE_DATA.darkness_filter > 0 && !is_token_under_light_aura(id))) {
+		if (pixeldata[3] == 255 || (playerTokenAuraIsLight && playerAuraIsVisible && window.CURRENT_SCENE_DATA.darkness_filter > 0 && !is_token_under_light_aura(id))) {
 
 			$(selector).hide();
 			if(window.TOKEN_OBJECTS[id].options.hideaurafog)

--- a/Fog.js
+++ b/Fog.js
@@ -425,7 +425,7 @@ function check_single_token_visibility(id){
 			let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 			let playerTokenAuraIsLight = (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
 			
-			if (is_token_under_fog(id) || (playerTokenAuraIsLight && !is_token_under_light_aura(id))) {
+			if (is_token_under_fog(id) || (playerTokenAuraIsLight && window.TOKEN_OBJECTS[playerTokenId].options.auraVisible && window.CURRENT_SCENE_DATA.darkness_filter > 0 && !is_token_under_light_aura(id))) {
 				$(selector).hide();
 				if(window.TOKEN_OBJECTS[id].options.hideaurafog)
 				{
@@ -483,7 +483,7 @@ function do_check_token_visibility() {
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 		let playerTokenAuraIsLight = (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
 			
-		if (pixeldata[3] == 255 || (playerTokenAuraIsLight && !is_token_under_light_aura(id))) {
+		if (pixeldata[3] == 255 || (playerTokenAuraIsLight && window.TOKEN_OBJECTS[playerTokenId].options.auraVisible && window.CURRENT_SCENE_DATA.darkness_filter > 0 && !is_token_under_light_aura(id))) {
 
 			$(selector).hide();
 			if(window.TOKEN_OBJECTS[id].options.hideaurafog)

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -520,7 +520,7 @@ function build_token_auras_inputs(tokenIds) {
 		type: "toggle",
 		options: [
 			{ value: true, label: "Light", description: "The token's aura is visually changed to look like light and is interacting with the scene darkness filter. If set on a player token and darkness is set on the scene: tokens not in visible 'light' auras are hidden." },
-			{ value: false, label: "Default", description: "Enable this to make the token's aura look like light and interact with the scene darkness filter. If set on a player token: hide tokens not in visible 'light' auras." }
+			{ value: false, label: "Default", description: "Enable this to make the token's aura look like light and interact with the scene darkness filter. If set on a player token and darkness is set on the scene: hide tokens not in visible 'light' auras." }
 		],
 		defaultValue: false
 	};

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -519,7 +519,7 @@ function build_token_auras_inputs(tokenIds) {
 		label: "Change aura appearance to light",
 		type: "toggle",
 		options: [
-			{ value: true, label: "Light", description: "The token's aura is visually changed to look like light and is interacting with the scene darkness filter. If set on a player token: tokens not in visible 'light' auras are hidden." },
+			{ value: true, label: "Light", description: "The token's aura is visually changed to look like light and is interacting with the scene darkness filter. If set on a player token and darkness is set on the scene: tokens not in visible 'light' auras are hidden." },
 			{ value: false, label: "Default", description: "Enable this to make the token's aura look like light and interact with the scene darkness filter. If set on a player token: hide tokens not in visible 'light' auras." }
 		],
 		defaultValue: false


### PR DESCRIPTION
Reported by natemoonlife on discord - even with auras disabled and/or no darkness auraislight was taking effect.

This disables the check if darkness = 0 & auras are enabled. This also allows token sync to not be an issue between a scene fully light outside a cave vs with darkness within.