### PR TITLE
QoL - when inputs are focused keep context menu open

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4598,7 +4598,8 @@ input.max_hp[disabled]{
 }
 
 .flyout-from-menu-item:hover ~ .context-menu-flyout,
-.context-menu-flyout:hover {
+.context-menu-flyout:hover,
+.context-menu-flyout:focus-within {
     visibility: visible;
     transition-delay: 0ms;
 }


### PR DESCRIPTION
Pointed out on discord by addroddyn. Context menu flyouts if the mouse is moved out of them when trying to type in an input it will hide the flyout. 

This sets focus-within to keep it visible when focusing an input.