### PR TITLE
Beta Fix - Minor bug fixes. Light improvements, revealed light only show when in LoS, owned tokens will still always show. 

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -2359,7 +2359,7 @@ function deselect_all_tokens() {
 		}
 	}
 	remove_selected_token_bounding_box();
-	let darknessFilter = (window.CURRENT_SCENE_DATA.darkness_filter) ? window.CURRENT_SCENE_DATA.darkness_filter : 0;
+	let darknessFilter = (window.CURRENT_SCENE_DATA.darkness_filter != undefined) ? window.CURRENT_SCENE_DATA.darkness_filter : 0;
 	let darknessPercent = 100 - parseInt(darknessFilter); 	
 	if(window.DM && darknessPercent < 25){
    	 	darknessPercent = 25; 	
@@ -2526,7 +2526,7 @@ function setTokenLight (token, options) {
 			
 			let lights = $("[id^='light_']");
 			for(let i = 0; i < lights.length; i++){
-				if(!lights[i].id.endsWith(window.PLAYER_ID) && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.player_owned & !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light){
+				if(!lights[i].id.endsWith(window.PLAYER_ID) && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.player_owned && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light){
 					$(lights[i]).css("visibility", "hidden");
 				}
 			}


### PR DESCRIPTION
Some minor bug fixes, missing &, missing != undefined. 

This prevents light from showing through walls. It also makes `reveal light to players` only reveal when in LoS of the players. Owned tokens will still always show light.

Examples for reveal light to players. Torchs in a room that you don't want them to see until they see the room.

Examples for owned tokens. A pet that they always want to see their vision.

I've added a radius for the ray casting - although not used just yet. 