### PR TITLE
Beta Improvement - Only grab 2 light polygon points from each closest wall

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -2799,12 +2799,14 @@ Particle.prototype.update = function(x, y) {
 
 Particle.prototype.look = function(ctx, walls, lightRadius=100000, fog=false, fogStyle, fogType=0, draw=true) {
 	lightPolygon = [{x: this.pos.x*window.CURRENT_SCENE_DATA.scale_factor, y: this.pos.y*window.CURRENT_SCENE_DATA.scale_factor}];
+	let prevClosestWall = null;
+    let prevClosestPoint = null;
 	for (let i = 0; i < this.rays.length; i++) {
 	    
 	    let pt;
 	    let closest = null;
 	    let record = Infinity;
-	    
+
 	    for (let j = 0; j < walls.length; j++) {
 	    
 	      pt = this.rays[i].cast(walls[j]);
@@ -2820,19 +2822,22 @@ Particle.prototype.look = function(ctx, walls, lightRadius=100000, fog=false, fo
 		          }
 	          }
 	          closest=pt;
+	          closestWall = walls[j]
 	        }
 
-	       
-	       
 	      }
-	    }
-	    
-	    if (closest) {
-
-	      lightPolygon.push({x: closest.x*window.CURRENT_SCENE_DATA.scale_factor, y: closest.y*window.CURRENT_SCENE_DATA.scale_factor})
+	    }	    
+	    if (closest && closestWall != prevClosestWall) {
+	    	if(prevClosestPoint){
+	    		 lightPolygon.push({x: prevClosestPoint.x*window.CURRENT_SCENE_DATA.scale_factor, y: prevClosestPoint.y*window.CURRENT_SCENE_DATA.scale_factor})
+	    	}
+	    	lightPolygon.push({x: closest.x*window.CURRENT_SCENE_DATA.scale_factor, y: closest.y*window.CURRENT_SCENE_DATA.scale_factor})
 	    } 
+	    prevClosestPoint = closest;
+	    prevClosestWall = closestWall;
 	}
-  	lightPolygon.push(lightPolygon[1]);
+	if(lightPolygon[1] != undefined)
+  		lightPolygon.push(lightPolygon[1]);
   	if(draw == true){
 		if(!fog){
 			  drawPolygon(ctx, lightPolygon, 'rgba(255, 255, 255, 1)', true);


### PR DESCRIPTION
You can look at window.lightPolygon to see the difference but what this does is as it's checking closest points it only adds them if it's the first or last point on the closest wall. Since all the walls are lines it's unnesecarry to add every point along the wall. 

On average were looking at 360+ (1 for every degree rotation) down to in the low double digits on polygon points for the light polygon that is drawn on light redraws. I think this will give an improvement to performance for some people and it requires less data points.