### PR TITLE
Beta - Allow player tokens will see other players vision if reveal light is enabled. They will still be able to select a token to get that specific tokens vision

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -2854,7 +2854,7 @@ let particle = new Particle(new Vector(200, 200), 1);
   		
 	  for(j = 0; j < selectedTokens.length; j++){
 	  	let tokenId = $(selectedTokens[j]).attr('data-id');
-	  	if(window.TOKEN_OBJECTS[tokenId].options.player_owned || tokenId.includes(window.PLAYER_ID) || window.DM)
+	  	if(window.TOKEN_OBJECTS[tokenId].options.player_owned || tokenId.includes(window.PLAYER_ID) || window.DM || (window.TOKEN_OBJECTS[tokenId].options.itemType == "pc" && window.TOKEN_OBJECTS[tokenId].options.reveal_light))
 	  		selectedIds.push(tokenId)
 	  }	  	
   }
@@ -2868,23 +2868,30 @@ let particle = new Particle(new Vector(200, 200), 1);
   	if(!found && window.DM && !window.TOKEN_OBJECTS[auraId].options.reveal_light){
   		$(light_auras[i]).css("visibility", "hidden");
   	}
+
   	if(selectedIds.length == 0 || found){
-  		if(window.TOKEN_OBJECTS[auraId].options.reveal_light && !window.DM && !auraId.includes(window.PLAYER_ID) && !window.TOKEN_OBJECTS[auraId].options.player_owned)
+  		if(selectedIds.length == 0  && !window.TOKEN_OBJECTS[auraId].options.itemType == "pc" && window.TOKEN_OBJECTS[auraId].options.reveal_light && !auraId.includes(window.PLAYER_ID) && !window.DM && !window.TOKEN_OBJECTS[auraId].options.player_owned)
+  			continue;
+  		
+  		if(window.TOKEN_OBJECTS[auraId].options.reveal_light && !auraId.includes(window.PLAYER_ID) && !window.TOKEN_OBJECTS[auraId].options.itemType == "pc" && !window.DM && !window.TOKEN_OBJECTS[auraId].options.player_owned)
   			continue; 
-  		if(window.DM){
-  			$(light_auras[i]).css("visibility", "visible");
-  		}
+
+
 
   		
+  		if(window.DM)
+  			$(light_auras[i]).css("visibility", "visible");
+  		
+  		
+  				
 	  	let tokenPos = {
 	  		x: (parseInt($(light_auras[i]).css('left'))+(parseInt($(light_auras[i]).css('width'))/2)),
 	  		y: (parseInt($(light_auras[i]).css('top'))+(parseInt($(light_auras[i]).css('height'))/2))
 	  	}
 	
-  	  particle.update(tokenPos.x, tokenPos.y); // moves particle
-	  particle.draw(context);            // draws particle
-
-	  particle.look(context, walls); 
+	  	particle.update(tokenPos.x, tokenPos.y); // moves particle
+		particle.draw(context);            // draws particle
+		particle.look(context, walls); 
 	
 	}    // draws rays
   }

--- a/Fog.js
+++ b/Fog.js
@@ -2865,7 +2865,7 @@ let particle = new Particle(new Vector(200, 200), 1);
 
   	found = selectedIds.some(r=> r == auraId);
 
-  	if(!found && window.DM){
+  	if(!found && window.DM && !window.TOKEN_OBJECTS[auraId].options.reveal_light){
   		$(light_auras[i]).css("visibility", "hidden");
   	}
   	if(selectedIds.length == 0 || found){


### PR DESCRIPTION
This is pretty essential in my games. I have players who play more than one PC in some games with a smaller number of players. Currently they are unable to see other player token's vision. This allows them to check their vision if reveal light to players is on. It acts a little different from other tokens in this sense but I think it's worth the trade off for the capability. Especially since it's not the only way pc tokens behave differently. Since there is no 'Player Accessible Stats' equivalent for player tokens.


https://user-images.githubusercontent.com/65363489/220834791-c3f4f58e-e32b-46f6-8a49-0e52b6fd626f.mp4

