### PR TITLE
Beta Fix - Stop player card passives from wrapping when the browser is zoomed out

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3095,7 +3095,7 @@ div#importer_area>div>div:first-of-type {
 #playersFolder .player-card-info {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: center;
     align-content: center;
     align-items: center;


### PR DESCRIPTION
Reported on discord 

https://discord.com/channels/815028457851191326/859099351711875092/1037805722974568509

This should stop it from wrapping at all zoom levels of the browser