### PR TITLE
Fix - Auras updating unexpectedly on copied tokens (nested variables in token options were still being pointed to each other)

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -2695,7 +2695,7 @@ function paste_selected_tokens() {
 		let id = window.TOKEN_PASTE_BUFFER[i];
 		let token = window.all_token_objects[id];
 		if (token == undefined || token.isPlayer()) continue; // only allow copy/paste for monster tokens, and protect against pasting deleted tokens
-		let options = Object.assign({}, token.options);
+		let options = $.extend(true, {}, token.options);
 		let newId = uuid();
 		options.id = newId;
 		// TODO: figure out the location under the cursor and paste there instead of doing center of view


### PR DESCRIPTION
Reported by natemoonlife on discord https://discord.com/channels/815028457851191326/815028804103307354/1041084687197687908

This changes the `token.options` copy function from `Object.assign`  to `$.extend(true,..`. This goes from a shallow copy where nested items still reference each other to a deep copy where they aren't. 

This should fix any nested options that are used like auras for copied tokens.