### PR TITLE
Fix: player sheet aoe buttons aren't being displayed

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -71,7 +71,6 @@ function inject_dice_roll(element) {
   console.debug("inject_dice_roll slashCommands", slashCommands);
   let updatedInnerHtml = element.text();
   for (const command of slashCommands) {
-    console.debug("inject_dice_roll command", command, command[0]);
     try {
       const diceRoll = DiceRoll.fromSlashCommand(command[0], window.PLAYER_NAME, window.PLAYER_IMG);
       updatedInnerHtml = updatedInnerHtml.replace(command[0], `<button class='avtt-roll-formula-button integrated-dice__container' title="${diceRoll.action?.toUpperCase() ?? "CUSTOM"}: ${diceRoll.rollType?.toUpperCase() ?? "ROLL"}" data-slash-command="${command[0]}">${diceRoll.expression}</button>`);

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -66,8 +66,9 @@ function inject_dice_roll(element) {
     console.debug("inject_dice_roll already has a button")
     return;
   }
-  const slashCommands = element.text().matchAll(multiDiceRollCommandRegex);
-  if (!slashCommands) return;
+  const slashCommands = [...element.text().matchAll(multiDiceRollCommandRegex)];
+  if (slashCommands.length === 0) return;
+  console.debug("inject_dice_roll slashCommands", slashCommands);
   let updatedInnerHtml = element.text();
   for (const command of slashCommands) {
     console.debug("inject_dice_roll command", command, command[0]);
@@ -105,12 +106,12 @@ function observe_character_sheet_changes(documentToObserve) {
     // console.log("dice_roll_observer", mutationList);
 
     // initial injection of our buttons
-    const notes = documentToObserve.find(".ddbc-note-components__component:not('.above-vtt-visited')");
+    const notes = documentToObserve.find(".ddbc-note-components__component:not('.above-vtt-dice-visited')");
     notes.each(function() {
       // console.log("dice_roll_observer iterating", mutationList);
       try {
         inject_dice_roll($(this));
-        $(this).addClass("above-vtt-visited"); // make sure we only parse this element once
+        $(this).addClass("above-vtt-dice-visited"); // make sure we only parse this element once
       } catch (error) {
         console.log("inject_dice_roll failed to process element", error);
       }


### PR DESCRIPTION
This was due to re-using `above-vtt-visited` as a marker class. The aoe buttons use that, and I was doing the same with the dice buttons. Now I'm using `above-vtt-dice-visited` instead.

I also changed my multi-command parsing to use an array so I can check the length and return early instead of unnecessarily processing every note.