### PR TITLE
Beta Fix - Allow more than 1 group

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -226,7 +226,7 @@ function token_context_menu_expanded(tokenIds, e) {
 			let group = uuid();
 			tokens.forEach(token => {
 				if (groupAll || clickedItem.hasClass('add-to-group')) {
-					token.options.groupId = id;
+					token.options.groupId = group;
 				} else {
 					token.options.groupId = undefined;
 				}


### PR DESCRIPTION
Currently id was being set to the wrong id variable. So only 1 group could ever be formed.