### PR TITLE
QoL - Allow hp bars to be larger for custom size tokens.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -737,8 +737,6 @@ class Token {
 		var self = this;
 		var bar_height = this.sizeHeight() * 0.2;
 
-		if (bar_height > 60)
-			bar_height = 60;
 
 		bar_height = Math.ceil(bar_height);
 		var hpbar = $("<div class='hpbar'/>");
@@ -750,6 +748,8 @@ class Token {
 		hpbar.toggleClass('tiny-or-smaller', false);
 		
 		let tokenWidth = this.sizeWidth() / window.CURRENT_SCENE_DATA.hpps;
+		if(tokenWidth >= 10)
+			hpbar.toggleClass('greater-than-10-wide', true);
 		if(tokenWidth < 2 && tokenWidth >= 1)
 			hpbar.toggleClass('medium', true);
 		if(tokenWidth < 1)
@@ -761,8 +761,6 @@ class Token {
 		hpbar.css("--font-size",fs);
 
 		var input_width = Math.floor(this.sizeWidth() * 0.3);
-		if (input_width > 90)
-			input_width = 90;
 
 		var hp_input = $("<input class='hp'>").css('width', input_width)
 		hp_input.val(this.options.hp);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1281,6 +1281,11 @@ div#combat_button{
     transform: translateX(-50%) scale(min(max(1, 0.5/var(--window-zoom)), 3));
     transition: 250ms transform linear 500ms;
 }
+
+.hpbar.greater-than-10-wide:focus-within,
+.hpbar.greater-than-10-wide:hover{
+    transform: translateX(-50%);
+}
 .hpbar.medium:focus-within,
 .hpbar.medium:hover{
     transform: translateX(-50%) scale(min(max(1, 1/var(--window-zoom)), 5));


### PR DESCRIPTION
Reported in discord as a bug by Harknail.

Large custom tokens like ships in spelljammer have their AC still increase in size but not the health bar.

Example image
https://cdn.discordapp.com/attachments/815028804103307354/1046901960143556628/image.png


This allows them to scale properly and I've chosen 10 units wide to be large enough to not scale the hp bar at all based on zoom as it's still large enough to view at furthest zoom in my opinion.