### PR TITLE
Fix - always/properly hide grid display options beside show grid

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -401,15 +401,11 @@ function edit_scene_dialog(scene_id) {
 			if ($(event.currentTarget).hasClass("rc-switch-checked")) {
 				// it was checked. now it is no longer checked
 				$(event.currentTarget).removeClass("rc-switch-checked");
-				gridStroke.hide()	
-				form.find(".sp-replacer").hide()
 				
 			} else {
 				// it was not checked. now it is checked
 				$(event.currentTarget).removeClass("rc-switch-unknown");
 				$(event.currentTarget).addClass("rc-switch-checked");
-				gridStroke.show()	
-				form.find(".sp-replacer").show()
 			}
 				handle_form_grid_on_change()
 		})

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3511,6 +3511,9 @@ span.exhaustion-pip.last{
     outline: 2px solid #000;
 }
 
+#grid_toggle:not(.rc-switch-checked) ~ *{
+    display:none !important;
+}
 .sidebar-hover-text-flyout {
     display: block;
     max-width: 400px;


### PR DESCRIPTION
Currently the options beside show grid get hidden when the button is clicked disabling it. However they aren't hidden if it starts as disabled. Also the new things I added weren't being hidden (didn't realize these things got hidden tbh but it makes sense). 

old:
![image](https://user-images.githubusercontent.com/65363489/218443946-d1932d1e-af93-4a58-b862-0dc272418d2c.png)


fix:
![image](https://user-images.githubusercontent.com/65363489/218443825-16c73caf-2b82-4fe0-9da5-73be74bddd97.png)
