### PR TITLE
Chore: Remove all references to window.CLOUD

### DIFF
--- a/AboveApi.js
+++ b/AboveApi.js
@@ -71,19 +71,18 @@ class AboveApi {
     return response;
   }
 
+  // Until we store more than {cloud:1} this isn't necessary
   static async getCampaignData() {
-    console.debug("startup", "getCampaignData")
     const response = await this.fetchJson("getCampaignData");
-    console.log("startup", "AboveApi.getCampaignData", response);
-    window.CLOUD = !!response?.Item?.data?.cloud;
+    console.log("AboveApi.getCampaignData", response);
     if(response.Item && response.Item.data) {
       return response.Item.data
     }
     return {};
   }
 
+  // Until we store more than {cloud:1} this isn't necessary
   static async setCampaignData() {
-    console.debug("startup", "setCampaignData")
     const config = {
       method: 'PUT',
       headers: {
@@ -95,7 +94,7 @@ class AboveApi {
     const url = this.#buildUrl("setCampaignData")
     const request = await fetch(url, config);
     const response = await request.json();
-    console.log("startup", "AboveApi.setCampaignData", response);
+    console.log("AboveApi.setCampaignData", response);
     return response;
   }
 

--- a/Fog.js
+++ b/Fog.js
@@ -1481,13 +1481,7 @@ function drawing_mouseup(e) {
 
 		
 		redraw_drawings();
-
-		if(window.DM)
-			window.ScenesHandler.persist();
-		if(window.CLOUD)
-			sync_drawings();
-		else
-			window.MB.sendMessage('custom/myVTT/drawing', data);
+		sync_drawings();
 	}
 	else if (window.DRAWFUNCTION === "eraser"){
 		if (window.DRAWSHAPE === "rect"){
@@ -1526,12 +1520,9 @@ function drawing_mouseup(e) {
 
 			}
 		}
-		if(window.DM)
-			window.ScenesHandler.persist();
-		if(window.CLOUD)
-			sync_drawings();
-		else
-			window.MB.sendMessage('custom/myVTT/drawing', data);
+
+		sync_drawings();
+
 	}
 	else if (window.DRAWFUNCTION === "wall-eraser"){
 		let canvas = $("#raycastingCanvas")[0];
@@ -1727,12 +1718,8 @@ function drawing_mouseup(e) {
 
 		redraw_light_walls();
 		redraw_light();
-		window.ScenesHandler.persist();
-		if(window.CLOUD)
-			sync_drawings();
-		else
-			window.MB.sendMessage('custom/myVTT/drawing', data);
-	}	
+		sync_drawings();
+	}
 	else if (window.DRAWFUNCTION === "draw_text"){
 		data[0] = "text";
 		const textWidth = e.clientX - window.BEGIN_MOUSEX
@@ -1855,30 +1842,18 @@ function finalise_drawing_fog(mouseX, mouseY, width, height) {
 		const radius = Math.round(Math.sqrt(Math.pow(centerX - mouseX, 2) + Math.pow(centerY - mouseY, 2)));
 		data = [centerX, centerY, radius, 0, 1, fog_type_to_int(), window.CURRENT_SCENE_DATA.scale_factor];
 		window.REVEALED.push(data);
-		if(window.CLOUD)
-			sync_fog();
-		else
-			window.MB.sendMessage('custom/myVTT/reveal', data);
-		window.ScenesHandler.persist();
+		sync_fog();
 		redraw_fog();
 	} else if (window.DRAWSHAPE == "rect") {
 		data = [window.BEGIN_MOUSEX, window.BEGIN_MOUSEY, width, height, 0, fog_type_to_int(), window.CURRENT_SCENE_DATA.scale_factor];
 		window.REVEALED.push(data);
-		if(window.CLOUD)
-			sync_fog();
-		else
-			window.MB.sendMessage('custom/myVTT/reveal', data);
-		window.ScenesHandler.persist();
+		sync_fog();
 		redraw_fog();
 	}
 	else if(window.DRAWSHAPE == "paint-bucket"){
 		data = [mouseX, mouseY, null, null, 4, fog_type_to_int(), window.CURRENT_SCENE_DATA.scale_factor]
 		window.REVEALED.push(data);
-		if(window.CLOUD)
-			sync_fog();
-		else
-			window.MB.sendMessage('custom/myVTT/reveal', data);
-		window.ScenesHandler.persist();
+		sync_fog();
 		redraw_fog();
 	}
 }
@@ -2240,23 +2215,10 @@ function savePolygon(e) {
 	}
 	clear_temp_canvas()
 
-	if(window.DM)
-		window.ScenesHandler.persist();
-
-	if(window.CLOUD){
-		if(window.DRAWFUNCTION === "draw"){
-			sync_drawings();
-		}
-		else{
-			sync_fog();
-		}
-	}
-	else{
-		window.MB.sendMessage(
-			window.DRAWFUNCTION === "draw" ?
-				 'custom/myVTT/reveal' : 'custom/myVTT/drawing',
-			data
-		);
+	if (window.DRAWFUNCTION === "draw") {
+		sync_drawings();
+	} else {
+		sync_fog();
 	}
 	window.BEGIN_MOUSEX = [];
 	window.BEGIN_MOUSEY = [];
@@ -2361,13 +2323,7 @@ function init_fog_menu(buttons){
 			window.REVEALED = [[0, 0, $("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor, $("#scene_map").height()*window.CURRENT_SCENE_DATA.scale_factor, 0, 0, window.CURRENT_SCENE_DATA.scale_factor]];
 
 			redraw_fog();
-			if(window.CLOUD){
-				sync_fog();
-			}
-			else{
-				window.ScenesHandler.persist();
-				window.ScenesHandler.sync();
-			}
+			sync_fog();
 		}
 	});
 
@@ -2410,13 +2366,7 @@ function init_fog_menu(buttons){
 		if (r == true) {
 			window.REVEALED = [];
 			redraw_fog();
-			if(window.CLOUD){
-				sync_fog();
-			}
-			else{
-				window.ScenesHandler.persist();
-				window.ScenesHandler.sync();
-			}
+			sync_fog();
 		}
 	});
 
@@ -2438,13 +2388,7 @@ function init_fog_menu(buttons){
 	fog_menu.find("#fog_undo").click(function(){
 		window.REVEALED.pop();
 		redraw_fog();
-		if(window.CLOUD){
-			sync_fog();
-		}
-		else{
-			window.ScenesHandler.persist();
-			window.ScenesHandler.sync();
-		}
+		sync_fog();
 	});
 
 	fog_button = $("<button style='display:inline;width:75px;' id='fog_button' class='drawbutton menu-button hideable ddbc-tab-options__header-heading'><u>F</u>OG</button>");
@@ -2640,11 +2584,7 @@ function init_walls_menu(buttons){
 
 			redraw_light_walls();
 			redraw_light();
-	 		window.ScenesHandler.persist();
-			if(window.CLOUD)
-				sync_drawings();
-			else
-				window.MB.sendMessage('custom/myVTT/drawing', data);
+			sync_drawings();
 		}
 	});
 

--- a/Main.js
+++ b/Main.js
@@ -1,4 +1,4 @@
-var abovevtt_version = '0.74';
+var abovevtt_version = '0.74'; // TODO: use window.AVTT_VERSION instead?
 
 /**
  * Before the page refreshes perform the innards
@@ -1056,19 +1056,17 @@ function init_controls() {
 		b2.append(b2ImageDivWrapper);
 		sidebarControls.append(b2);
 
-		if (window.CLOUD) {
-			let b3 = $("<div id='switch_scenes' class='tab-btn hasTooltip button-icon blue-tab' data-name='Scenes' data-target='#scenes-panel'></div>").click(switch_control);
-			let b3ImageDiv = $('<div></div>');
-			let b3ImageDivWrapper = $('<div class="sidebar-tab-image" style="width:100%;height:100%;"></div>');
-			let b3Image = `${window.EXTENSION_PATH}assets/icons/photo.svg`;
-			b3ImageDiv.css({
-				"mask": `url(${b3Image}) no-repeat center / contain`,
-				"-webkit-mask": `url(${b3Image}) no-repeat center / contain`
-			});
-			b3ImageDivWrapper.append(b3ImageDiv);
-			b3.append(b3ImageDivWrapper);
-			sidebarControls.append(b3);
-		}
+		let b3 = $("<div id='switch_scenes' class='tab-btn hasTooltip button-icon blue-tab' data-name='Scenes' data-target='#scenes-panel'></div>").click(switch_control);
+		let b3ImageDiv = $('<div></div>');
+		let b3ImageDivWrapper = $('<div class="sidebar-tab-image" style="width:100%;height:100%;"></div>');
+		let b3Image = `${window.EXTENSION_PATH}assets/icons/photo.svg`;
+		b3ImageDiv.css({
+			"mask": `url(${b3Image}) no-repeat center / contain`,
+			"-webkit-mask": `url(${b3Image}) no-repeat center / contain`
+		});
+		b3ImageDivWrapper.append(b3ImageDiv);
+		b3.append(b3ImageDivWrapper);
+		sidebarControls.append(b3);
 	} else {
 		let b2 = $("<div id='switch_characters' class='tab-btn hasTooltip button-icon blue-tab' data-name='Players' data-target='#players-panel'></div>").click(switch_control);
 		let b2ImageDiv = $('<div></div>');
@@ -2689,13 +2687,7 @@ function init_ui() {
 
 	window.WaypointManager=new WaypointManagerClass();
 
-	if (window.DM) {
-		setTimeout(function() {
-			if(!window.CLOUD){
-				window.ScenesHandler.switch_scene(window.ScenesHandler.current_scene_id, ct_load); // LOAD THE SCENE AND PASS CT_LOAD AS CALLBACK
-			}
-		}, 5000);
-	}
+	// TODO: I don't think this needs to be a timeout any more. Figure what window.STARTING does and make this better
 	setTimeout(function() {
 		window.STARTING = false;
 	}, 6000);

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -410,21 +410,19 @@ class MessageBroker {
 				}
 			}
 
-			if(window.CLOUD && msg.sceneId && window.CURRENT_SCENE_DATA){ // WE NEED TO IGNORE CERTAIN MESSAGE IF THEY'RE NOT FROM THE CURRENT SCENE
-				if(msg.sceneId!=window.CURRENT_SCENE_DATA.id){
-					if(["custom/myVTT/delete_token",
-						"custom/myVTT/createtoken",
-						"custom/myVTT/reveal",
-						"custom/myVTT/fogdata",
-						"custom/myVTT/drawing",
-						"custom/myVTT/drawdata",
-						"custom/myVTT/highlight",
-						"custom/myVTT/pointer",
-					   ].includes(msg.eventType)){
-						   console.log("skipping msg from a different scene");
-					   	return;
-					   }
-				}
+			// WE NEED TO IGNORE CERTAIN MESSAGE IF THEY'RE NOT FROM THE CURRENT SCENE
+			if (msg.sceneId && window.CURRENT_SCENE_DATA && msg.sceneId !== window.CURRENT_SCENE_DATA.id && [
+				"custom/myVTT/delete_token",
+				"custom/myVTT/createtoken",
+				"custom/myVTT/reveal",
+				"custom/myVTT/fogdata",
+				"custom/myVTT/drawing",
+				"custom/myVTT/drawdata",
+				"custom/myVTT/highlight",
+				"custom/myVTT/pointer"
+			].includes(msg.eventType)) {
+				console.log("skipping msg from a different scene");
+				return;
 			}
 
 			if (msg.eventType == "custom/myVTT/token" && (msg.sceneId == window.CURRENT_SCENE_DATA.id || msg.data.id in window.TOKEN_OBJECTS)) {
@@ -1312,20 +1310,10 @@ class MessageBroker {
 				check_single_token_visibility(data.id);
 			}
 		}
-
-
-	if (window.DM) {
-		console.log("**** persistoooooooooo token");
-		window.ScenesHandler.persist();
-	}
 }
 
 	handleScene(msg) {
 		console.debug("handlescene", msg);
-		if (window.DM && ! (window.CLOUD) ) {
-			alert('WARNING!!!!!!!!!!!!! ANOTHER USER JOINED AS DM!!!! ONLY ONE USER SHOULD JOIN AS DM. EXITING NOW!!!');
-			location.reload();
-		}
 
 		// DISABLED THANKS TO POLLING
 		/*if ((!window.DM) && (typeof window.PLAYERDATA !== "undefined")) {
@@ -1336,7 +1324,6 @@ class MessageBroker {
 		let data = msg.data;
 		let self=this;
 
-		if(window.CLOUD){
 			if(data.dm_map_usable=="1"){ // IN THE CLOUD WE DON'T RECEIVE WIDTH AND HEIGT. ALWAYS LOAD THE DM_MAP FIRST, AS TO GET THE PROPER WIDTH
 				data.map=data.dm_map;
 				if(data.dm_map_is_video=="1")
@@ -1347,7 +1334,6 @@ class MessageBroker {
 				if(data.player_map_is_video=="1")
 					data.is_video=true;
 			}
-		}
 
 		for(const i in msg.data.tokens){
 			if(i == msg.data.tokens[i].id)
@@ -1357,7 +1343,7 @@ class MessageBroker {
 		}
 		msg.data.tokens = Object.fromEntries(Object.entries(msg.data.tokens).filter(([_, v]) => v != null));
 		window.CURRENT_SCENE_DATA = msg.data;
-		if(window.CLOUD && window.DM){
+		if(window.DM){
 			window.ScenesHandler.scene=window.CURRENT_SCENE_DATA;
 		}
 		window.CURRENT_SCENE_DATA.vpps=parseFloat(window.CURRENT_SCENE_DATA.vpps);
@@ -1407,7 +1393,7 @@ class MessageBroker {
 			set_default_vttwrapper_size()
 			
 			// WE USED THE DM MAP TO GET RIGH WIDTH/HEIGHT. NOW WE REVERT TO THE PLAYER MAP
-			if(window.CLOUD && !window.DM && data.dm_map_usable=="1"){
+			if(!window.DM && data.dm_map_usable=="1"){
 				$("#scene_map").stop();
 				$("#scene_map").css("opacity","0");
 				console.log("switching back to player map");
@@ -1428,15 +1414,12 @@ class MessageBroker {
 				});
 			}
 
-			if(window.CLOUD){
-				let data = {
+				$("#combat_area").empty();
+				ct_load({
 					loading: true,
 					current: $("#combat_area [data-current]").attr('data-target')
-				}
-				$("#combat_area").empty();
-				ct_load(data);
+				});
 				redraw_light();
-			}
 
 
 			if(window.DM)
@@ -1446,7 +1429,7 @@ class MessageBroker {
 			}
 			if(!window.DM)
 					check_token_visibility();
-	
+
 
 			if (window.EncounterHandler !== undefined) {
 				fetch_and_cache_scene_monster_items();
@@ -1497,11 +1480,10 @@ class MessageBroker {
 
 	handleSyncMeUp(msg) {
 		if (DM) {
-			window.ScenesHandler.sync();
 			ct_persist(); // force refresh of combat tracker for late users
 			if (window.CURRENT_SOUNDPAD) {
 				let audioPlaying;
-				for(i in $("audio")){
+				for(const i in $("audio")){
 			    if($("audio")[i].paused == false){
 			    		audioPlaying = true;
 			        break;
@@ -1523,7 +1505,7 @@ class MessageBroker {
 
 	handleAudioPlayingSync(msg){
 		if(window.DM){
-			for(i in $("audio")){
+			for(const i in $("audio")){
 		    if($("audio")[i].paused == false){
 		    	var data={
 						channel: i,
@@ -1628,7 +1610,6 @@ class MessageBroker {
 			data: data,
 		}
 
-		if(window.CLOUD)
 			message.cloud=1;
 
 		if(!["custom/myVTT/switch_scene","custom/myVTT/update_scene"].includes(eventType))

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -211,53 +211,9 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			}
 		});
 
-
-
-
-		this.persist();
-
 		// some things can't be done correctly until after the scene finishes loading
 		redraw_settings_panel_token_examples();
-
 	}
-
-	sync() {
-		if(window.CLOUD)
-			return;
-		console.log('inviooooooooooooooooooooooooooooooooooooooooooo');
-
-		$("#scene_map").width();
-
-		var data = {};
-		data.id=window.CURRENT_SCENE_DATA.id;
-		
-		data.grid = window.CURRENT_SCENE_DATA.grid;
-		data.snap = window.CURRENT_SCENE_DATA.snap;
-		//data.scale=window.CURRENT_SCENE_DATA.scaleX;
-		data.hpps = window.CURRENT_SCENE_DATA.hpps;
-		data.vpps = window.CURRENT_SCENE_DATA.vpps;
-		data.fpsq = window.CURRENT_SCENE_DATA.fpsq;
-		data.upsq = window.CURRENT_SCENE_DATA.upsq;
-		
-		data.grid_subdivded = window.CURRENT_SCENE_DATA.grid_subdivided;
-		data.offsetx = window.CURRENT_SCENE_DATA.offsetx;
-		data.offsety = window.CURRENT_SCENE_DATA.offsety;
-
-		data.map = this.scene.player_map;
-		data.is_video = this.scene.player_map_is_video;
-		data.width = $("#scene_map").width();
-		data.height = $("#scene_map").height();
-		data.tokens = [];
-		data.fog_of_war = this.scene.fog_of_war;
-		data.reveals = window.REVEALED;
-		data.drawings = window.DRAWINGS;
-		for (var id in window.TOKEN_OBJECTS) {
-			data.tokens[id].push(window.TOKEN_OBJECTS[id].options);
-		}
-
-		window.MB.sendMessage('custom/myVTT/scene', data); // issue with message size ??
-	}
-
 
 	display_scene_properties(scene_id) {
 		console.log('inizio....');
@@ -302,8 +258,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				};
 			});
 			iframe.remove();
-			//self.persist();
-			
+
 			// SORT
 			self.sources = Object.keys(scraped_sources)
 				.sort(
@@ -393,7 +348,6 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				});
 			}
 			iframe.remove();
-			self.persist();
 			callback();
 		});
 	}
@@ -582,7 +536,6 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			}
 
 			iframe.remove();
-			self.persist();
 			console.log('INVOKO CALLBACK');
 			callback();
 		});
@@ -598,10 +551,6 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 			window.TOKEN_OBJECTS[id] = new Token(options);
 
-			window.TOKEN_OBJECTS[id].persist = function() {
-				self.persist();
-			}
-
 			window.TOKEN_OBJECTS[id].sync = function() {
 				window.MB.sendMessage('custom/myVTT/token', window.TOKEN_OBJECTS[id].options);
 			}
@@ -609,8 +558,6 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 		window.TOKEN_OBJECTS[id].place();
 		this.scene.hasTokens = true;
-		if (save)
-			this.persist();
 	}
 
 
@@ -633,84 +580,26 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		window.MB.sendMessage("custom/myVTT/update_scene",sceneData,dontswitch);
 	}
 
-	delete_scene(sceneId) { // not the index, but the actual id
-		if(!window.CLOUD) return;
+	delete_scene(sceneId, reloadUI = true) { // not the index, but the actual id
 		window.MB.sendMessage("custom/myVTT/delete_scene",{ id: sceneId });
 		let sceneIndex = window.ScenesHandler.scenes.findIndex(s => s.id === sceneId);
 		window.ScenesHandler.scenes.splice(sceneIndex, 1);
+		if (reloadUI) {
+			did_update_scenes();
+		}
 	}
 
 	persist() {
-		if(window.CLOUD)
-			return;
-		console.log("persisting");
-		if (window.STARTING)
-			return;
-
-		for (var id in window.TOKEN_OBJECTS) {
-			this.scene.tokens[id] = window.TOKEN_OBJECTS[id].options;
-		}
-
-		if (typeof this.scene !== "undefined") {
-			this.scene.reveals = [].concat(window.REVEALED); // USE A CLONE OF THE CURRENT REVEALED ARRAY...
-			this.scene.drawings = [].concat(window.DRAWINGS);
-		}
-
-		localStorage.setItem("ScenesHandler" + this.gameid, JSON.stringify(this.scenes));
-		localStorage.setItem("CurrentScene" + this.gameid, this.current_scene_id);
+		console.error("ScenesHandler.persist is no longer a function. Stop calling it!");
 	}
 
-	constructor(gameid) {
-		this.gameid = gameid;
+	sync() {
+		console.error("ScenesHandler.sync is no longer a function. Stop calling it!");
+	}
 
+	constructor() {
 		this.sources = {};
-
-
-		if(window.CLOUD){
-			const fromStorage = localStorage.getItem(`ScenesHandler${find_game_id()}`);
-			if (fromStorage != null) {
-				this.scenes = $.parseJSON(fromStorage);
-				console.debug("from localStorage", `ScenesHandler${find_game_id()}`, this.scenes);
-			} else {
-				this.scenes=[];
-			}
-			this.current_scene_id=null;
-		}
-		else{ // LEGACY
-			if (localStorage.getItem('ScenesHandler' + gameid) != null) {
-				this.scenes = $.parseJSON(localStorage.getItem('ScenesHandler' + gameid));
-				this.current_scene_id = localStorage.getItem("CurrentScene" + gameid);
-				if (!this.scenes.hasOwnProperty('player_map_is_video')) {
-					this.scenes.player_map_is_video = "0";
-				}
-				if (!this.scenes.hasOwnProperty('dm_map_is_video')) {
-					this.scenes.dm_map_is_video = "0";
-				}
-			}
-			else {
-				this.scenes = [];
-				this.scenes.push({
-					title: "The Tavern",
-					dm_map: "",
-					player_map: "https://i.pinimg.com/originals/a2/04/d4/a204d4a2faceb7f4ae93e8bd9d146469.jpg",
-					scale: "100",
-					dm_map_usable: "0",
-					player_map_is_video: "0",
-					dm_map_is_video: "0",
-					fog_of_war: "1",
-					tokens: {},
-					grid: "0",
-					hpps: "72",
-					vpps: "72",
-					snap: "1",
-					fpsq: "5",
-					upsq: "ft",
-					offsetx: 29,
-					offsety: 54,
-					reveals: [[0, 0, 0, 0, 2, 0]],
-				});
-				this.current_scene_id = 0;
-			}
-		} // END OF LEGACY
+		this.scenes = [];
+		this.current_scene_id = null;
 	}
 }

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -482,11 +482,7 @@ function edit_scene_dialog(scene_id) {
 		scene.fog_of_war = "1";
 
 
-	const submitButton = $("<button type='button'>Save And Switch</button>");
-
-	if(window.CLOUD)
-		submitButton.html("Save");
-
+	const submitButton = $("<button type='button'>Save</button>");
 	submitButton.click(function() {
 		console.log("Saving scene changes")
 
@@ -495,14 +491,8 @@ function edit_scene_dialog(scene_id) {
 			scene[key] = formData[key];
 		}
 
-		if(window.CLOUD){
-			const isNew = false;
-			window.ScenesHandler.persist_scene(scene_id, isNew);
-		}
-		else{
-			window.ScenesHandler.persist();
-			window.ScenesHandler.switch_scene(scene_id);
-		}
+		const isNew = false;
+		window.ScenesHandler.persist_scene(scene_id, isNew);
 		$("#edit_dialog").remove();
 		$("#scene_selector").removeAttr("disabled");
 		$("#scene_selector_toggle").click();
@@ -519,10 +509,7 @@ function edit_scene_dialog(scene_id) {
 		window.ScenesHandler.scene.upsq = "ft";
 		window.ScenesHandler.scene.grid_subdivided = "0";
 		consider_upscaling(window.ScenesHandler.scene);
-		if(window.CLOUD)
-			window.ScenesHandler.persist_current_scene();
-		else
-			window.ScenesHandler.persist();	
+		window.ScenesHandler.persist_current_scene();
 		window.ScenesHandler.reload();
 		$("#wizard_popup").empty().append("You're good to go!!");
 		$("#exitWizard").remove();
@@ -553,10 +540,7 @@ function edit_scene_dialog(scene_id) {
 			$("#wizard_popup").delay(5000).animate({ opacity: 0 }, 4000, function() {
 				$("#wizard_popup").remove();
 			});
-			if(window.CLOUD)
-				window.ScenesHandler.persist_current_scene();
-			else
-				window.ScenesHandler.persist();
+			window.ScenesHandler.persist_current_scene();
 			window.ScenesHandler.reload();
 			$("#raycastingCanvas").css('visibility', 'visible');
 			$("#darkness_layer").css('visibility', 'visible');
@@ -572,10 +556,7 @@ function edit_scene_dialog(scene_id) {
 			window.ScenesHandler.scene.fpsq = "10";
 			window.ScenesHandler.scene.upsq = "ft";
 			consider_upscaling(window.ScenesHandler.scene);
-			if(window.CLOUD)
-				window.ScenesHandler.persist_current_scene();
-			else
-				window.ScenesHandler.persist();
+			window.ScenesHandler.persist_current_scene();
 			window.ScenesHandler.reload();
 			$("#exitWizard").remove();
 			$("#wizard_popup").empty().append("You're good to go! Medium token will match the original grid size");
@@ -601,10 +582,7 @@ function edit_scene_dialog(scene_id) {
 		$("#wizard_popup").delay(5000).animate({ opacity: 0 }, 4000, function() {
 			$("#wizard_popup").remove();
 		});
-		if(window.CLOUD)
-			window.ScenesHandler.persist_current_scene();
-		else
-			window.ScenesHandler.persist();
+		window.ScenesHandler.persist_current_scene();
 		$("#exitWizard").remove();
 		window.ScenesHandler.reload();
 		$("#raycastingCanvas").css('visibility', 'visible');
@@ -626,10 +604,7 @@ function edit_scene_dialog(scene_id) {
 		$("#wizard_popup").delay(5000).animate({ opacity: 0 }, 4000, function() {
 			$("#wizard_popup").remove();
 		});
-		if(window.CLOUD)
-			window.ScenesHandler.persist_current_scene();
-		else
-			window.ScenesHandler.persist();
+		window.ScenesHandler.persist_current_scene();
 		$("#exitWizard").remove();
 		window.ScenesHandler.reload();
 		$("#raycastingCanvas").css('visibility', 'visible');
@@ -641,7 +616,6 @@ function edit_scene_dialog(scene_id) {
 
 		window.ScenesHandler.scenes[scene_id].scale_factor=1;		
     
-		/*window.ScenesHandler.persist();*/
 		window.ScenesHandler.switch_scene(scene_id, function() {
 			$("#tokens").hide();
 			window.CURRENT_SCENE_DATA.grid_subdivided = "0";
@@ -967,14 +941,7 @@ function edit_scene_dialog(scene_id) {
 				scene[key] = formData[key];
 			}
 
-			if(window.CLOUD){
-				window.ScenesHandler.persist_scene(scene_id,true);
-			}
-			else{
-				window.ScenesHandler.persist();
-				window.ScenesHandler.switch_scene(scene_id);
-			}
-			
+			window.ScenesHandler.persist_scene(scene_id,true);
 			window.ScenesHandler.switch_scene(scene_id);
 			let copiedSceneData = $.extend(true, {}, window.CURRENT_SCENE_DATA);
 
@@ -1066,23 +1033,6 @@ function edit_scene_dialog(scene_id) {
 	})
 
 
-	var hide_all_button = $("<button type='button'>COVER WITH FOG</button>");
-	if(window.CLOUD){
-		hide_all_button.hide();
-	}
-	hide_all_button.click(function() {
-		r = confirm("This will delete all current FOG zones on this scene and HIDE ALL THE MAP to the player. Are you sure?");
-		if (r == true) {
-			scene.reveals = [];
-			if (scene_id == window.ScenesHandler.current_scene_id) {
-				window.REVEALED = [];
-				redraw_fog();
-			}
-			window.ScenesHandler.persist();
-			window.ScenesHandler.sync();
-		}
-	});
-
 	/*var export_grid=$("<button>Send Grid Data to the Community</button>")
 	export_grid.click(function(){
 	});*/
@@ -1091,7 +1041,6 @@ function edit_scene_dialog(scene_id) {
 
 	form.append(submitButton);
 	form.append(cancel);
-	form.append(hide_all_button);
 	//		f.append(export_grid);
 	container.css('opacity', '0.0');
 	container.append(form);
@@ -1110,228 +1059,6 @@ function edit_scene_dialog(scene_id) {
 	$("#edit_scene_form").find(`[name='dm_map']`).attr("placeholder", "Only the DM will see this image/video");
 	validate_image_input($(playerMapRow).find("input")[0])
 	validate_image_input($(dmMapRow).find("input")[0])
-}
-
-function refresh_scenes() {
-	target = $("#scene_selector");
-	target.find(".scene").remove();
-
-	for (var i = 0; i < window.ScenesHandler.scenes.length; i++) {
-		let scene_id = i;
-		var scene = window.ScenesHandler.scenes[i];
-		var newobj = $("<div class='scene' data-scene-index='"+i+"'/>");
-
-
-		title = $("<div class='scene_title' style='text-align:center;'/>");
-		title.html(scene.title);
-
-		if ( (i == window.ScenesHandler.current_scene_id)   && (!window.CLOUD))
-			newobj.addClass('active_scene');
-		newobj.append(title);
-		controls = $("<div/>");
-		if(window.CLOUD){
-			let switch_players=$("<button class='player_scenes_button'>PLAYERS</button>");
-
-			if(window.PLAYER_SCENE_ID==window.ScenesHandler.scenes[scene_id].id){
-				console.log("players are here!");
-				switch_players.addClass("selected");
-			}
-
-			switch_players.click(function(){
-				let msg={
-					sceneId:window.ScenesHandler.scenes[scene_id].id,
-				};
-				window.PLAYER_SCENE_ID=window.ScenesHandler.scenes[scene_id].id;
-				$(".player_scenes_button.selected").removeClass("selected");
-				$(this).addClass("selected");
-				window.MB.sendMessage("custom/myVTT/switch_scene",msg);
-				add_zoom_to_storage()
-			});
-			
-			let switch_dm=$("<button class='dm_scenes_button'>DM</button>");
-			if(window.CURRENT_SCENE_DATA && (window.CURRENT_SCENE_DATA.id==window.ScenesHandler.scenes[scene_id].id)){
-				switch_dm.addClass("selected");
-			}
-			switch_dm.click(function(){
-				$(".dm_scenes_button.selected").removeClass("selected");
-				let msg={
-					sceneId:window.ScenesHandler.scenes[scene_id].id,
-					switch_dm: true
-				};
-				$(this).addClass("selected");
-				window.MB.sendMessage("custom/myVTT/switch_scene",msg);
-				add_zoom_to_storage()
-			});
-			if(scene.player_map){
-				switch_players.removeAttr("disabled");
-				switch_dm.removeAttr("disabled");
-			}
-			else{
-				switch_players.attr("disabled","true");
-				switch_dm.attr("disabled","true");
-			}
-			
-			controls.append(switch_players);
-			controls.append(switch_dm);
-		}
-		else{
-			switch_button = $("<button>SWITCH</button>");
-			if(scene.player_map)
-				switch_button.removeAttr("disabled");
-			else
-				switch_button.attr("disabled","true");
-				
-			switch_button.click(function() {
-				window.ScenesHandler.switch_scene(scene_id);
-				$("#scene_selector_toggle").click();
-				refresh_scenes();
-			});
-			controls.append(switch_button);
-		}
-		edit_button = $("<button><img height=10 src='"+window.EXTENSION_PATH+"assets/icons/edit.svg'></button>");
-		edit_button.click(function() {
-			edit_scene_dialog(scene_id);
-		});
-		controls.append(edit_button);
-		delete_button=$("<button><img height=10 src='"+window.EXTENSION_PATH+"assets/icons/delete.svg'></button>");
-		delete_button.click(function() {
-			r = confirm("Are you sure that you want to delete this scene?");
-			if (r == true) {
-				if(window.CLOUD){
-					window.MB.sendMessage("custom/myVTT/delete_scene",{id:window.ScenesHandler.scenes[scene_id].id})
-				}
-				window.ScenesHandler.scenes.splice(scene_id, 1);
-				if(!window.CLOUD){
-					window.ScenesHandler.persist();
-				}
-				refresh_scenes();
-				
-			}
-		});
-		controls.append(delete_button);
-		newobj.append(controls);
-
-		$("#addscene").parent().before(newobj);	
-	}
-	if(!$("#scene_selector").hasClass("ui-sortable")) {
-		$("#scene_selector").sortable({
-			handle: ".scene_title",
-			forcePlaceholderSize: true,
-			placeholder: "sortable_placeholder", 
-			update: function(event, ui) {
-				let fromSceneIndex = ui.item.attr("data-scene-index");
-				let toSceneIndex;
-				let j = 0;
-				let tempScenes = [];
-				$("#scene_selector").children('.scene').each(function(j) {
-					let oldSceneID = $(this).attr("data-scene-index");
-					if (fromSceneIndex == oldSceneID) {
-						toSceneIndex = j;
-					}
-					tempScenes.push(window.ScenesHandler.scenes[oldSceneID]);
-					$(this).attr("data-scene-index", j);
-					if ($(this).hasClass('active_scene')) {
-						window.ScenesHandler.current_scene_id = j;
-					}
-					j++;
-				});
-				console.log("Scene "+fromSceneIndex+" moved to "+toSceneIndex);
-				if(window.CLOUD){
-					let neworder;
-					console.log(window.ScenesHandler.scenes);
-					if(toSceneIndex < fromSceneIndex){ // moving back
-						if(toSceneIndex==0)
-							neworder=window.ScenesHandler.scenes[0].order-100;
-						else
-							neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex-1].order)/2);
-					}
-					else{
-						if(toSceneIndex==(window.ScenesHandler.scenes.length-1)){
-							neworder=window.ScenesHandler.scenes[toSceneIndex].order+100;
-						}
-						else
-							neworder=Math.round((window.ScenesHandler.scenes[toSceneIndex].order + window.ScenesHandler.scenes[toSceneIndex+1].order)/2);
-					}
-					window.ScenesHandler.scenes[fromSceneIndex].order=neworder;
-					window.ScenesHandler.persist_scene(fromSceneIndex);
-				}
-				window.ScenesHandler.scenes = tempScenes;
-				window.ScenesHandler.persist();
-				refresh_scenes();
-			}
-		});
-	}
-	$("#scene_selector").css("overflow","auto");
-}
-
-function init_scene_selector() {
-	if (window.CLOUD) return;
-	ss = $("<div  id='scene_selector' />");
-	ss.hide();
-
-
-	addblock = $("<div style='float:left;overflow: hidden;display:block;'/>");
-	addbutton = $("<button id='addscene'><span class='material-icons button-icon md-dark md-32'>add</span></button></button>");
-
-	addbutton.click(function() {
-		window.ScenesHandler.scenes.push({
-			id: uuid(),
-			title: "New Scene",
-			dm_map: "",
-			player_map: "",
-			scale: "100",
-			dm_map_usable: "0",
-			player_map_is_video: "0",
-			dm_map_is_video: "0",
-			fog_of_war: "1",
-			tokens: {},
-			fpsq: 5,
-			upsq: 'ft',
-			hpps: 60,
-			vpps: 60,
-			offsetx: 0,
-			offsety: 0,
-			grid: 0,
-			snap: 0,
-			reveals: [], // SPECIAL MESSAGE TO REVEAL EVERYTHING
-			order: Date.now()
-		}
-		);
-		if(window.CLOUD){
-			window.ScenesHandler.persist_scene(window.ScenesHandler.scenes.length -1,true);
-		}
-		else{
-			window.ScenesHandler.persist();
-		}
-		refresh_scenes();
-	});
-
-
-	addblock.append(addbutton);
-	ss.append(addblock);
-
-
-	let toggle = $("<div id='scene_selector_toggle' class='hideable ddbc-tab-options__header-heading'>SCENES<span class='material-icons md-dark md-14 md-weight-700'>expand_more</span></div>");
-
-	toggle.click(function() {
-		if (ss.hasClass("menu_opened")) {
-			ss.slideUp().removeClass("menu_opened");
-			toggle.removeClass("menu_opened");
-			toggle.removeClass("ddbc-tab-options__header-heading--is-active");
-		} else {
-			ss.slideDown().addClass("menu_opened");
-			toggle.addClass("menu_opened");
-			toggle.addClass("ddbc-tab-options__header-heading--is-active");
-			refresh_scenes();
-		}
-
-		
-
-	});
-	$(window.document.body).append(ss);
-	let pill = $(`<div id="scene_selector_toggle_pill" class="ddbc-tab-options--layout-pill" />`);
-	pill.append(toggle);
-	$(window.document.body).append(pill);
 }
 
 function display_sources() {
@@ -1924,7 +1651,7 @@ function create_scene_folder_inside(fullPath) {
 }
 
 function rename_scene_folder(item, newName, alertUser) {
-	console.groupCollapsed("rename_scene_folder");
+	console.group("rename_scene_folder");
 	if (!item.isTypeFolder() || !item.folderPath.startsWith(RootFolder.Scenes.path)) {
 		console.groupEnd();
 		console.warn("rename_scene_folder called with an incorrect item type", item);
@@ -2061,14 +1788,14 @@ function expand_folders_to_active_scenes() {
 }
 
 function delete_scenes_within_folder(listItem) {
-	console.groupCollapsed(`delete_scenes_within_folder`);
+	console.group(`delete_scenes_within_folder`);
 	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 
 	console.log("about to delete all scenes within", adjustedPath);
 	console.debug("before deleting from scenes", window.ScenesHandler.scenes);
 	window.ScenesHandler.scenes
 		.filter(scene => scene.folderPath?.startsWith(adjustedPath))
-		.forEach(scene => window.ScenesHandler.delete_scene(scene.id));
+		.forEach(scene => window.ScenesHandler.delete_scene(scene.id, false));
 	console.debug("after deleting from scenes", window.ScenesHandler.scenes);
 
 	console.log("about to delete all folders within", adjustedPath);
@@ -2080,7 +1807,7 @@ function delete_scenes_within_folder(listItem) {
 }
 
 function move_scenes_to_parent_folder(listItem) {
-	console.groupCollapsed(`move_scenes_to_parent_folder`);
+	console.group(`move_scenes_to_parent_folder`);
 	let adjustedPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 	let oneLevelUp = sanitize_folder_path(listItem.folderPath.replace(RootFolder.Scenes.path, ""));
 
@@ -2118,7 +1845,7 @@ function move_scene_to_folder(listItem, folderPath) {
 }
 
 function move_scenes_folder(listItem, folderPath) {
-	console.groupCollapsed(`move_scenes_folder`);
+	console.group(`move_scenes_folder`);
 	let fromPath = sanitize_folder_path(listItem.fullPath().replace(RootFolder.Scenes.path, ""));
 
 	// move the actual item

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -12,12 +12,10 @@ function init_sidebar_tabs() {
     sidebarContent.append(tokensPanel.build());
     init_tokens_panel();
 
-    if (window.CLOUD) {
       $("#scenes-panel").remove();
       scenesPanel = new SidebarPanel("scenes-panel", false);
       sidebarContent.append(scenesPanel.build());
       init_scenes_panel();
-    }
 
   } else {
     $("#players-panel").remove();
@@ -1642,7 +1640,6 @@ function delete_item(listItem) {
     case ItemType.Scene:
       if (confirm(`Are you sure that you want to delete the scene named "${listItem.name}"?`)) {
         window.ScenesHandler.delete_scene(listItem.sceneId);
-        did_update_scenes();
       }
       break;
     case ItemType.PC:

--- a/Text.js
+++ b/Text.js
@@ -665,12 +665,7 @@ function draw_text(
                 window.DRAWINGS[drawing][2] = parseInt($(this).css('top')) + parseInt(font.size);     
             }
                         
-        
-            window.ScenesHandler.persist();
-            if(window.CLOUD)
-                sync_drawings();
-            else
-                window.MB.sendMessage('custom/myVTT/drawing', data);
+            sync_drawings();
         }
     });
 
@@ -688,11 +683,7 @@ function draw_text(
             }
         }
         redraw_text();
-        window.ScenesHandler.persist();
-        if(window.CLOUD)
-            sync_drawings();
-        else
-            window.MB.sendMessage('custom/myVTT/drawing', data);
+        sync_drawings();
         return false;
     });
     textSVG.on('dblclick', function(){
@@ -718,11 +709,7 @@ function draw_text(
         
        window.DRAWINGS = window.DRAWINGS.filter((d) => d[9] != $(this)[0].id);
         $(this).remove();
-        window.ScenesHandler.persist();
-        if(window.CLOUD)
-            sync_drawings();
-        else
-            window.MB.sendMessage('custom/myVTT/drawing', data);
+        sync_drawings();
     });
 }
 

--- a/Token.js
+++ b/Token.js
@@ -51,10 +51,8 @@ class Token {
 		this.selected = false;
 		this.options = options;
 		this.sync = null;
-		this.persist = null;
-		if(window.CLOUD)
 			this.persist= ()=>{};
-		
+
 		this.doing_highlight = false;
 		if (typeof this.options.size == "undefined") {
 			this.options.size = window.CURRENT_SCENE_DATA.hpps; // one grid square
@@ -311,12 +309,8 @@ class Token {
 		$("#light_" + id.replaceAll("/", "")).remove();
 		$(`.aura-element-container-clip[id='${id}']`).remove()
 		if (persist == true) {
-			if(window.CLOUD && sync){
+			if (sync) {
 				window.MB.sendMessage("custom/myVTT/delete_token",{id:id});
-			}
-			else if(!window.CLOUD && window.DM){
-				window.ScenesHandler.persist();
-				window.ScenesHandler.sync();
 			}
 			draw_selected_token_bounding_box(); // redraw the selection box
 		}
@@ -435,8 +429,6 @@ class Token {
 	place_sync_persist() {
 		this.place();
 		this.sync();
-		if (this.persist != null)
-			this.persist();
 	}
 
 	highlight(dontscroll=false) {
@@ -737,9 +729,7 @@ class Token {
 		self.update_from_page();
 		if (self.sync != null)
 			self.sync(e);
-		if (self.persist != null)
-			self.persist(e);
-		
+
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 		let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
 		if(self.options.auraislight){
@@ -2183,9 +2173,6 @@ class Token {
 			return;
 		}
 		this.options.abilityTracker[key] = asNumber;
-		if (this.persist !== undefined && this.persist != null) {
-			this.persist();
-		}
 	}
 	// returns the stored value as a number or returns defaultValue
 	get_tracked_ability(key, defaultValue) {
@@ -3315,19 +3302,9 @@ function delete_selected_tokens() {
 	tokensToDelete.forEach(t => window.TOKEN_OBJECTS_RECENTLY_DELETED[t.options.id] = Object.assign({}, t.options));
 	console.log("delete_selected_tokens", window.TOKEN_OBJECTS_RECENTLY_DELETED);
 
-	if(window.CLOUD){
 		for (let i = 0; i < tokensToDelete.length; i++) {
 			tokensToDelete[i].delete(); // don't persist on each token delete, we'll do that next
 		}
-	}
-	else{
-		// delete these in a separate loop to prevent altering the array while iterating over it
-		for (let i = 0; i < tokensToDelete.length; i++) {
-			tokensToDelete[i].delete(false); // don't persist on each token delete, we'll do that next
-		}
-		window.ScenesHandler.persist();
-		window.ScenesHandler.sync();
-	}
 	draw_selected_token_bounding_box(); // redraw the selection box
 	ct_persist();
 }

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -72,7 +72,7 @@ function rollback_from_my_tokens() {
     console.warn("rollback_from_my_tokens is no longer supported");
     return;
 
-    console.groupCollapsed("rollback_from_my_tokens");
+    console.group("rollback_from_my_tokens");
     tokendata.didMigrateToMyToken = false;
     mytokens = [];
     mytokensfolders = [];
@@ -158,7 +158,7 @@ function find_builtin_token(fullPath) {
         console.warn("find_builtin_token was called with the wrong token type.", fullPath, "should start with", RootFolder.AboveVTT.path);
         return undefined;
     }
-    console.groupCollapsed("find_builtin_token");
+    console.group("find_builtin_token");
     let found = builtInTokens.find(t => {
         let dirtyPath = `${RootFolder.AboveVTT.path}${t.folderPath}/${t.name}`;
         let fullTokenPath = sanitize_folder_path(dirtyPath);
@@ -198,7 +198,7 @@ function backfill_mytoken_folders() {
  */
 function rebuild_token_items_list() {
     if (!window.DM) return;
-    console.groupCollapsed("rebuild_token_items_list");
+    console.group("rebuild_token_items_list");
     try {
 
 
@@ -444,7 +444,7 @@ function redraw_token_list(searchTerm, enableDraggable = true) {
         // don't do anything on startup
         return;
     }
-    console.groupCollapsed("redraw_token_list");
+    console.group("redraw_token_list");
     update_token_folders_remembered_state();
     let list = $(`<div class="custom-token-list"></div>`);
     tokensPanel.body.empty();


### PR DESCRIPTION
PR #898 made `window.CLOUD` the default. This removes it entirely. This also removes code that was only accessible if `!window.CLOUD`