### PR TITLE
Beta Fix - When dragging a different token then selected it should now appropriately update light, when dragging another token into fog that would be revealed with new light should no longer hide the token

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -2976,17 +2976,16 @@ function redraw_light(){
 
   	found = selectedIds.some(r=> r == auraId);
 
-  	if(!found && window.DM && !window.TOKEN_OBJECTS[auraId].options.reveal_light){
-  		$(light_auras[i]).css("visibility", "hidden");
-  	}
 
 	let tokenPos = {
 		x: (parseInt($(light_auras[i]).css('left'))+(parseInt($(light_auras[i]).css('width'))/2)),
 		y: (parseInt($(light_auras[i]).css('top'))+(parseInt($(light_auras[i]).css('height'))/2))
 	}
 	
+
 	particle.update(tokenPos.x, tokenPos.y); // moves particle
 	particle.look(context, walls, 100000, undefined, undefined, undefined, false); // draws rays for clip paths
+
 	let path = "";
 	let adjustScale = (window.CURRENT_SCENE_DATA.scale_factor != undefined) ? window.CURRENT_SCENE_DATA.scale_factor : 1;
 	for( let i = 0; i < lightPolygon.length; i++ ){
@@ -2994,6 +2993,9 @@ function redraw_light(){
 	}
 	$(`.aura-element-container-clip[id='${auraId}']`).css('clip-path', `path('${path}')`)
 
+  	if(!found && window.DM && !window.TOKEN_OBJECTS[auraId].options.reveal_light){
+  		$(light_auras[i]).css("visibility", "hidden");
+  	}
   	if(selectedIds.length == 0 || found){
   		if(selectedIds.length == 0  && window.TOKEN_OBJECTS[auraId].options.itemType != "pc" && window.TOKEN_OBJECTS[auraId].options.reveal_light && !auraId.includes(window.PLAYER_ID) && !window.DM && !window.TOKEN_OBJECTS[auraId].options.player_owned)
   			continue;
@@ -3001,11 +3003,10 @@ function redraw_light(){
   		if(window.TOKEN_OBJECTS[auraId].options.reveal_light && !auraId.includes(window.PLAYER_ID) && window.TOKEN_OBJECTS[auraId].options.itemType != "pc" && !window.DM && !window.TOKEN_OBJECTS[auraId].options.player_owned)
   			continue; 
 
+	  	if(window.DM){
+	  		$(light_auras[i]).css("visibility", "visible");
+	  	}
 
-  		
-  		if(window.DM)
-  			$(light_auras[i]).css("visibility", "visible");
-  		
   		
   		particle.update(tokenPos.x, tokenPos.y); // moves particle
 		particle.look(context, walls); 

--- a/Token.js
+++ b/Token.js
@@ -1662,6 +1662,7 @@ class Token {
 						if (get_avtt_setting_value("allowTokenMeasurement")){
 							WaypointManager.fadeoutMeasuring()
 						}	
+						redraw_light();
 						self.update_and_sync(event, false);
 						if (self.selected ) {
 							for (let tok of $(".token.tokenselected")){
@@ -1678,7 +1679,7 @@ class Token {
 						window.DRAGGING = false;
 						draw_selected_token_bounding_box();
 						window.toggleSnap=false;
-						redraw_light();
+
 						pauseCursorEventListener = false;
 					},
 
@@ -1802,7 +1803,10 @@ class Token {
 							
 							WaypointManager.setCanvas(canvas);
 					}
-
+					if(window.DM){
+				   		$("[id^='light_']").css('visibility', "visible");
+				   	}
+				   	redraw_light();
 					remove_selected_token_bounding_box();
 				},
 
@@ -2060,6 +2064,9 @@ class Token {
 				window.MULTIPLE_TOKEN_SELECTED = (count > 1);
 				draw_selected_token_bounding_box(); // update rotation bounding box
 				check_token_visibility();
+				if(window.DM){
+			   		$("[id^='light_']").css('visibility', "visible");
+			   	}
 				redraw_light();
 			});
 			


### PR DESCRIPTION
This fixes two bugs:

1) When a token is selected and you start a drag on a different token it was updating the light at the wrong time revealing no vision/light. (As DM)

2) When a token is selected and you drag a different one into darkness as a player it hides that token even if the new light draw should reveal it. (As player)


Both these should be fixed with this.