### PR TITLE
Add ddb popout and send to gamelog button when hovering token notes.

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -653,10 +653,10 @@ class JournalManager{
 			      { title: 'h6', block: 'h6' }
 			    ] },
 				{ title: 'Containers', items: [
-			      { title: 'Quote Box', block: 'blockquote', wrapper: true, classes: 'text--quote-box'},
-			      { title: 'Rules Text', block: 'aside', wrapper: true, classes: 'rules-text' },
-			      { title: 'Ripped Paper', block: 'aside', wrapper: true, classes: 'block-torn-paper' },
-			      { title: 'Read Aloud Text', block: 'aside', wrapper: true, classes: 'read-aloud-text' },
+			      { title: 'Quote Box', block: 'div', wrapper: true, classes: 'text--quote-box'},
+			      { title: 'Rules Text', block: 'div', wrapper: true, classes: 'rules-text' },
+			      { title: 'Ripped Paper', block: 'div', wrapper: true, classes: 'block-torn-paper' },
+			      { title: 'Read Aloud Text', block: 'div', wrapper: true, classes: 'read-aloud-text' },
 			      { title: 'Stat Block Paper', block: 'div', wrapper: true, classes: 'Basic-Text-Frame stat-block-background' },
 			    ] }
 			],
@@ -1043,12 +1043,12 @@ class JournalManager{
 				}
 
 		
