### PR TITLE
QoL - Disable ping when not on select tool (stop pings when drawing polygons and other drawings)

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2755,6 +2755,8 @@ function init_ui() {
 	darknessLayer.css("left", "0");
 
 	tempOverlay.dblclick(function(e) {
+		if(window.DRAWFUNCTION != 'select')
+			return;
 		e.preventDefault();
 
 		var mousex = Math.round((e.pageX - 200) * (1.0 / window.ZOOM));


### PR DESCRIPTION
This returns the double click function if not on the select tool for pings. I've found when drawing/fog polygons especially it pings frustratingly often. This should reduce messages and avoid unnesecarry pings.