### PR TITLE
Allow 0/0 vision to show revealed light; When no player token placed show all player vision

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -389,7 +389,7 @@ function is_token_under_fog(tokenid){
 	var pixeldata2 = ctx2.getImageData(left, top, 1, 1).data;
 
 	let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-	let playerTokenAuraIsLight = (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+	let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
 
 
 	if (!window.TOKEN_OBJECTS[tokenid].options.revealInFog && (pixeldata[3] == 255 || (pixeldata2[2] == 0 && playerTokenAuraIsLight)))
@@ -432,8 +432,8 @@ function check_single_token_visibility(id){
 			var selector = "div[data-id='" + id + "']";
 			let auraSelector = ".aura-element[id='light_" + auraSelectorId + "']";
 			let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-			let playerTokenAuraIsLight = (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
-			let playerAuraIsVisible =  (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraVisible;
+			let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+			let playerAuraIsVisible =  (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraVisible;
 
 			if (!window.TOKEN_OBJECTS[id].options.revealInFog && (is_token_under_fog(id) || (playerTokenAuraIsLight && window.CURRENT_SCENE_DATA.darkness_filter > 0 && !is_token_under_light_aura(id)))) {
 
@@ -498,7 +498,7 @@ function do_check_token_visibility() {
 		let auraSelector = ".aura-element[id='light_" + auraSelectorId + "']";
 
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-		let playerTokenAuraIsLight = (playerTokenId == undefined) ? false : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+		let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
 			
 		if (!window.TOKEN_OBJECTS[id].options.revealInFog && (pixeldata[3] == 255 || (pixeldata2[2] == 0 && playerTokenAuraIsLight) || (playerTokenAuraIsLight && window.CURRENT_SCENE_DATA.darkness_filter > 0  && (!is_token_under_light_aura(id) && pixeldata[2] == 0 && window.CURRENT_SCENE_DATA.darkness_filter == 100)))) {
 			$(selector).hide();

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1266,9 +1266,9 @@ class MessageBroker {
 			if(window.DM && msg.loading){
 				window.TOKEN_OBJECTS[data.id].update_and_sync();
 			}
-			
-			if(playerTokenId != undefined && data.auraislight){
-				if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
+			let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+			if(data.auraislight){
+				if(playerTokenAuraIsLight){
 						check_token_visibility();
 				}
 				else{
@@ -1299,9 +1299,10 @@ class MessageBroker {
 			t.place();
 
 			let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-			if(playerTokenId != undefined && data.auraislight){
-				if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
-						check_token_visibility()
+			let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+			if(data.auraislight){
+				if(playerTokenAuraIsLight){
+						check_token_visibility();
 				}
 				else{
 					check_single_token_visibility(data.id);
@@ -1426,9 +1427,7 @@ class MessageBroker {
 					persist: false
 				});
 			}
-			if(!window.DM)
-					check_token_visibility();
-	
+
 			if(window.CLOUD){
 				let data = {
 					loading: true,
@@ -1445,7 +1444,9 @@ class MessageBroker {
 			else{
 			 	window.MB.sendMessage('custom/myVTT/syncmeup');
 			}
-
+			if(!window.DM)
+					check_token_visibility();
+	
 
 			if (window.EncounterHandler !== undefined) {
 				fetch_and_cache_scene_monster_items();

--- a/Token.js
+++ b/Token.js
@@ -741,8 +741,9 @@ class Token {
 			self.persist(e);
 		
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-		if(playerTokenId != undefined && self.options.auraislight){
-			if(window.TOKEN_OBJECTS[playerTokenId].options.auraislight){
+		let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+		if(self.options.auraislight){
+			if(playerTokenAuraIsLight){
 					check_token_visibility()
 			}
 			else{
@@ -2672,7 +2673,7 @@ function setTokenLight (token, options) {
 
 	const innerlightSize = options.light1.feet.length > 0 ? (options.light1.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
 	const outerlightSize = options.light2.feet.length > 0 ? (options.light2.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
-	if ((innerlightSize > 0 || outerlightSize > 0) && options.auraislight) {
+	if (options.auraislight) {
 		// use sizeWidth and sizeHeight???
 		const totallight = innerlightSize + outerlightSize;
 		const lightRadius = innerlightSize ? (innerlightSize + (options.size/window.CURRENT_SCENE_DATA.scale_factor / 2)) : 0;
@@ -2718,16 +2719,15 @@ function setTokenLight (token, options) {
 	}
 	if(!window.DM){
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-		if(playerTokenId != undefined){
-			
-			let lights = $("[id^='light_']");
-			for(let i = 0; i < lights.length; i++){
-				if(!lights[i].id.endsWith(window.PLAYER_ID) && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.player_owned && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light){
-					$(lights[i]).css("visibility", "hidden");
-				}
-			}
-			
-
+		
+		let lights = $("[id^='light_']");
+		for(let i = 0; i < lights.length; i++){
+			if(!lights[i].id.endsWith(window.PLAYER_ID) && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.player_owned && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light){
+				$(lights[i]).css("visibility", "hidden");
+			}		
+			if(playerTokenId == undefined && window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.itemType == 'pc'){
+				$(lights[i]).css("visibility", "visible");
+			}	
 		}
 	}
 }


### PR DESCRIPTION
Two more of the feedback issues I think should be fixed.

When a player is connected without their token placed show all player vision. 

When a token has 0/0 vision allow them to see revealed light still.