-				aside.rules-text a {
+				.rules-text a {
 				    color: #129b54!important;
 				    transition: .3s
 				}
 
-				aside.rules-text p:first-child {
+				.rules-text p:first-child {
 				    font-size: 16px
 				}
 
@@ -1067,7 +1067,7 @@ class JournalManager{
 				}
 
 
-				aside.block-torn-paper,aside.epigraph,aside.epigraph--with-author {
+				.block-torn-paper,.epigraph,.epigraph--with-author {
 				    overflow: auto;
 				    background: var(--theme-quote-bg-color,#fff);
 				    color: var(--theme-quote-fg-color,#242527);
@@ -1083,12 +1083,12 @@ class JournalManager{
 				    position: relative
 				}
 
-				aside.epigraph--with-author p:last-child {
+				.epigraph--with-author p:last-child {
 				    font-style: italic;
 				    text-align: right
 				}
 
-				aside.rules-text {
+				.rules-text {
 				    overflow: auto;
 				    display: block;
 				    margin: 30px 0;
@@ -1108,12 +1108,12 @@ class JournalManager{
 				    filter: drop-shadow(0 5px 8px #ccc)
 				}
 
-				aside.rules-text p:first-child {
+				.rules-text p:first-child {
 				    text-transform: uppercase;
 				    font-weight: 700
 				}
 
-				aside.read-aloud-text {
+				.read-aloud-text {
 				    overflow: auto;
 				    display: block;
 				    margin: 30px 0;

--- a/Token.js
+++ b/Token.js
@@ -1160,7 +1160,91 @@ class Token {
 				conditionContainer.dblclick(function(){
 					window.JOURNAL.display_note(self.options.id);
 				})
-				symbolImage.attr('title', window.JOURNAL.notes[this.options.id].plain);
+
+				let noteHover = `<div class="tooltip-header">
+						        <div class="tooltip-header-icon">
+						            
+						        </div>
+						        <div class="tooltip-header-text">
+						            ${window.JOURNAL.notes[this.options.id].title}
+						        </div>
+						        <div class="tooltip-header-identifier tooltip-header-identifier-condition">
+						           Note
+						        </div>
+						    </div>
+						    <div class="tooltip-body note-text">
+						        <div class="tooltip-body-description">
+						            <div class="tooltip-body-description-text note-text">
+						                ${window.JOURNAL.notes[this.options.id].text}
+						            </div>
+						        </div>
+						    </div>
+						</div>`
+							
+				let flyoutLocation = convert_point_from_map_to_view(parseInt(this.options.left), parseInt(this.options.top))
+		
+				let hoverNoteTimer;
+				symbolImage.on({
+					'mouseover': function(e){
+						hoverNoteTimer = setTimeout(function () {
+			            	build_and_display_sidebar_flyout(e.clientY, function (flyout) {
+					            flyout.addClass("prevent-sidebar-modal-close"); // clicking inside the tooltip should not close the sidebar modal that opened it
+					            const tooltipHtml = $(noteHover);
+					            flyout.append(tooltipHtml);
+					            let sendToGamelogButton = $(`<a class="ddbeb-button" href="#">Send To Gamelog</a>`);
+					            sendToGamelogButton.css({ "float": "right" });
+					            sendToGamelogButton.on("click", function(ce) {
+					                ce.stopPropagation();
+					                ce.preventDefault();
+					                const tooltipWithoutButton = $(noteHover);
+					                tooltipWithoutButton.css({
+					                    "width": "100%",
+					                    "max-width": "100%",
+					                    "min-width": "100%"
+					                });
+					                send_html_to_gamelog(noteHover);
+					            });
+					            flyout.css({
+					            	left: flyoutLocation.x - scrollX+20,
+					            	top: flyoutLocation.y - scrollY,
+					            	width: '400px'
+					            })
+
+					            const buttonFooter = $("<div></div>");
+					            buttonFooter.css({
+					                height: "40px",
+					                width: "100%",
+					                position: "relative",
+					                background: "#fff"
+					            });
+					            flyout.append(buttonFooter);
+					            buttonFooter.append(sendToGamelogButton);
+
+					      
+
+					            flyout.hover(function (hoverEvent) {
+					                if (hoverEvent.type === "mouseenter") {
+					                    clearTimeout(removeToolTipTimer);
+					                    removeToolTipTimer = undefined;
+					                } else {
+					                    remove_tooltip(500);
+					                }
+					            });
+					            flyout.css("background-color", "#fff");
+					        });
+			        	}, 500);		
+					
+					},
+					'mouseout': function(e){
+						clearTimeout(hoverNoteTimer)
+					}
+			
+			    });
+			
+			    
+							
+
+
 				conditionContainer.css('width', symbolSize + "px");
 				conditionContainer.css("height", symbolSize + "px");
 				symbolImage.height(symbolSize + "px");

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -6067,12 +6067,12 @@ button.journal-view-button.journal-button {
 }
 
 
-.note-text aside.rules-text a {
+.note-text .rules-text a {
     color: #129b54!important;
     transition: .3s
 }
 
-.note-text aside.rules-text p:first-child {
+.note-text .rules-text p:first-child {
     font-size: 16px
 }
 
@@ -6092,9 +6092,9 @@ button.journal-view-button.journal-button {
 }
 
 
-.note-text aside.block-torn-paper,
-.note-text aside.epigraph,
-.note-text aside.epigraph--with-author {
+.note-text .block-torn-paper,
+.note-text .epigraph,
+.note-text .epigraph--with-author {
     overflow: auto;
     background: var(--theme-quote-bg-color,#fff);
     color: var(--theme-quote-fg-color,#242527);
@@ -6110,12 +6110,12 @@ button.journal-view-button.journal-button {
     position: relative
 }
 
-.note-text aside.epigraph--with-author p:last-child {
+.note-text .epigraph--with-author p:last-child {
     font-style: italic;
     text-align: right
 }
 
-.note-text aside.rules-text {
+.note-text .rules-text {
     overflow: auto;
     display: block;
     margin: 30px 0;
@@ -6135,12 +6135,12 @@ button.journal-view-button.journal-button {
     filter: drop-shadow(0 5px 8px #ccc)
 }
 
-.note-text aside.rules-text p:first-child {
+.note-text .rules-text p:first-child {
     text-transform: uppercase;
     font-weight: 700
 }
 
-.note-text aside.read-aloud-text {
+.note-text .read-aloud-text {
     overflow: auto;
     display: block;
     margin: 30px 0;


### PR DESCRIPTION

https://user-images.githubusercontent.com/65363489/221323849-7f055e3d-18d4-4745-86bc-b3531ba56c35.mp4

Adds ddb tooltip styling to hover popup for token notes. There's a small delay before it pops up so it doesn't popup when unintended. We can adjust this delay if necessary. 

I also changed the ddb styles in journals to divs as the gamelog functions don't support blockquote/asides and the styles function the same on divs.