### PR TITLE
Fix: Revealed hidden light should not have lowered opacity for DMs

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -2696,7 +2696,7 @@ function setTokenLight (token, options) {
 			$("#scene_map_container").prepend(lightElement);
 		}
 		if(window.DM){
-			options.hidden ? token.parent().parent().find("#light_" + tokenId).css("opacity", 0.5)
+			(options.hidden && !options.reveal_light) ? token.parent().parent().find("#light_" + tokenId).css("opacity", 0.5)
 			: token.parent().parent().find("#light_" + tokenId).css("opacity", 1)
 		}
 		else{


### PR DESCRIPTION
Currently when a token is hidden with revealed light (a hidden light source) it shows at a lower opacity for DM's. This makes it fully visible.