### PR TITLE
QoL - Allow token image split urls on `, ` (comma space). Allows mass add of gdrive images easily or other images with comma seperation.

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -20,6 +20,10 @@ function parse_img(url){
 		return "";
 	}
 	retval = url;
+	if(retval.startsWith("data:")){
+		alert("You cannot use urls starting with data:");
+		return "";
+	}
 	if (retval.startsWith("https://drive.google.com") && retval.indexOf("uc?id=") < 0) {
 		retval = 'https://drive.google.com/uc?id=' + retval.split('/')[5];
 	} else if (retval.includes("dropbox.com") && retval.includes("?dl=")) {

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -216,7 +216,10 @@ class SidebarPanel {
           if(imageUrl.startsWith("data:")){
             alert("You cannot use urls starting with data:");
           } else {
-            imageUrlEntered(parse_img(imageUrl));
+            let imageUrlSplit = imageUrl.split(', ');
+            for(i = 0; i < imageUrlSplit.length; i++){
+              imageUrlEntered(parse_img(imageUrlSplit[i]));
+            }      
           }
         }
     );


### PR DESCRIPTION
Gdrive gives multilinks a comma seperated this would allow quick addition of those links to tokens.

Example video:
https://discord.com/channels/815028457851191326/815028716040224818/1051686680551235604