### PR TITLE
Beta Fix - Fix scaled map size/position: Remove map, darkness layer from scaled css selectors as the new container is already scaled

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5052,9 +5052,7 @@ div.ddbc-tab-options--layout-pill>button{
 #fog_overlay,
 #text_overlay,
 #draw_overlay,
-#darkness_layer,
 #scene_map_container,
-#scene_map,
 #grid_overlay{
     transform: scale(var(--scene-scale));
     transform-origin: top left;


### PR DESCRIPTION
since these are now in the container remove the selectors otherwise we don't see the whole map