### PR TITLE
Beta Fix - draw drawings on scene load

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1402,7 +1402,7 @@ class MessageBroker {
 
 			reset_canvas();
 			redraw_fog();
-
+			redraw_drawings();
 			apply_zoom_from_storage();
 
 
@@ -1487,7 +1487,6 @@ class MessageBroker {
 		else {
 			window.DRAWINGS = [];
 		}
-		redraw_drawings();
 		redraw_text();
 
 


### PR DESCRIPTION
Drawings aren't loading on scene load due to me moving the redraw when I was doing text and a reset_canvas being called after draw. This moves it back.