### PR TITLE
Beta Fix - Prevent flickering when zooming due to rendering issues

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5448,7 +5448,7 @@ div.ddbc-tab-options--layout-pill>button{
 }
 
 .aura-element.islight{
-    animation: aurafx-flicker 15s infinite alternate ease-in-out;
+    filter:blur(10px);
     z-index: 9;
 }
 #scene_map{


### PR DESCRIPTION
The animation with a bunch of light on the map is not appreciated by the browser. Almost ironic the animation name was flicker lol

A static blur seems to resolve this issue on my end. Probably also will increase performance a bit. The animation was so subtle it barely had an effect anyway. 

https://user-images.githubusercontent.com/65363489/221227275-d4b399fe-e878-4651-909c-cf65c1b9d029.mp4



