### PR TITLE
 Beta Fix - remove accidently added context menu item hp roll

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1183,7 +1183,7 @@ function build_options_flyout_menu(tokenIds) {
 		let setting = token_settings[i];
 		if (allTokensAreAoe && !availableToAoe.includes(setting.name)) {
 			continue;
-		} else if(setting.hiddenSetting) {
+		} else if(setting.hiddenSetting || setting.name == 'defaultmaxhptype') {
 			continue;
 		}
 		let tokenSettings = tokens.map(t => t.options[setting.name]);


### PR DESCRIPTION
I accidently removed a if statement continue that stops the hp roll drop down from showing up in the token context menu. After they are placed this setting isn't needed in the menu.