### PR TITLE
Fix - Clearing/updating current turn and round properly from tokens on del/clear/scene swap

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -806,7 +806,15 @@ function ct_load(data=null){
 			}		
 		}
 		if(data.current){
+			for (tokenID in window.TOKEN_OBJECTS){
+				if(window.TOKEN_OBJECTS[tokenID].options.current != undefined){
+					delete window.TOKEN_OBJECTS[tokenID].options.current;
+					window.TOKEN_OBJECTS[tokenID].update_and_sync();
+				}
+			}
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
+			window.TOKEN_OBJECTS[data.current].options.current = true;
+			window.TOKEN_OBJECTS[data.current].update_and_sync();
 		}
 		else{
 			for (tokenID in window.TOKEN_OBJECTS){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -203,8 +203,11 @@ function init_combat_tracker(){
 			ct_remove_token(window.all_token_objects[id], false);
 			if(window.TOKEN_OBJECTS[id] != undefined){
 				window.TOKEN_OBJECTS[id].options.ct_show = undefined;
-				if(window.TOKEN_OBJECTS[id].round != undefined){
+				if(window.TOKEN_OBJECTS[id].options.round != undefined){
 					delete window.TOKEN_OBJECTS[tokenID].options.round;	
+				}
+				if(window.TOKEN_OBJECTS[id].options.current != undefined){
+					delete window.TOKEN_OBJECTS[tokenID].options.current;	
 				}
 				window.TOKEN_OBJECTS[id].update_and_sync();
 			}
@@ -588,7 +591,13 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	del.click(
 		function(){
 			if(window.TOKEN_OBJECTS[token.options.id] != undefined){
-				window.TOKEN_OBJECTS[token.options.id].options.ct_show = undefined;
+				window.TOKEN_OBJECTS[token.options.id].options.ct_show = undefined;	
+				if(window.TOKEN_OBJECTS[id].options.round != undefined){
+					delete window.TOKEN_OBJECTS[tokenID].options.round;	
+				}
+				if(window.TOKEN_OBJECTS[id].options.current != undefined){
+					delete window.TOKEN_OBJECTS[tokenID].options.current;	
+				}
 				window.TOKEN_OBJECTS[token.options.id].update_and_sync();
 			}
 			if(window.all_token_objects[token.options.id] != undefined){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -807,14 +807,17 @@ function ct_load(data=null){
 		}
 		if(data.current){
 			for (tokenID in window.TOKEN_OBJECTS){
-				if(window.TOKEN_OBJECTS[tokenID].options.current != undefined){
+				if(window.TOKEN_OBJECTS[tokenID].options.current != undefined && tokenID != data.current){
 					delete window.TOKEN_OBJECTS[tokenID].options.current;
 					window.TOKEN_OBJECTS[tokenID].update_and_sync();
 				}
 			}
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
-			window.TOKEN_OBJECTS[data.current].options.current = true;
-			window.TOKEN_OBJECTS[data.current].update_and_sync();
+			if(window.TOKEN_OBJECTS[data.current] != undefined){
+				window.TOKEN_OBJECTS[data.current].options.current = true;
+				window.TOKEN_OBJECTS[data.current].update_and_sync();
+			}
+
 		}
 		else{
 			for (tokenID in window.TOKEN_OBJECTS){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -204,10 +204,10 @@ function init_combat_tracker(){
 			if(window.TOKEN_OBJECTS[id] != undefined){
 				window.TOKEN_OBJECTS[id].options.ct_show = undefined;
 				if(window.TOKEN_OBJECTS[id].options.round != undefined){
-					delete window.TOKEN_OBJECTS[tokenID].options.round;	
+					delete window.TOKEN_OBJECTS[id].options.round;	
 				}
 				if(window.TOKEN_OBJECTS[id].options.current != undefined){
-					delete window.TOKEN_OBJECTS[tokenID].options.current;	
+					delete window.TOKEN_OBJECTS[id].options.current;	
 				}
 				window.TOKEN_OBJECTS[id].update_and_sync();
 			}
@@ -592,11 +592,11 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		function(){
 			if(window.TOKEN_OBJECTS[token.options.id] != undefined){
 				window.TOKEN_OBJECTS[token.options.id].options.ct_show = undefined;	
-				if(window.TOKEN_OBJECTS[id].options.round != undefined){
-					delete window.TOKEN_OBJECTS[tokenID].options.round;	
+				if(window.TOKEN_OBJECTS[token.options.id].options.round != undefined){
+					delete window.TOKEN_OBJECTS[token.options.id].options.round;	
 				}
-				if(window.TOKEN_OBJECTS[id].options.current != undefined){
-					delete window.TOKEN_OBJECTS[tokenID].options.current;	
+				if(window.TOKEN_OBJECTS[token.options.id].options.current != undefined){
+					delete window.TOKEN_OBJECTS[token.options.id].options.current;	
 				}
 				window.TOKEN_OBJECTS[token.options.id].update_and_sync();
 			}


### PR DESCRIPTION
Reported by Garrett on discord https://discord.com/channels/815028457851191326/852495991227809802/1039699690557546597


This should clear those values properly on del/clear. 

Edit: This also looks like it was happening on scene swaps where it was updated for the session but not saved under certain circumstances. Added a fix for that as well.