### PR TITLE
Fix video map volume for sources other than youtube

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -428,7 +428,7 @@ function load_scenemap(url, is_video = false, width = null, height = null, callb
 			newmapSize = 'width: ' + width + 'px; height: ' + height + 'px;';
 		}
 
-		var newmap = $(`<video style="${newmapSize} position: absolute; top: 0; left: 0;z-index:10" playsinline autoplay loop onloadstart="${$(this).prop('volume', $("#youtube_volume").val()/100)}" id="scene_map" src="${url}" />`);
+		var newmap = $(`<video style="${newmapSize} position: absolute; top: 0; left: 0;z-index:10" playsinline autoplay loop onloadstart="this.volume=${$("#youtube_volume").val()/100}" id="scene_map" src="${url}" />`);
 		newmap.on("loadeddata", callback);
 		newmap.on("error", map_load_error_cb);
 

--- a/Main.js
+++ b/Main.js
@@ -428,7 +428,7 @@ function load_scenemap(url, is_video = false, width = null, height = null, callb
 			newmapSize = 'width: ' + width + 'px; height: ' + height + 'px;';
 		}
 
-		var newmap = $('<video style="' + newmapSize + ' position: absolute; top: 0; left: 0;z-index:10" playsinline autoplay muted loop id="scene_map" src="' + url + '" />');
+		var newmap = $(`<video style="${newmapSize} position: absolute; top: 0; left: 0;z-index:10" playsinline autoplay loop onloadstart="${$(this).prop('volume', $("#youtube_volume").val()/100)}" id="scene_map" src="${url}" />`);
 		newmap.on("loadeddata", callback);
 		newmap.on("error", map_load_error_cb);
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -663,7 +663,6 @@ class MessageBroker {
 				audio_changesettings(msg.data.channel,msg.data.volume,msg.data.loop);
 			}
 			if(msg.eventType=="custom/myVTT/changeyoutube"){
-				if(window.YTPLAYER){
 					$("#youtube_volume").val(msg.data.volume);
 					if(window.YTPLAYER)
 					{
@@ -672,7 +671,6 @@ class MessageBroker {
 					else{
 						$("#scene_map").prop("volume", msg.data.volume/100);
 					}
-				}
 			}
 
 			if (msg.eventType == "custom/myVTT/playerdata") {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -666,7 +666,12 @@ class MessageBroker {
 				if(window.YTPLAYER){
 					$("#youtube_volume").val(msg.data.volume);
 					if(window.YTPLAYER)
+					{
 						window.YTPLAYER.setVolume(msg.data.volume);
+					}
+					else{
+						$("#scene_map").prop("volume", msg.data.volume/100);
+					}
 				}
 			}
 

--- a/SoundPad.js
+++ b/SoundPad.js
@@ -385,6 +385,9 @@ function init_audio(){
 			};
 			window.MB.sendMessage("custom/myVTT/changeyoutube",data);
 		}
+		else{
+			$("#scene_map").prop("volume", $("#youtube_volume").val()/100);
+		}
 	});
 	
 	if(!window.DM)


### PR DESCRIPTION
Since the video tag had 'muted' as a property no audio would play for sources other than youtube.

This allows sources like Gdrive videos to have functioning audio and has the audio slider apply to them