### PR TITLE
QoL - ctrl/meta+a will select all text in inputs. Disable auto select on scene rows other than urls so minor adjustments can be made more easily.

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -298,6 +298,9 @@ window.addEventListener("keydown", async (event) => {
     if (event.shiftKey && arrowKeys.includes(event.key) ) {
         rotationKeyPresses.push(event.key)
     }
+    if((event.ctrlKey || event.metaKey) && event.key == 'a' && event.target.tagName == 'INPUT'){
+        event.target.select();
+    }
 });
 window.addEventListener("keyup", async (event) => {
     if (!event.shiftKey) {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -188,7 +188,7 @@ function edit_scene_dialog(scene_id) {
 			if (imageValidation){
 				rowInput = $(`<input type="text" onClick="this.select();" name=${name} style='width:100%' autocomplete="off" onblur="validate_image_input(this)" value="${scene[name] || "" }" />`);
 			}else{
-				rowInput = $(`<input type="text" onClick="this.select();" name=${name} style='width:100%' autocomplete="off" value="${scene[name] || ""}" />`);
+				rowInput = $(`<input type="text" name=${name} style='width:100%' autocomplete="off" value="${scene[name] || ""}" />`);
 			}
 			 
 		}


### PR DESCRIPTION
This has ctrl/meta+a run `select()` if pressed when focusing an `input`. Also removes the auto select from scene rows other than urls so minor adjustments/highlighting can be done more easily. 