### PR TITLE
Fix drawing light when a token is selected that someone else is dragging. Remove unnecessary light redraws.

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -520,7 +520,6 @@ function do_check_token_visibility() {
 		$(".aura-element[id='light_" + auraSelectorId + "'] ~ .aura-element[id='light_" + auraSelectorId + "']").remove();
 	}
 	console.log("finished");
-	redraw_light();
 }
 
 function circle2(a, b) {

--- a/PeerCommunication.js
+++ b/PeerCommunication.js
@@ -734,7 +734,9 @@ function peer_is_dragging_token(eventData) {
   if (!html || html.length === 0) {
     noisy_log("peer_is_dragging_token no html", eventData);
     html = $(`#tokens div[data-id='${eventData.tokenId}']`).clone();
-    html.attr("data-id", `dragging-${eventData.tokenId}`);
+    html.attr("data-clone-id", `dragging-${eventData.tokenId}`);
+    html.attr("data-id", ``);
+    html.removeClass('tokenselected');
     if (!html || html.length === 0) {
       noisy_log("peer_is_dragging_token no token on scene matching", `#tokens div[data-id='${eventData.tokenId}']`, eventData);
       return;

--- a/Token.js
+++ b/Token.js
@@ -2076,7 +2076,7 @@ class Token {
 		toggle_player_selectable(this, token)
 		//check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 		console.groupEnd()
-		redraw_light();
+
 	}
 
 	// key: String, numberRemaining: Number; example: track_ability("1stlevel", 2) // means they have 2 1st level spell slots remaining


### PR DESCRIPTION
Removes light_redraws that were getting called redundantly. Every token drag was causing 3 redraws when we only want it to redraw when it's moving animation is complete.

Also fixes an error where when the dragged token was cloned for peer streaming it was being picked up as a selected token to check vision for. Removing the tokenselected class from the cloned token fixes this error.