### PR TITLE
Fix - Flicker on certain zoom levels when using light auras

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5315,31 +5315,10 @@ div.ddbc-tab-options--layout-pill>button{
     transform: scale(var(--scene-scale));
     transform-origin: top left;
 }
+
 @keyframes aurafx-flicker{
-    0%  {filter: blur(10px);transform:scale(1);}
-    10% {filter: blur(15px);transform:scale(1.005);}
-    20% {filter: blur(10px);transform:scale(0.995);}
-    30% {filter: blur(10px);transform:scale(1);}
-    40% {filter: blur(15px);transform:scale(0.995);}
-    50% {filter: blur(20px);transform:scale(1.005);}
-    60% {filter: blur(15px);transform:scale(0.995);}
-    70% {filter: blur(12px);transform:scale(1);}
-    80% {filter: blur(15px);transform:scale(0.995);}
-    90% {filter: blur(10px);transform:scale(1.005);}
-    100%{filter: blur(15px);transform:scale(1);}
-}
-@keyframes aurafx-flicker-no-blur{
-    0%  {transform:scale(1);}
-    10% {transform:scale(1.005);}
-    20% {transform:scale(0.995);}
-    30% {transform:scale(1);}
-    40% {transform:scale(0.995);}
-    50% {transform:scale(1.005);}
-    60% {transform:scale(0.995);}
-    70% {transform:scale(1);}
-    80% {transform:scale(0.995);}
-    90% {transform:scale(1.005);}
-    100%{transform:scale(1);}
+    0%  {filter: blur(10px);}
+    100%{filter: blur(15px);}
 }
 
 .aurafx-flicker{


### PR DESCRIPTION
A hard to trigger bug with light auras reported on discord. 

At some zoom levels the animation was causing flashing. I had to manually set my zoom and move it bit by bit till I found one. Musashi and F I Z Z C A N N O N both had this happen.  F I Z Z C A N N O N couldn't get it to trigger again once zooming away.

I've changed the animation at the zoom level that was triggering it and the flickering stopped. I then couldn't reproduce the flickering so I'm hoping this caught it all.