### PR TITLE
Allow players to join as dm - with some minor differences either due to DnDBeyond permissions or stuff we save local still (eg. notes require export/import since still local)

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -3220,11 +3220,11 @@ $(function() {
 	// SCB: Append our logo
 	contentDiv.append($("<img class='above-vtt-logo above-vtt-right-margin-5px' width='120px' src='" + window.EXTENSION_PATH + "assets/logo.png'>"));
 
-	if(is_dm) {
+	
 		contentDiv.append($("<a class='above-vtt-campaignscreen-blue-button above-vtt-right-margin-5px button joindm btn modal-link ddb-campaigns-detail-body-listing-campaign-link' style='position:relative'>JOIN AS DM</a>"));
 		warningDiv.append($("<a class='ddb-campaigns-warning-div' style='color: #333; padding-left: 15%'>If you press 'RESET INVITE LINK' you will lose your cloud data!</a>"));
 		warningtitleDiv.append($("<a class='above-vtt-warning-secondary-div' style='color: #c53131; font-weight: 900; font-size: 16px; font-family: roboto; background-color: #fff; border: 2px solid #c53131; border-radius: 4px; padding: 10px 145px 30px 145px;'>WARNING FOR ABOVEVTT!!!</a>"));
-	}
+	
 
 	$(".ddb-campaigns-character-card-footer-links").each(function() {
 		if($(this).find(".ddb-campaigns-character-card-footer-links-item-edit").length == 0)


### PR DESCRIPTION
This mostly seems to work as expected again after the changes that have been made since removal of this feature. I think it would be worth while to enable this feature again - it does get requested semi-often.

Things that work:
- Scenes
- Monster sheets
- Tokens already placed on map (not notes requires export/import)
- Combat tracker
- Drawing, fog and other tools


Some differences other than the above:
- Players still only have access to view other player sheets as they would on DnDBeyond
- Journals, audio are still saved locally so exports/imports might be required to move these between DM's.
- Token customizations (similar to above stored locally - requires import/export)