### PR TITLE
Beta Fix - DM see light revealed to players when checking player token vision

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -2865,7 +2865,7 @@ let particle = new Particle(new Vector(200, 200), 1);
 
   	found = selectedIds.some(r=> r == auraId);
 
-  	if(!found && window.DM){
+  	if(!found && window.DM && !window.TOKEN_OBJECTS[auraId].options.reveal_light){
   		$(light_auras[i]).css("visibility", "hidden");
   	}
   	if(selectedIds.length == 0 || found){


### PR DESCRIPTION
Currently if a DM checks a token for vision 'reveal' light sources are not visible. This fixes that.

Example

https://user-images.githubusercontent.com/65363489/220820619-0a4275c7-0720-4dcc-bca0-6b61d1da476f.mp4

