### PR TITLE
Add table and code button to Journal

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -367,8 +367,8 @@ class JournalManager{
 		tinyMCE.init({
 			selector: '#' + tmp,
 			menubar: false,
-			plugins: 'save,hr,image,link,lists,media,paste,tabfocus,textcolor,colorpicker,autoresize',
-			toolbar1: 'undo,|,paste,|,bold,|,italic,|,underline,|,strikethrough,|,blockquote,|,alignleft,|,aligncenter,|,alignright,|,outdent,|,indent,|,bullist,|,numlist,|,forecolor,|,backcolor,|,fontselect,|,fontsizeselect,|,formatselect,|,removeformat,|,hr,link,|,unlink,|,image,|,media',
+			plugins: 'save,hr,image,link,lists,media,paste,tabfocus,textcolor,colorpicker,autoresize, code, table',
+			toolbar1: 'undo,|,paste,|,bold,|,italic,|,underline,|,strikethrough,|,blockquote,|,alignleft,|,aligncenter,|,alignright,|,outdent,|,indent,|,bullist,|,numlist,|,forecolor,|,backcolor,|,fontselect,|,fontsizeselect,|,formatselect,|,removeformat,|,hr,link,|,unlink,|,image,|,media,|,table,|,code',
 			image_class_list: [
 				{title: 'None', value: ''},
 				{title: 'Magnify', value: 'magnify'},


### PR DESCRIPTION
These buttons are available on dndbeyond's tinymce and I think they'd be quite useful to have.

Example:
![image](https://user-images.githubusercontent.com/65363489/208417385-035fbafb-7ca7-4d0a-ac39-ccea26c7a739.png)
