### PR TITLE
Beta Feature Improvement: stream token position while dragging

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -723,6 +723,11 @@ function ct_list_tokens() {
 	return tokenIds;
 }
 
+/** @return {string|undefined} the id of the token that is currently active in the combat tracker; undefined if no active turn */
+function ct_current_turn() {
+	return $('#combat_area tr[data-current=1]').attr("data-target");
+}
+
 function ct_persist(){
 	var data= [];
 	$('#combat_area tr').each( function () {			

--- a/Fog.js
+++ b/Fog.js
@@ -1159,7 +1159,7 @@ function drawing_mousemove(e) {
 					WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX/window.CURRENT_SCENE_DATA.scale_factor, window.BEGIN_MOUSEY/window.CURRENT_SCENE_DATA.scale_factor, mouseX/window.CURRENT_SCENE_DATA.scale_factor, mouseY/window.CURRENT_SCENE_DATA.scale_factor);
 					WaypointManager.draw(false);
 					context.fillStyle = '#f50';
-					send_ruler_to_peers();
+					sendRulerPositionToPeers();
 				}
 			}else{
 				drawLine(context,

--- a/PeerManager.js
+++ b/PeerManager.js
@@ -306,14 +306,6 @@ class PeerManager {
           connectionsToSendTo = [];
         }
         break;
-      case PeerEventType.ruler:
-        if (this.allowCursorAndRulerStreaming) {
-          noisy_log("PeerManager.send filtering", data.message, this.skipCursorEvents, this.connections.map(pc => pc.playerId));
-          connectionsToSendTo = this.connections.filter(pc => !this.skipRulerEvents.includes(pc.playerId));
-        } else {
-          connectionsToSendTo = [];
-        }
-        break;
       default:
         noisy_log("PeerManager.send not filtering", data.message);
         connectionsToSendTo = this.connections;

--- a/Token.js
+++ b/Token.js
@@ -1595,10 +1595,13 @@ class Token {
 						window.DRAGGING = false;
 						draw_selected_token_bounding_box();
 						window.toggleSnap=false;
+
+						pauseCursorEventListener = false;
 					},
 
 				start: function (event) {
 					event.stopImmediatePropagation();
+					pauseCursorEventListener = true; // we're going to send events from drag, so we don't need the eventListener sending events, too
 					if (get_avtt_setting_value("allowTokenMeasurement")) {
 						$("#temp_overlay").css("z-index", "50");
 					}
@@ -1724,17 +1727,19 @@ class Token {
 						top: tokenPosition.y
 					};
 
-					if (get_avtt_setting_value("allowTokenMeasurement")) {
+					const allowTokenMeasurement = get_avtt_setting_value("allowTokenMeasurement")
+					if (allowTokenMeasurement) {
 						const tokenMidX = tokenPosition.x + Math.round(self.options.size / 2);
 						const tokenMidY = tokenPosition.y + Math.round(self.options.size / 2);
 
 						clear_temp_canvas();
 						WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX/window.CURRENT_SCENE_DATA.scale_factor, window.BEGIN_MOUSEY/window.CURRENT_SCENE_DATA.scale_factor, tokenMidX/window.CURRENT_SCENE_DATA.scale_factor, tokenMidY/window.CURRENT_SCENE_DATA.scale_factor);
 						WaypointManager.draw(false, Math.round(tokenPosition.x + (self.options.size / 2))/window.CURRENT_SCENE_DATA.scale_factor, Math.round(tokenPosition.y + self.options.size + 10)/window.CURRENT_SCENE_DATA.scale_factor);
-						if (!self.options.hidden) {
-							send_ruler_to_peers();
-						}
 					}
+					if (!self.options.hidden) {
+						sendTokenPositionToPeers(tokenPosition.x, tokenPosition.y, self.options.id, allowTokenMeasurement);
+					}
+
 
 					//console.log("Changing to " +ui.position.left+ " "+ui.position.top);
 					// HACK TEST 


### PR DESCRIPTION
This cleans up the event stream quite a bit. Rather than sending separate events for cursor and ruler, we now send a single event that either includes ruler data or it doesn't. While a player is dragging a token, we also send that token's id in the event which the other peers use to move a clone of the token around the scene. Combining the ruler and cursor events significantly reduces the number of events we stream. I also removed some unused data from the events which reduces the event size. So while this adds token streaming, the overhead is actually lower than what it used to be.


![avtt-token-drag-streaming-demo-1](https://user-images.githubusercontent.com/584771/219496883-ff5a3d6f-0aba-456e-9e77-56362f9c0889.gif)
