### PR TITLE
Beta Fix - Token settings panel not working

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1533,7 +1533,10 @@ class Token {
 			this.update_opacity(tok, true);
 
 			setTokenAuras(tok, this.options);
-			setTokenLight(tok, this.options);
+			if(!this.options.id.includes('exampleToken')){
+				setTokenLight(tok, this.options);
+			}
+
 
 			setTokenBase(tok, this.options);
 


### PR DESCRIPTION
Stop checking token light on example tokens. Since they aren't placed on the map it errors out on checking their options breaking the token settings panel.