### PR TITLE
Beta fix - white behind transparent maps for all browsers and bump up DM max darkness a bit so darker maps are still visible.

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -438,7 +438,9 @@ function load_scenemap(url, is_video = false, width = null, height = null, callb
 		if (width == null) {
 			newmap.on("loadedmetadata", function (e) {
 				console.log("video width:", this.videoWidth);
-				console.log("video height:", this.videoHeight);;
+				console.log("video height:", this.videoHeight);
+				$('#scene_map').width(this.videoWidth);
+				$('#scene_map').height(this.videoHeight);
 				$("#scene_map_container").toggleClass('map-loading', false);
 			});
 		}

--- a/Main.js
+++ b/Main.js
@@ -414,8 +414,6 @@ function load_scenemap(url, is_video = false, width = null, height = null, callb
 			newmap.height(height);
 		}
 		newmap.on("load", () => {
-			$("#scene_map_container").css("width", $("#scene_map").width())
-			$("#scene_map_container").css("height", $("#scene_map").height())
 			$("#scene_map_container").toggleClass('map-loading', false);
 		});
 		if (callback != null) {	
@@ -440,17 +438,11 @@ function load_scenemap(url, is_video = false, width = null, height = null, callb
 		if (width == null) {
 			newmap.on("loadedmetadata", function (e) {
 				console.log("video width:", this.videoWidth);
-				console.log("video height:", this.videoHeight);
-				$('#scene_map').width(this.videoWidth);
-				$('#scene_map').height(this.videoHeight);
-				$("#scene_map_container").css("width", $("#scene_map").width());
-				$("#scene_map_container").css("height", $("#scene_map").height());
+				console.log("video height:", this.videoHeight);;
 				$("#scene_map_container").toggleClass('map-loading', false);
 			});
 		}
 		else{
-			$("#scene_map_container").css("width", width);
-			$("#scene_map_container").css("height", height);
 			$("#scene_map_container").toggleClass('map-loading', false);
 		}
 		$("#scene_map_container").append(newmap);

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1363,7 +1363,6 @@ class MessageBroker {
 
 			$("#scene_map").width(window.CURRENT_SCENE_DATA.width);
 			$("#scene_map").height(window.CURRENT_SCENE_DATA.height);
-			$("#VTT").css('--scene-url', `url('${data.map}')`);
 			$("#VTT").css("--scene-scale", scaleFactor)
 			
 
@@ -1375,8 +1374,8 @@ class MessageBroker {
 
 
    	 	let darknessPercent = 100 - parseInt(window.CURRENT_SCENE_DATA.darkness_filter);
-   	 	if(window.DM && darknessPercent < 10){
-   	 		darknessPercent = 10;
+   	 	if(window.DM && darknessPercent < 25){
+   	 		darknessPercent = 25;
    	 	}
    	 	$('#VTT').css('--darkness-filter', darknessPercent + "%");
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5030,6 +5030,7 @@ div.ddbc-tab-options--layout-pill>button{
 }
 #scene_map{
     mix-blend-mode: multiply;
+    background:#000;
 }
 #darkness_layer{
     z-index: 8;
@@ -5037,9 +5038,7 @@ div.ddbc-tab-options--layout-pill>button{
     filter: brightness(var(--darkness-filter));
 
 }
-#scene_map_container:not(.video){
-    -webkit-mask-image: var(--scene-url);
-}
+
 #scene_map_container{
     overflow: clip;
     transition: opacity 1.5s linear 0s;


### PR DESCRIPTION
So Nate turned me towards the simple solution here. Just make the image background black. Fixes the issues completely. Maps load without being masked due to CORS issue and we don't get white areas around transparent maps. 

Since certain image sources were giving errors on masks this is the best workaround. Also simpler/less processing than what I was doing before anyway. I removed the previous code I tried to fix it with since it's no longer necesarry.

Thanks to Nate for the assist.


I also reduced the darkness max for DMs again as dark maps were hard to see still. This should be a bit better - we can always adjust further based on feedback.


---
Firefox player left - chrome DM right
![image](https://user-images.githubusercontent.com/65363489/216790404-9345657e-bd6b-4877-a246-0dbc1631f73e.png)
