### PR TITLE
Fix: peer cursors and rulers were not being cleared all the time

### DIFF
--- a/PeerManager.js
+++ b/PeerManager.js
@@ -77,7 +77,7 @@ class PeerManager {
         window.PeerManager.disconnectFromPeer(conn.peer);
       });
       conn.on("data", (data) => {
-        // console.debug("PeerManager connection data", data);
+        noisy_log("PeerManager connection data", data);
         handle_peer_event(data);
       });
       conn.on("error", (error) => {
@@ -279,7 +279,7 @@ class PeerManager {
    *  @param {string} playerId - the DDB id of the character
    *  @return {PeerConnection|undefined} the PeerConnection for the player if it exists, else undefined */
   findConnectionByPlayerId(playerId) {
-    // console.debug("PeerManager.findConnectionByPlayerId", playerId);
+    noisy_log("PeerManager.findConnectionByPlayerId", playerId);
     const playerIdString = `${playerId}`; // in case we get a number
     return this.connections.find(pc => pc.playerId === playerIdString);
   }
@@ -288,7 +288,7 @@ class PeerManager {
    *  @param {string} peerId - the id of the peerjs peer
    *  @return {PeerConnection|undefined} the PeerConnection for the peer if it exists, else undefined */
   findConnectionByPeerId(peerId) {
-    // console.debug("PeerManager.findConnectionByPeerId", peerId);
+    noisy_log("PeerManager.findConnectionByPeerId", peerId);
     return this.connections.find(pc => pc.peerId === peerId);
   }
 
@@ -300,7 +300,7 @@ class PeerManager {
     switch (data.message) {
       case PeerEventType.cursor:
         if (this.allowCursorAndRulerStreaming) {
-          // console.debug("PeerManager.send filtering", data.message, this.skipCursorEvents, this.connections.map(pc => pc.playerId));
+          noisy_log("PeerManager.send filtering", data.message, this.skipCursorEvents, this.connections.map(pc => pc.playerId));
           connectionsToSendTo = this.connections.filter(pc => !this.skipCursorEvents.includes(pc.playerId));
         } else {
           connectionsToSendTo = [];
@@ -308,14 +308,14 @@ class PeerManager {
         break;
       case PeerEventType.ruler:
         if (this.allowCursorAndRulerStreaming) {
-          // console.debug("PeerManager.send filtering", data.message, this.skipCursorEvents, this.connections.map(pc => pc.playerId));
+          noisy_log("PeerManager.send filtering", data.message, this.skipCursorEvents, this.connections.map(pc => pc.playerId));
           connectionsToSendTo = this.connections.filter(pc => !this.skipRulerEvents.includes(pc.playerId));
         } else {
           connectionsToSendTo = [];
         }
         break;
       default:
-        // console.debug("PeerManager.send not filtering", data.message);
+        noisy_log("PeerManager.send not filtering", data.message);
         connectionsToSendTo = this.connections;
       break;
     }
@@ -387,7 +387,7 @@ class PeerManager {
       // now let's check deep within peerjs for any that we don't know about
       for (const peerId in this.peer.connections) {
         const connections = this.peer.connections[peerId];
-        // console.log(`PeerManager.checkForStaleConnections this.peer.connections[${peerId}]`, connections)
+        noisy_log(`PeerManager.checkForStaleConnections this.peer.connections[${peerId}]`, connections)
         connections.forEach(conn => {
           if (!conn.open) {
             try {


### PR DESCRIPTION
The problem here was the way that I was using the debounce functions for fading them out. The way that a debounce function works is by calling `setTimeout`, storing the id of the timeout, and clearing/resetting it every time it's called. So any time the timeout gets cleared, it essentially delays the execution of the function. I was calling the same debounce function with different playerId variables which ended up clearing the previous execution which may or may not have been called with a different playerId. Since the timeout id is unique to function, but not unique to the parameters it's called with, fading a playerId would clear out the execution of other playerId fade outs. 

The solution is to store a debounce function for each playerId. An alternative could be to track timestamps from every peer event, and then fade them out within a setInterval function. The reason I went with separate debounce functions, is because setTimeout is significantly more efficient than date parsing. So while this sets a few different setTimeout functions, it's still more efficient than setting Date.now() for every event.