### PR TITLE
Beta QoL - smooth transition on darkness when clicked instead of drag

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -324,11 +324,16 @@ function edit_scene_dialog(scene_id) {
 	let darknessFilterRange = $(`<input name="darkness_filter" class="darkness-filter-range" type="range" value="${darknessValue}" min="0" max="100" step="1"/>`);
 	
 	darknessFilterRange.on(' input change', function(){
+		$("#darkness_layer").toggleClass("smooth-transition", true);
 		let darknessFilterRangeValue = parseInt(darknessFilterRange.val());
    	 	let darknessPercent = 100 - darknessFilterRangeValue;
    	 	if(window.CURRENT_SCENE_DATA.id == window.ScenesHandler.scenes[scene_id].id) {
 	   	 	$('#VTT').css('--darkness-filter', darknessPercent + "%");
    		}
+   		setTimeout(function(){
+   			$("#darkness_layer").toggleClass("smooth-transition", false);
+   		}, 400);
+   		
 	});
 	darknessFilterRange.on(' mouseup', function(){
    	 	let darknessFilterRangeValue = parseInt(darknessFilterRange.val());

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4230,6 +4230,10 @@ input.max_hp[disabled]{
 }
 /*minimize windows*/
 
+#darkness_layer.smooth-transition{
+    transition: filter 350ms linear;
+}
+
 .minimized > *:not(#ct_text_title, .player_title, .monster_title, #text_controller_title), 
 #combat_tracker_title_bar.minimized:after,
 #combat_tracker_title_bar.minimized ~ *{


### PR DESCRIPTION
Reported on discord

Currently when the darkness filter is changed with a click the change can be jarring. This smooths it out.


https://user-images.githubusercontent.com/65363489/199291739-58dc1e45-cc42-480f-b183-4e57535c51b0.mp4

