### PR TITLE
Feature: Parse multiple dice roll commands in character sheet notes

### DIFF
--- a/ChatObserver.js
+++ b/ChatObserver.js
@@ -18,8 +18,8 @@ class ChatObserver {
                     input.val("");
                     return;
                 }
-                let slashCommandMatch = value.match(slashCommandRegex);
-                if (slashCommandMatch?.index === 0 && !value.startsWith("/w ")) {
+                let slashCommandMatch = value.match(diceRollCommandRegex);
+                if (slashCommandMatch?.index === 0) {
                     if (self.#parseSlashCommand(value)) {
                         self.#didSubmit(input, value);
                     } else {
@@ -64,7 +64,7 @@ class ChatObserver {
         let didSend = window.diceRoller.roll(diceRoll);
         if (didSend === false) {
             // it was too complex so try to send it through rpgDiceRoller
-            let expression = text.replace(slashCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
+            let expression = text.replace(diceRollCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
             didSend = send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
         }
         return didSend;

--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -6,7 +6,8 @@ $(function() {
 const allDiceRegex = /\d+d(?:100|20|12|10|8|6|4)(?:kh\d+|kl\d+)|\d+d(?:100|20|12|10|8|6|4)/g; // ([numbers]d[diceTypes]kh[numbers] or [numbers]d[diceTypes]kl[numbers]) or [numbers]d[diceTypes]
 const validExpressionRegex = /^[dkhl\s\d+\-]*$/g; // any of these [d, kh, kl, spaces, numbers, +, -] // Should we support [*, /] ?
 const validModifierSubstitutions = /(?<!\w)(str|dex|con|int|wis|cha|pb)(?!\w)/gi // case-insensitive shorthand for stat modifiers as long as there are no letters before or after the match. For example `int` and `STR` would match, but `mint` or `strong` would not match.
-const slashCommandRegex = /\/(r|roll|save|hit|dmg|skill|heal|w)\s/;
+const diceRollCommandRegex = /^\/(r|roll|save|hit|dmg|skill|heal)\s/; // matches only the slash command. EG: `/r 1d20` would only match `/r`
+const multiDiceRollCommandRegex = /\/(r|roll|save|hit|dmg|skill|heal) [^\/]*/g; // globally matches the full command. EG: `note: /r 1d20 /r2d4` would find ['/r 1d20', '/r2d4']
 const allowedExpressionCharactersRegex = /^(\d+d\d+|kh\d+|kl\d+|\+|-|\d+|\s+|STR|str|DEX|dex|CON|con|INT|int|WIS|wis|CHA|cha|PB|pb)*/; // this is explicitly different from validExpressionRegex. This matches an expression at the beginning of a string while validExpressionRegex requires the entire string to match. It is also explicitly declaring the modifiers as case-sensitive because we can't search the entire thing as case-insensitive because the `d` in 1d20 needs to be lowercase.
 
 class DiceRoll {
@@ -184,9 +185,9 @@ class DiceRoll {
      */
     static fromSlashCommand(slashCommandText, name = undefined, avatarUrl = undefined, entityType = undefined, entityId = undefined, sendToOverride = undefined) {
         let modifiedSlashCommand = replaceModifiersInSlashCommand(slashCommandText);
-        let slashCommand = modifiedSlashCommand.match(slashCommandRegex)?.[0];
-        let expression = modifiedSlashCommand.replace(slashCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
-        let action = modifiedSlashCommand.replace(slashCommandRegex, "").replace(allowedExpressionCharactersRegex, "");
+        let slashCommand = modifiedSlashCommand.match(diceRollCommandRegex)?.[0];
+        let expression = modifiedSlashCommand.replace(diceRollCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
+        let action = modifiedSlashCommand.replace(diceRollCommandRegex, "").replace(allowedExpressionCharactersRegex, "");
         console.debug("DiceRoll.fromSlashCommand text: ", slashCommandText, ", slashCommand:", slashCommand, ", expression: ", expression, ", action: ", action);
         let rollType = undefined;
         if (slashCommand.startsWith("/r")) {
@@ -571,7 +572,7 @@ function replaceModifiersInSlashCommand(slashCommandText) {
         return "";
     }
 
-    const expression = slashCommandText.replace(slashCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
+    const expression = slashCommandText.replace(diceRollCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
 
     if (expression === undefined || expression === "") {
         return slashCommandText; // no valid expression to parse
@@ -579,6 +580,8 @@ function replaceModifiersInSlashCommand(slashCommandText) {
 
     const modifiers = getCharacterStatModifiers();
     if (modifiers === undefined) {
+        // This will happen if the DM opens a character sheet before the character stats have loaded
+        console.warn("getCharacterStatModifiers returned undefined. This command may not parse properly", slashCommandText);
         return slashCommandText; // missing required info
     }
 

--- a/Main.js
+++ b/Main.js
@@ -1689,32 +1689,6 @@ function observe_character_sheet_aoe(documentToObserve) {
 	aoe_observer.observe(mutation_target, mutation_config);
 }
 
-
-/** Called from our character sheet observer for Dice Roll formulae.
- * @param element the jquery element that we observed changes to
- */
-function inject_dice_roll(element) {
-	try {
-		if (element.find("button.avtt-roll-formula-button").length > 0) {
-			console.debug("inject_dice_roll already has a button")
-			return;
-		}
-		const text = element.text();
-		if (text.match(slashCommandRegex)?.[0]) {
-			const diceRoll = DiceRoll.fromSlashCommand(text, window.PLAYER_NAME, window.PLAYER_IMG);
-			const button = $(`<button class='avtt-roll-formula-button integrated-dice__container' title="${diceRoll.action?.toUpperCase() ?? "CUSTOM"}: ${diceRoll.rollType?.toUpperCase() ?? "ROLL"}">${diceRoll.expression}</button>`);
-			button.on("click", function (clickEvent) {
-				clickEvent.stopPropagation();
-				window.diceRoller.roll(diceRoll);
-			});
-			element.empty();
-			element.append(button);
-		}
-	} catch (error) {
-		console.log("inject_dice_roll failed to process element", element, error);
-	}
-}
-
 /**
  * Opens the character sheet window.
  * @param {String} sheet_url URL to DDB charater


### PR DESCRIPTION
This updates the regex parsing to globally match anything up to another `/`, and then iterates over all matches.  
For example:  
`Some Note: /hit 2d20kh1 Advantage /dmg 2d10 big damage` would find these matches  
`['/hit 2d20kh1 Advantage ', '/dmg 2d10 big damage']` as seen here  
<img width="605" alt="Screenshot 2023-02-18 at 8 35 01 AM" src="https://user-images.githubusercontent.com/584771/219871502-54ea3de3-2360-46b4-8ae1-15ebe30c2ef3.png">

This conveniently allows us to have other notes before dice roll commands, and if you add a trailing `/` you can have them after the dice commands, too. 