### PR TITLE
Beta Fix - Check light auras when using arrow keys

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -371,14 +371,10 @@ class Token {
 			left > this.walkableArea.right + this.options.size 
 		) { return; }
 
-		this.update_from_page();
 		this.options.top = top + 'px';
 		this.options.left = left + 'px';
 		this.place(100);
-		this.sync();
-		if (this.persist != null) {
-			this.persist();
-		}
+		this.update_and_sync();
 	}
 
 	snap_to_closest_square() {


### PR DESCRIPTION
Added update_and_sync to move(top, left) - removed redundant code that would run twice otherwise. This fixes light revealing tokens with arrow key movement.

reported on discord: https://discord.com/channels/815028457851191326/859099351711875092/1037805722974568509