### PR TITLE
Move initial monster statblock location to the right of the combat tracker instead of behind it

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -678,7 +678,7 @@ function load_monster_stat_iframe(monsterId, tokenId) {
 
 	// create a monster block wrapper element
 	if (! $("#resizeDragMon").length) {
-		const monStatBlockContainer = $(`<div id='resizeDragMon' style="display:none; left:204px"></div>`);
+		const monStatBlockContainer = $(`<div id='resizeDragMon' style="display:none; left:300px"></div>`);
 		$("body").append(monStatBlockContainer)
 		monStatBlockContainer.append(build_combat_tracker_loading_indicator())
 		const loadingIndicator = monStatBlockContainer.find(".sidebar-panel-loading-indicator")
@@ -861,7 +861,7 @@ function load_monster_stat_iframe(monsterId, tokenId) {
 
 function build_draggable_monster_window() {
 
-	const draggable_resizable_div = $(`<div id='resizeDragMon' style="display:none; left:204px"></div>`);
+	const draggable_resizable_div = $(`<div id='resizeDragMon' style="display:none; left:300px"></div>`);
 
 	// check if the monster pane is not open
 	if (! $("#resizeDragMon").length) {


### PR DESCRIPTION
This has just been a little annoyance of mine that I've been meaning to adjust.

Now:
![image](https://user-images.githubusercontent.com/65363489/221422180-cfa045d4-ca37-420e-aaee-f24598946574.png)

Fix
![image](https://user-images.githubusercontent.com/65363489/221422263-770505dd-7d15-42ec-bb90-0b5558c66e64.png)
