### PR TITLE
Fix - Combat Tracker initiative order on rolling groups and stop it from popping to the top of scroll

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -349,6 +349,7 @@ function ct_reorder(persist=true) {
 		});
 
 	$("#combat_area").append(items);
+	ct_update_popout();
 	if(persist)
 		ct_persist();
 }
@@ -738,6 +739,11 @@ function ct_update_popout(){
 				ct_update_popout();
 			});
 		}
+		
+		if($(window.childWindows['Combat Tracker'].document).find("tr[data-current=1]").length>0){
+			$(window.childWindows['Combat Tracker'].document).find("tr[data-current=1]")[0].scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });
+		}
+		
 	}
 }
 
@@ -835,7 +841,10 @@ function ct_load(data=null){
 	if(window.DM){
 		ct_reorder();
 	}
-	ct_update_popout();
+	else{
+		ct_update_popout();
+	}
+
 }
 
 


### PR DESCRIPTION
Sometimes initiative ends up out of order in the popup and every time a token is placed it pops to the top of scroll. This should fix it to be at the current turn.