### PR TITLE
Beta Fix - Update light visibility on moving with arrow keys.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -682,8 +682,7 @@ class Token {
 			self.sync(e);
 		if (self.persist != null)
 			self.persist(e);
-		/* UPDATE COMBAT TRACKER */
-		this.update_combat_tracker()
+
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 		if(playerTokenId != undefined && self.options.auraislight){
 			if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
@@ -696,6 +695,8 @@ class Token {
 		else{
 			check_single_token_visibility(self.options.id);
 		}
+		/* UPDATE COMBAT TRACKER */
+		this.update_combat_tracker()
 	}
 	update_combat_tracker(){
 		/* UPDATE COMBAT TRACKER */

--- a/Token.js
+++ b/Token.js
@@ -696,7 +696,6 @@ class Token {
 		else{
 			check_single_token_visibility(self.options.id);
 		}
-
 	}
 	update_combat_tracker(){
 		/* UPDATE COMBAT TRACKER */

--- a/Token.js
+++ b/Token.js
@@ -371,14 +371,10 @@ class Token {
 			left > this.walkableArea.right + this.options.size 
 		) { return; }
 
-		this.update_from_page();
 		this.options.top = top + 'px';
 		this.options.left = left + 'px';
 		this.place(100);
-		this.sync();
-		if (this.persist != null) {
-			this.persist();
-		}
+		this.update_and_sync();
 	}
 
 	snap_to_closest_square() {
@@ -688,6 +684,19 @@ class Token {
 			self.persist(e);
 		/* UPDATE COMBAT TRACKER */
 		this.update_combat_tracker()
+		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
+		if(playerTokenId != undefined && self.options.auraislight){
+			if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
+					check_token_visibility()
+			}
+			else{
+				check_single_token_visibility(self.options.id);
+			}	
+		}
+		else{
+			check_single_token_visibility(self.options.id);
+		}
+
 	}
 	update_combat_tracker(){
 		/* UPDATE COMBAT TRACKER */
@@ -1808,18 +1817,6 @@ class Token {
 		// this.toggle_player_owned(token)
 		toggle_player_selectable(this, token)
 		//check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
-		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-		if(playerTokenId != undefined && this.options.auraislight){
-			if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
-					check_token_visibility()
-			}
-			else{
-				check_single_token_visibility(self.options.id);
-			}	
-		}
-		else{
-			check_single_token_visibility(self.options.id);
-		}
 		console.groupEnd()
 	}
 

--- a/Token.js
+++ b/Token.js
@@ -686,19 +686,6 @@ class Token {
 			self.sync(e);
 		if (self.persist != null)
 			self.persist(e);
-		
-		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-		if(playerTokenId != undefined && self.options.auraislight){
-			if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
-					check_token_visibility()
-			}
-			else{
-				check_single_token_visibility(self.options.id);
-			}	
-		}
-		else{
-			check_single_token_visibility(self.options.id);
-		}
 		/* UPDATE COMBAT TRACKER */
 		this.update_combat_tracker()
 	}
@@ -1821,6 +1808,18 @@ class Token {
 		// this.toggle_player_owned(token)
 		toggle_player_selectable(this, token)
 		//check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
+		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
+		if(playerTokenId != undefined && this.options.auraislight){
+			if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
+					check_token_visibility()
+			}
+			else{
+				check_single_token_visibility(self.options.id);
+			}	
+		}
+		else{
+			check_single_token_visibility(self.options.id);
+		}
 		console.groupEnd()
 	}
 

--- a/Token.js
+++ b/Token.js
@@ -682,7 +682,7 @@ class Token {
 			self.sync(e);
 		if (self.persist != null)
 			self.persist(e);
-
+		
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 		if(playerTokenId != undefined && self.options.auraislight){
 			if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){


### PR DESCRIPTION
Added update_and_sync to `move(top, left)` - removed redundant code that would run twice otherwise. This fixes light revealing tokens with arrow key movement.

reported on discord: https://discord.com/channels/815028457851191326/859099351711875092/1037805722974568509