### PR TITLE
Change reveal light to dropdown with, never, in line of sight, always; Fix some tokens snapping to odd locations; Fix checking for vision before the move animation completes

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1243,9 +1243,6 @@ class MessageBroker {
 		}
 			
 		if (data.id in window.TOKEN_OBJECTS) {
-			if(data.id == playerTokenId && window.TOKEN_OBJECTS[data.id].options.auraislight != data.auraislight){
-				auraislightchanged = true;
-			}
 			for (var property in data) {
 				if(msg.sceneId != window.CURRENT_SCENE_DATA.id && (property == "left" || property == "top" || property == "hidden"))
 					continue;				
@@ -1264,24 +1261,6 @@ class MessageBroker {
 			if(window.DM && msg.loading){
 				window.TOKEN_OBJECTS[data.id].update_and_sync();
 			}
-			let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
-			if(data.auraislight){
-				if(playerTokenAuraIsLight){
-						check_token_visibility();
-				}
-				else{
-					check_single_token_visibility(data.id);
-				}	
-			}
-			else{
-				if(auraislightchanged){
-					check_token_visibility();
-				}
-				else{
-					check_single_token_visibility(data.id);
-				}
-
-			}// CHECK FOG OF WAR VISIBILITY OF TOKEN
 		}	
 		else if(data.left){
 			// SOLO PLAYER. PUNTO UNICO DI CREAZIONE DEI TOKEN

--- a/Token.js
+++ b/Token.js
@@ -1315,7 +1315,12 @@ class Token {
 					}, { duration: animationDuration, queue: true, complete: function() {
 						draw_selected_token_bounding_box();
 						redraw_light();
-					} });
+						if(!window.DM){
+									check_token_visibility();											
+							}
+						}
+						
+					});
 				
 
 
@@ -1519,6 +1524,16 @@ class Token {
 					color: 'rgba(255, 255, 255, 0.5)'
 				}
 			}
+			if(this.options.player_owned && this.options.reveal_light != 'never' && this.options.reveal_light != 'los'){
+				this.options.reveal_light = 'always'
+			}
+			if(this.options.reveal_light == undefined || this.options.reveal_light == false){
+				this.options.reveal_light = 'never';
+			}
+			if(this.options.reveal_light == true){
+				this.options.reveal_light = 'los'
+			}
+
 			let tokenImage
 			// new aoe tokens use arrays as imsrc
 			if (!this.isAoe()){
@@ -2139,11 +2154,14 @@ class Token {
 
 				window.MULTIPLE_TOKEN_SELECTED = (count > 1);
 				draw_selected_token_bounding_box(); // update rotation bounding box
-				check_token_visibility();
 				if(window.DM){
 			   		$("[id^='light_']").css('visibility', "visible");
 			   	}
-				redraw_light();
+			   	else if(tok.options.itemType == 'pc' || token.options.player_owned){
+			   		redraw_light();
+			   	}
+				
+				check_token_visibility();
 			});
 			
 			console.groupEnd()
@@ -2641,7 +2659,7 @@ function setTokenAuras (token, options) {
 			if(window.TOKEN_OBJECTS[playerTokenId].options.auraowned){
 				let auras = $("[id^='aura_']");
 				for(let i = 0; i < auras.length; i++){
-					if(!auras[i].id.endsWith(window.PLAYER_ID) && !window.TOKEN_OBJECTS[$(auras[i]).attr("data-id")].options.player_owned && !window.TOKEN_OBJECTS[$(auras[i]).attr("data-id")].options.reveal_light){
+					if(!auras[i].id.endsWith(window.PLAYER_ID) && window.TOKEN_OBJECTS[$(auras[i]).attr("data-id")].options.reveal_light != 'los' && window.TOKEN_OBJECTS[$(auras[i]).attr("data-id")].options.reveal_light != 'always'){
 						$(auras[i]).css("visibility", "hidden");
 					}
 				}
@@ -2684,7 +2702,7 @@ function setTokenLight (token, options) {
 			$("#scene_map_container").prepend(lightElement);
 		}
 		if(window.DM){
-			(options.hidden && !options.reveal_light) ? token.parent().parent().find("#light_" + tokenId).css("opacity", 0.5)
+			(options.hidden && options.reveal_light == 'never') ? token.parent().parent().find("#light_" + tokenId).css("opacity", 0.5)
 			: token.parent().parent().find("#light_" + tokenId).css("opacity", 1)
 		}
 		else{
@@ -2709,7 +2727,7 @@ function setTokenLight (token, options) {
 		
 		let lights = $("[id^='light_']");
 		for(let i = 0; i < lights.length; i++){
-			if(!lights[i].id.endsWith(window.PLAYER_ID) && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.player_owned && !window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light){
+			if(!lights[i].id.endsWith(window.PLAYER_ID) && window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light != 'always' && window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light != 'los'){
 				$(lights[i]).css("visibility", "hidden");
 			}		
 			if(playerTokenId == undefined && window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.itemType == 'pc'){

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -807,14 +807,15 @@ function build_token_light_inputs(tokenIds) {
 	const reveallightOption = {
 		name: "reveal_light",
 		label: "Reveal light to players",
-		type: "toggle",
+		type: "dropdown",
 		options: [
-			{ value: true, label: "Enable", description: "Token light is revealed to players." },
-			{ value: false, label: "Disable", description: "Token light is revealed to players." }
+			{ value: 'never', label: "Never", description: "Token light is revealed to players." },
+			{ value: 'los', label: "When in line of sight", description: "Token light is revealed to players when in line of sight." },
+			{ value: 'always', label: "Always", description: "Token light is revealed to players always." },
 		],
 		defaultValue: false
 	};
-	let revealLightInput = build_toggle_input(reveallightOption, auraRevealLightEnabled, function(name, newValue) {
+	let revealLightInput = build_dropdown_input(reveallightOption, auraRevealLightEnabled, function(name, newValue) {
 		console.log(`${name} setting is now ${newValue}`);
 		tokens.forEach(token => {
 			token.options[name] = newValue;


### PR DESCRIPTION
- So this changes the reveal light option to 3 options

Never
When in LoS (this works like reveal currently does)
Always


Always will always show their light, for pcs/owned tokens it will show their vision as well.

- Fixes an error that occurs when closestwalls aren't found causing tokens to not be draggable properly - they snap towards the top left corner. 

- Fixes checking for token visibility before the animation finishes. This caused sometimes light to be reveal without a token or tokens to be revealed without light. Depending when the check ran in the moving animation.