### PR TITLE
Beta Fix - Update vision after finalizing a wall or erasing a wall for DM view

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1474,11 +1474,13 @@ function drawing_mouseup(e) {
 			window.StoredWalls = [];
 			window.wallToStore = [];
 			window.MOUSEDOWN = false;
+			redraw_light_walls();
+			redraw_light();
 		}
 
 		
 		redraw_drawings();
-		redraw_light_walls();
+
 		if(window.DM)
 			window.ScenesHandler.persist();
 		if(window.CLOUD)
@@ -1723,6 +1725,7 @@ function drawing_mouseup(e) {
  		
 
 		redraw_light_walls();
+		redraw_light();
 		window.ScenesHandler.persist();
 		if(window.CLOUD)
 			sync_drawings();


### PR DESCRIPTION
Currently vision doesn't update immediately after finalizing a wall or erasing one in the DM view. Player view works fine. This should fix DM view by adding redraw_light to the eraser and wall mouseup. If using segmented walls it won't trigger until the wall is finalized.