### PR TITLE
Adjust background of pause - add backdrop blur and condense repeated css

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4387,7 +4387,9 @@ input.max_hp[disabled]{
     pointer-events: none;
 }
 
-.import-loading-indicator{
+.import-loading-indicator,
+.paused-indicator,
+.dm-paused-indicator{
     position: fixed;
     z-index: 100000;
     left: calc(50% - 170px);
@@ -4399,6 +4401,7 @@ input.max_hp[disabled]{
     background: #fff6;
     height: 112px;
     width: 200px;
+    backdrop-filter: blur(6px);
 }
 .import-loading-indicator .loading-status-indicator__subtext{
     overflow: visible;
@@ -4421,19 +4424,9 @@ input.max_hp[disabled]{
 
 .paused-indicator,
 .dm-paused-indicator{
-    position: fixed;
-    z-index: 100000;
-    left: calc(50% - 170px);
+    top: unset;
     bottom: 50px;
-    text-align: center;
-    transform: translate(-50%);
-    border-radius:20px;
-    border:1px solid #000;
-    box-shadow: 0px 0px 2px 2px #0008;
-    background: #fff6;
     height: 130px;
-    width: 200px;
-
 }
 .paused-indicator .paused-status-indicator__subtext,
 .dm-paused-indicator .paused-status-indicator__subtext{


### PR DESCRIPTION
Darn I was too slow to update the PR before merge lol.

 This just adds a blur to the backdrop - looks nicer on some maps where it was too transparent. Also condenses the css instead of repeating it.

Examples:

![image](https://user-images.githubusercontent.com/65363489/218605998-cc741bac-b85b-4ae5-80a0-01ccbeb3903f.png)

If you merge this no need to include it in the change log separate from the pause.