### PR TITLE
Potential Fix - jitsi embed

### DIFF
--- a/Jitsi.js
+++ b/Jitsi.js
@@ -18,7 +18,7 @@ function create_jitsi_button() {
 }
 
 function init_jitsi(tileLayout) {
-	const domain = 'meet.jit.si';
+	const domain = '8x8.vc';
 	const options = {
 		roomName: 'aboveVTT-' + find_game_id(),
 		width: '100%',


### PR DESCRIPTION
So I found another official jitsi implementation. 8x8 offers free video that uses jitsi and acts as a relay. 

Found the server here:
https://jitsi.github.io/handbook/docs/community/community-instances/

Now I don't know if they have the same thing going on where it will lock us out when more people are using it I couldn't find any explicit limit on searches but it's currently working for me.

If we find this server also has the same limit - unless there's another free server amongst the community servers I don't see us being able to fix this.

Maybe fixes #713