### PR TITLE
Editable, Moveable, adjusts with scale changes to stay in postion and better quality text

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -828,11 +828,13 @@ function redraw_text() {
 	$('#text_div').empty();
 	for(drawing in window.DRAWINGS){
 		const [shape, x, y, width, height, text, font, stroke, rectColor, textid, scale] = window.DRAWINGS[drawing]
+
 		if(shape == 'text' && textid == undefined){
 			let newTextId = uuid();
+			setScale = (window.CURRENT_SCENE_DATA.scale_factor == "") ? 1 : window.CURRENT_SCENE_DATA.scale_factor;
 			window.DRAWINGS[drawing].push(rectColor);
 			window.DRAWINGS[drawing].push(newTextId);
-			window.DRAWINGS[drawing].push(window.CURRENT_SCENE_DATA.scale_factor)
+			window.DRAWINGS[drawing].push(setScale);
 		}
    		if(shape == 'text')
 			draw_text(undefined, ...window.DRAWINGS[drawing]);	
@@ -1624,7 +1626,7 @@ function handle_drawing_button_click() {
 		else{
 			$("#temp_overlay").css("z-index", "50")
 		}
-		if ($(clicked).is("#text_button")){
+		if ($(clicked).is("#text_button") && $("#text_button #text_select").hasClass('ddbc-tab-options__header-heading--is-active')){
 			$("#text_div").css("z-index", "51")
 		}
 		else{

--- a/Fog.js
+++ b/Fog.js
@@ -1626,7 +1626,7 @@ function handle_drawing_button_click() {
 		else{
 			$("#temp_overlay").css("z-index", "50")
 		}
-		if ($(clicked).is("#text_button") && $("#text_button #text_select").hasClass('ddbc-tab-options__header-heading--is-active')){
+		if (($(clicked).is("#text_button") ||$(clicked).is("#text_select")) && $("#text_select").hasClass('ddbc-tab-options__header-heading--is-active')){
 			$("#text_div").css("z-index", "51")
 		}
 		else{

--- a/Main.js
+++ b/Main.js
@@ -2807,11 +2807,11 @@ function init_ui() {
 	drawOverlay.css("left", "0");
 	drawOverlay.css("z-index", "18");
 
-	const textOverlay = $("<canvas id='text_overlay'></canvas>");
-	textOverlay.css("position", "absolute");
-	textOverlay.css("top", "0");
-	textOverlay.css("left", "0");
-	textOverlay.css("z-index", "18");
+	const textDiv = $("<div id='text_div'></div>");
+	textDiv.css("position", "absolute");
+	textDiv.css("top", "0");
+	textDiv.css("left", "0");
+	textDiv.css("z-index", "20");
 
 	const grid = $("<canvas id='grid_overlay'></canvas>");
 	grid.css("position", "absolute");
@@ -2824,7 +2824,7 @@ function init_ui() {
 	fog.css("top", "0");
 	fog.css("left", "0");
 	fog.css("position", "absolute");
-	fog.css("z-index", "20");
+	fog.css("z-index", "21");
 
 	// this overlay sits above all other canvases
 	// we draw to this and then bake the image into the corresponding
@@ -2901,7 +2901,7 @@ function init_ui() {
 	VTT.append(fog);
 	VTT.append(grid);
 	VTT.append(drawOverlay);
-	VTT.append(textOverlay);
+	VTT.append(textDiv);
 	VTT.append(tempOverlay);
 	mapContainer.append(darknessLayer);
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1372,8 +1372,7 @@ class MessageBroker {
 
 			reset_canvas();
 			redraw_fog();
-			redraw_drawings();
-			redraw_text();
+
 			apply_zoom_from_storage();
 
 

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -185,7 +185,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			reset_canvas();
 			redraw_fog();
 			redraw_drawings();
-			redraw_text()
+			redraw_text();
 			$("#VTT").css("transform", "scale(" + window.ZOOM + ")");
 
 			set_default_vttwrapper_size()

--- a/Text.js
+++ b/Text.js
@@ -586,7 +586,7 @@ function draw_text(
     if($(`svg[id='${id}']`).length>0)
         return;
     if(rectColor == null)
-        rectcolor = 'transparent';
+        rectColor = 'transparent';
 
     let adjustScale = (scale/window.CURRENT_SCENE_DATA.scale_factor);   
 
@@ -616,7 +616,7 @@ function draw_text(
             <title>${text}</title>
             <rect x="0" y="0" width="${width}" height="${height}" style="fill:${rectColor}"/>
             <g style="text-anchor: ${anchor}; font-size:${font.size}px; font-style:${font.style}; font-weight: ${font.weight}; text-decoration: ${underline}; font-family: ${font.font};">
-            <text x="${x}" y="${font.size}" style="fill: ${font.color}; stroke: ${stroke.color}; stroke-width: ${stroke.size}; filter:${shadowStyle};stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;">${textPart}</text>
+            <text x="${x}" y="${font.size}" style="fill: ${font.color}; stroke: ${stroke.color}; stroke-width: ${stroke.size}; filter:${shadowStyle};stroke-linecap:butt;stroke-linejoin:round;paint-order:stroke;stroke-opacity:1;">${textPart}</text>
             </g>
          </svg>
     `);

--- a/Text.js
+++ b/Text.js
@@ -52,6 +52,7 @@ function apply_settings_to_boxes(){
         "background-color": window.TEXTDATA.text_background_color,
         "font-family": window.TEXTDATA.text_font,
         "font-size": `calc(${window.TEXTDATA.text_size}px * var(--window-zoom))`,
+        "line-height": `calc(${window.TEXTDATA.text_size}px * var(--window-zoom))`,
         "font-weight": window.TEXTDATA.text_bold ? "bold" : "normal",
         "font-style": window.TEXTDATA.text_italic ? "italic" : "normal",
         "text-decoration": window.TEXTDATA.text_underline ? "underline" : "none",
@@ -319,7 +320,7 @@ function create_text_controller() {
  * @param {Number} height height of text area
  * @returns a div which has the title bar with submit/close buttons and a text area
  */
-function create_moveable_text_box(x,y,width, height) {
+function create_moveable_text_box(x,y,width, height, text = undefined) {
     const textInputInside = $(`<div class="text-input-inside"/>`);
     textInputInside.css({
         "position": "fixed",
@@ -400,9 +401,11 @@ function create_moveable_text_box(x,y,width, height) {
         title="Input your text, this is an approximation of your final text"
         type="text" autocomplete="off"/>`
     );
+    if(text != undefined)
+        input.val(text)
     textInputInside.append(input)
     $(input).css({
-        "white-space": "nowrap",
+        "white-space": "pre-wrap",
         "overflow": "hidden"
     });
     
@@ -431,6 +434,7 @@ function handle_auto_resize(e){
     width,
     height,
     linewidth,
+    editTextID = undefined
 ]) {
     create_text_controller()
     create_moveable_text_box(x,y,width, height);
@@ -438,7 +442,7 @@ function handle_auto_resize(e){
 
 
 /**
- * Bakes the text and rectangle into the text_overlay canvas layer
+ * Bakes the text into the text_div layer
  * @param {Event} event 
  * @returns 
  */
@@ -480,23 +484,9 @@ function handle_draw_text_submit(event) {
         size: parseInt($(textBox).css("-webkit-text-stroke-width")) / window.ZOOM,
         color: $(textBox).css("-webkit-text-stroke-color"),
     };
-    // only draw a rect if it's not fully transparent
-    let data = [];
-    if (!is_rgba_fully_transparent(rectColor)) {
-        data = [
-            "text-rect",
-            "filled",
-            rectColor,
-            rectX,
-            rectY,
-            width,
-            height,
-            window.LINEWIDTH,
-        ];
-        window.DRAWINGS.push(data);
-    }
     // data should match params in draw_text
     // push the starting position of y south based on the font size
+    let textid = uuid();
     data = ["text",
         rectX,
         rectY + font.size,
@@ -504,15 +494,16 @@ function handle_draw_text_submit(event) {
         height,
         text,
         font,
-        stroke
+        stroke,
+        rectColor,
+        textid,
+        window.CURRENT_SCENE_DATA.scale_factor
     ];
     // bake this data and redraw all text
     window.DRAWINGS.push(data);
     $(".text-input-title-bar-exit").click();
-    redraw_text()
-    window.ScenesHandler.persist();
-    if (window.CLOUD) sync_drawings();
-    else window.MB.sendMessage("custom/myVTT/drawing", data);
+    redraw_text();
+    sync_drawings();
 
 }
 
@@ -566,7 +557,7 @@ function get_x_start_and_width_of_text(x, width, text, font, stroke) {
 
 /**
  * Draw the text to the text overlay using the data in window.DRAWINGS
- * @param {*} context html canvas context for text_overlay
+ * @param {*} This is no longer used will clean up later - was text canvas ctx but canvas is no longer used
  * @param {String} type aka shape, not used
  * @param {Number} startingX starting position text background
  * @param {Number} startingY starting positon text background
@@ -575,6 +566,7 @@ function get_x_start_and_width_of_text(x, width, text, font, stroke) {
  * @param {String} text the value to be drawn
  * @param {Object} font font styling object
  * @param {Object} stroke stroke styling object
+ * @param {String} text unique id
  */
 function draw_text(
     context,
@@ -586,68 +578,113 @@ function draw_text(
     text,
     font,
     stroke,
+    rectColor = 'transparent',
+    id = '',
+    scale = window.CURRENT_SCENE_DATA.scale_factor
 ) {
-    context.font = `${font.weight} ${font.style} ${font.size/window.CURRENT_SCENE_DATA.scale_factor}px ${font.font}`;
-    context.strokeStyle = stroke.color;
-    context.lineWidth = stroke.size/window.CURRENT_SCENE_DATA.scale_factor;
-    context.fillStyle = font.color;
 
-    const lines = text.split(/\r?\n/);
-    // these values are modified per line depending on the line width
-    // and the alignment used
-    let x = startingX/window.CURRENT_SCENE_DATA.scale_factor;
-    let y = startingY/window.CURRENT_SCENE_DATA.scale_factor;
-    // draw stroke text first
+    if($(`svg[id='${id}']`).length>0)
+        return;
+
+
+    let adjustScale = (scale/window.CURRENT_SCENE_DATA.scale_factor);   
+
+    font.size = font.size / adjustScale
+    stroke.size = stroke.size / adjustScale
+    width = width / adjustScale 
+    height = height / adjustScale 
+    startingX = startingX / adjustScale 
+    startingY = startingY / adjustScale
+
+    let shadowStyle ='';
     if (font.shadow && font.shadow !== "none"){
         const shadowRegex = /(rgb\(.*\))\s(\d+px)\s(\d+px)\s(\d+px)/
         const [_, shadowColor, shadowOffsetX, shadowOffsetY, shadowBlur ] = font.shadow.match(shadowRegex)
-        context.filter = `drop-shadow(${shadowOffsetX} ${shadowOffsetY} ${shadowBlur} ${shadowColor})`
+        shadowStyle = `drop-shadow(${shadowOffsetX} ${shadowOffsetY} ${shadowBlur} ${shadowColor})`
     }
     
-    lines.forEach((line) => {
-        const [textX, textWidth] = get_x_start_and_width_of_text(
-            x,
-            width,
-            line,
-            font,
-            stroke
-        );
+    let x = (font.align == 'right') ? '100%' : ((font.align=='center') ? '50%' : '0');
+    let anchor = (font.align == 'right') ? 'end' : ((font.align=='center') ? 'middle' : 'start');
+    let underline = (font.underline == true) ? 'underline' : 'none';
 
-        // const textMetrics = context.measureText(line)
+    let fontSize=font.size; 
+    let lineHeight=12;  
+    let textPart=text.split('\n').map(function(returnSplitText,i){ return `<tspan x="${x}" y="${font.size+i*fontSize}">${returnSplitText}</tspan>`}).join('\n');
+    let textSVG = $(`
+        <svg id='${id}' width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" style="left: ${startingX}px; top: ${startingY-font.size}px; position:absolute; z-index: 500">
+            <title>${text}</title>
+            <rect x="0" y="0" width="${width}" height="${height}" style="fill:${rectColor}"/>
+            <g style="text-anchor: ${anchor}; font-size:${font.size}px; font-style:${font.style}; font-weight: ${font.weight}; text-decoration: ${underline}; font-family: ${font.font};">
+            <text x="${x}" y="${font.size}" style="fill: ${font.color}; stroke: ${stroke.color}; stroke-width: ${stroke.size}; filter:${shadowStyle};stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;">${textPart}</text>
+            </g>
+         </svg>
+    `);
 
-        context.strokeText(line, textX, y);
-        // underlining isn't perfect
-        if (font.underline) {
-            drawLine(
-                context,
-                textX,
-                y + font.size / 10,
-                textX + textWidth,
-                y + font.size / 10,
-                stroke.color,
-                font.size / 10
-            );
+ 
+    $('#text_div').append(textSVG);
+
+
+
+    textSVG.draggable({
+        containment: '#text_div',
+        start: function () {
+            $("#resizeDragMon").append($('<div class="iframeResizeCover"></div>'));
+            $("#sheet").append($('<div class="iframeResizeCover"></div>'));
+        },
+        drag: function(event,ui)
+        {
+            ui.position.top = Math.round((ui.position.top - 200) / window.ZOOM );
+            ui.position.left = Math.round((ui.position.left - 200) / window.ZOOM );
+
+        },  
+        stop: function (event, ui) {
+            $('.iframeResizeCover').remove();
+            
+            for(drawing in window.DRAWINGS){
+                if(window.DRAWINGS[drawing][9] != id)
+                    continue;
+                window.DRAWINGS[drawing][1] = parseInt($(this).css('left'));
+                window.DRAWINGS[drawing][2] = parseInt($(this).css('top')) + parseInt(font.size);     
+            }
+                        
+        
+            window.ScenesHandler.persist();
+            if(window.CLOUD)
+                sync_drawings();
+            else
+                window.MB.sendMessage('custom/myVTT/drawing', data);
         }
-
-        y += font.size;
     });
-    // loop the lines again as large stroke size will overlap the fill text
-    // so add fill text in last
-    x = startingX/window.CURRENT_SCENE_DATA.scale_factor;
-    y = startingY/window.CURRENT_SCENE_DATA.scale_factor;
-  
-    context.filter = "none"
-    lines.forEach((line) => {
 
-        const [textX, textWidth] = get_x_start_and_width_of_text(
-            x,
-            width,
-            line,
-            font,
-            stroke
-        );
-        context.fillText(line, textX, y);
-        y += font.size;
+
+
+    textSVG.on('dblclick', function(){
+        create_text_controller();
+
+        window.TEXTDATA = [];
+        window.TEXTDATA.text_alignment = font.align;
+        window.TEXTDATA.text_color = font.color;
+        window.TEXTDATA.text_background_color = rectColor;
+        window.TEXTDATA.text_font = font.font;
+        window.TEXTDATA.text_size = font.size;
+        window.TEXTDATA.text_bold = (font.style == 'bold') ? true : false;
+        window.TEXTDATA.text_italic = (font.style == 'italic') ? true : false;
+        window.TEXTDATA.text_underline = font.underline;
+        window.TEXTDATA.stroke_color = stroke.color;
+        window.TEXTDATA.stroke_size = stroke.size;
+        window.TEXTDATA.text_shadow = (font.shadow != 'none') ? true : false;
+        apply_settings_to_boxes();
+
+        let bounds = $(this)[0].getBoundingClientRect();
+        create_moveable_text_box(bounds.left, bounds.top-25, bounds.width, bounds.height+25, text)
+        
+       window.DRAWINGS = window.DRAWINGS.filter((d) => d[9] != $(this)[0].id);
+        $(this).remove();
+        window.ScenesHandler.persist();
+        if(window.CLOUD)
+            sync_drawings();
+        else
+            window.MB.sendMessage('custom/myVTT/drawing', data);
     });
 }
 
@@ -706,6 +743,7 @@ function init_text_button(buttons) {
             window.DRAWINGS = window.DRAWINGS.filter(
                 (d) => !d[0].includes("text")
             );
+            $("#text_div svg").empty();
             redraw_text();
             sync_drawings()
         }

--- a/Text.js
+++ b/Text.js
@@ -711,7 +711,7 @@ function init_text_button(buttons) {
      textMenu.append(
         `<div class='ddbc-tab-options--layout-pill'>
                 <button id='text_select' class='drawbutton menu-option draw-option ddbc-tab-options__header-heading ddbc-tab-options__header-heading--is-active'
-                    data-shape='rect' data-unique-with="control" data-function="draw_text">
+                   data-unique-with="control" data-function="edit_text">
                         Move/Edit
                 </button>
             </div>`

--- a/Text.js
+++ b/Text.js
@@ -585,7 +585,8 @@ function draw_text(
 
     if($(`svg[id='${id}']`).length>0)
         return;
-
+    if(rectColor == null)
+        rectcolor = 'transparent';
 
     let adjustScale = (scale/window.CURRENT_SCENE_DATA.scale_factor);   
 

--- a/Text.js
+++ b/Text.js
@@ -580,7 +580,7 @@ function draw_text(
     stroke,
     rectColor = 'transparent',
     id = '',
-    scale = window.CURRENT_SCENE_DATA.scale_factor
+    scale = (window.CURRENT_SCENE_DATA.scale_factor == "") ? 1 : window.CURRENT_SCENE_DATA.scale_factor
 ) {
 
     if($(`svg[id='${id}']`).length>0)
@@ -588,7 +588,9 @@ function draw_text(
     if(rectColor == null)
         rectColor = 'transparent';
 
-    let adjustScale = (scale/window.CURRENT_SCENE_DATA.scale_factor);   
+    divideScale = (window.CURRENT_SCENE_DATA.scale_factor == "") ? 1 : window.CURRENT_SCENE_DATA.scale_factor;
+
+    let adjustScale = (scale/divideScale);   
 
     font.size = font.size / adjustScale
     stroke.size = stroke.size / adjustScale
@@ -660,6 +662,7 @@ function draw_text(
 
 
     textSVG.on('dblclick', function(){
+
         create_text_controller();
 
         window.TEXTDATA = [];
@@ -705,10 +708,17 @@ function init_text_button(buttons) {
     textMenu = $(
         "<div id='text_menu' class='top_menu' style='position:fixed; top:25px; width:75px'></div>"
     );
-
+     textMenu.append(
+        `<div class='ddbc-tab-options--layout-pill'>
+                <button id='text_select' class='drawbutton menu-option draw-option ddbc-tab-options__header-heading ddbc-tab-options__header-heading--is-active'
+                    data-shape='rect' data-unique-with="control" data-function="draw_text">
+                        Move/Edit
+                </button>
+            </div>`
+    );
     textMenu.append(
         `<div class='ddbc-tab-options--layout-pill'>
-                <button id='text_draw' class='drawbutton menu-option draw-option ddbc-tab-options__header-heading ddbc-tab-options__header-heading--is-active'
+                <button id='text_draw' class='drawbutton menu-option draw-option ddbc-tab-options__header-heading'
                     data-shape='rect' data-unique-with="control" data-function="draw_text">
                         Draw
                 </button>

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5195,6 +5195,15 @@ div.ddbc-tab-options--layout-pill>button{
 
 }
 
+#text_div{
+    pointer-events:none;
+}
+
+#text_div svg text{
+    pointer-events:all;
+    cursor: move;
+}
+
 #scene_map_container{
     overflow: clip;
     transition: opacity 1.5s linear 0s;


### PR DESCRIPTION
Changing text to SVG allows it to scale better with zoom giving it better quality.

We've had some canvas performance issues, although text isn't changed often 1 less large canvas may help. Scaling text in canvas doesn't look great.

This starts off by allowing the DM to move the text if they have the text tool selected. It works off the same data so it does pull in old text and convert. If your players are on the old version new text will still draw as canvas drawings. 

It does add a few extra data points (id, backround fill) as we no longer need to fill the background rect seperate and a way to identify them was needed.

This will also allow us to potentially edit the text ~~in the future~~ now. 

https://user-images.githubusercontent.com/65363489/217996328-8b076056-fd70-4033-93b4-83fffa413fe7.mp4





https://user-images.githubusercontent.com/65363489/218035618-c3e94502-6f0d-4c28-bc3a-c7e79a4cf6ee.mp4

