### PR TITLE
Fix - Hide aura in fog option

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -489,7 +489,10 @@ function do_check_token_visibility() {
 			$(selector).hide();
 			if(window.TOKEN_OBJECTS[id].options.hideaurafog)
 			{
-					$(auraSelector).hide();
+				$(auraSelector).hide();
+			}
+			else{
+				$(auraSelector).show();
 			}
 		}
 		else if (!window.TOKEN_OBJECTS[id].options.hidden) {


### PR DESCRIPTION
I don't think it's necessary to push this to live right away can go in beta. Noticed it while trying to fix the other more important issues.

Just currently light is hidden always when in fog. This allows the option to work correctly again. For when you want people to see auras/light coming out of fog but not the token. Like light sources (enemy carrying a torch) coming from around a corner.