### PR TITLE
Beta Fix - Only have group rotation grabber when more than 1 token is selected.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -2890,9 +2890,10 @@ function do_draw_selected_token_bounding_box() {
 	grabber2.css('z-index', 100000); // make sure the grabber is above all the tokens
 	grabber2.css('background', '#ced9e0')
 	grabber2.css('border-radius', `${Math.ceil(grabberSize / 2)}px`); // make it round
-	grabber2.css('padding', '1px');
+	grabber2.css('padding', '2px');
 	grabber2.css('cursor', 'move');
-	$("#tokens").append(grabber2);
+	if(window.CURRENTLY_SELECTED_TOKENS.length > 1)
+		$("#tokens").append(grabber2);
 
 	// handle eye grabber dragging
 	let click = {


### PR DESCRIPTION
Only adds the group rotation grabber when more than 1 token is selected.

![image](https://user-images.githubusercontent.com/65363489/220808473-49257b13-9006-453a-b62e-5ff7cde09701.png)


I don't quite see what mikedave in discord is seeing but I adjusted the grabber slightly to center the svg. 

I'll double check firefox in case that's where you saw the odd icon size.

![image](https://user-images.githubusercontent.com/65363489/220808572-a57a6bcf-ce7f-4be3-a6c5-4dd9647207ab.png)
