### PR TITLE
QoL - In DM view reduce wall shadows darkness when the map is dark already.

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1387,6 +1387,10 @@ class MessageBroker {
    	 	let darknessPercent = 100 - parseInt(darknessfilter);
    	 	if(window.DM && darknessPercent < 25){
    	 		darknessPercent = 25;
+   	 		$('#raycastingCanvas').css('opacity', '0');
+   	 	}
+   	 	else if(window.DM){
+   	 		$('#raycastingCanvas').css('opacity', '');
    	 	}
    	 	$('#VTT').css('--darkness-filter', darknessPercent + "%");
 

--- a/Token.js
+++ b/Token.js
@@ -2547,7 +2547,10 @@ function deselect_all_tokens() {
 	if(window.DM && darknessPercent < 25){
    	 	darknessPercent = 25; 	
    	 	$('#VTT').css('--darkness-filter', darknessPercent + "%");
-   	 	$('#raycastingCanvas').css('opacity', 0.5);
+   	 	$('#raycastingCanvas').css('opacity', 0);
+   	}
+   	else if(window.DM){
+   		$('#raycastingCanvas').css('opacity', '');
    	}
    	if(window.DM){
    		$("[id^='light_']").css('visibility', "visible");


### PR DESCRIPTION
There's been feedback about maps being too dark with, darkness, fog and shadows from vision. This removes the darkness overlapping from vision when the map is already dark. You'll still see fog as darker as I think it's important to know where that is at all times.

https://cdn.discordapp.com/attachments/852495991227809802/1080942418054103151/fog_and_darkness.gif