### PR TITLE
Bug workaround: store and load the sceneslist from localStorage

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -671,7 +671,13 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 
 		if(window.CLOUD){
-			this.scenes=[];
+			const fromStorage = localStorage.getItem(`ScenesHandler${find_game_id()}`);
+			if (fromStorage != null) {
+				this.scenes = $.parseJSON(fromStorage);
+				console.debug("from localStorage", `ScenesHandler${find_game_id()}`, this.scenes);
+			} else {
+				this.scenes=[];
+			}
 			this.current_scene_id=null;
 		}
 		else{ // LEGACY

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1745,6 +1745,13 @@ function init_scenes_panel() {
  */
 function did_update_scenes() {
 	if (!window.DM) return;
+
+	// store this locally in case we run into the cloud bug that prevents the scenelist event from being sent down
+	const sanitizedScenes = window.ScenesHandler.scenes.filter(sceneData => !sceneData.dm_map.startsWith("data:") && !sceneData.player_map.startsWith("data:"));
+	localStorage.setItem(`ScenesHandler${find_game_id()}`, JSON.stringify(sanitizedScenes));
+	console.debug("did_update_scenes", `ScenesHandler${find_game_id()}`, sanitizedScenes);
+
+
 	rebuild_scene_items_list();
 
 	// Filters scene list by search input if scenes-panel is active


### PR DESCRIPTION
We see reports of the scenes list not loading. We've tracked this to the `sceneslist` event not coming down from the server. The primary cause of that seems to be that the event data is too large. Until we can get some cloud work done to change the scenelist event to a REST request, this will act as a fallback to local storage.

The scenes list will load from localstorage, then if/when the sceneslist event comes, it will overwrite scenes and localstorage. If the event doesn't come down, then they will just continue to operate with localstorage.