### PR TITLE
Beta Fix - Different Mask for transparent edges of map (Chrome fix for transparent edges of maps)

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5038,7 +5038,7 @@ div.ddbc-tab-options--layout-pill>button{
 
 }
 #scene_map_container:not(.video){
-    -webkit-mask-image: var(--scene-url);
+    -webkit-mask-box-image: var(--scene-url);
 }
 #scene_map_container{
     overflow: clip;


### PR DESCRIPTION
So this is actually a CORS issue. When the issue happens most mask types are blocked. In chrome -webkit-mask-box-image works. I don't think there's a work around for firefox unless we can detect which have CORS errors and which don't. This is tested with discord images that have the CORS issue. 

If there is a way to detect when the CORS issue happens we could have it working on all non CORS issue maps but I can't quite figure out how to capture that error and do stuff. If anyone has any ideas on that let me know. 

------

~~I haven't had a chance to make sure this works player side due to dndbeyond issues. I don't see why it wouldn't be just to be safe. I'll report back when player sheets come back online.~~ Works.

There are some sources/images that just don't like the other css mask for some reason. Tested this with Musashi and seems to fix the issue. 

White circle is an aura the 'map' is the other thing lol.

![image](https://user-images.githubusercontent.com/65363489/216783810-a4872bcd-7103-46a0-bd58-a99d5b031a70.png)


If we don't have the mask this is what we'd be looking at: 
![image](https://user-images.githubusercontent.com/65363489/216783961-de42c192-b677-415c-b062-4807dbc8479c.png)
