### PR TITLE
rebuild how window.pcs is collected, and improve error messaging

### DIFF
--- a/AboveApi.js
+++ b/AboveApi.js
@@ -49,7 +49,7 @@ class AboveApi {
 
   static checkForErrors(response) {
     if (typeof response.message === "string" && response.message.toLowerCase().includes("error")) {
-      throw response.message;
+      throw new Error(response.message);
     }
   }
 
@@ -113,10 +113,10 @@ class AboveApi {
   static async migrateScenes(gameId, scenes) {
     console.debug(`AboveApi.migrateScenes gameId: ${gameId}`, scenes);
     if (!Array.isArray(scenes)) {
-      throw `AboveApi.migrateScenes received the wrong data type: ${typeof scenes}`;
+      throw new Error(`AboveApi.migrateScenes received the wrong data type: ${typeof scenes}`);
     }
     if (scenes.length === 0) {
-      throw `AboveApi.migrateScenes received an empty list of scenes`;
+      throw new Error(`AboveApi.migrateScenes received an empty list of scenes`);
     }
 
     // never upload data urls

--- a/CampaignPage.js
+++ b/CampaignPage.js
@@ -12,15 +12,13 @@ $(function() {
           window.MB = new MessageBroker();
           inject_chat_buttons();
         } else {
-          gather_pcs();
           inject_instructions();
           inject_dm_join_button();
           inject_player_join_buttons();
         }
       })
       .catch(error => {
-        console.error("Failed to harvest gameId and campaignSecret on", window.location.href, error);
-        showDebuggingAlert();
+        showError(error, "Failed to harvest gameId and campaignSecret on", window.location.href);
       });
   }
 });
@@ -124,8 +122,7 @@ function inject_dm_join_button() {
         }, 2000);
       })
       .catch((error) => {
-        console.error("Failed to start AboveVTT", error);
-        showDebuggingAlert();
+        showError(error, "Failed to start AboveVTT from dm join button");
       })
       .finally(() => {
         $(e.currentTarget).removeClass("button-loading");

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -161,7 +161,7 @@ function set_window_name_and_image(callback) {
     console.warn("set_window_name_and_image has failed after 30 attempts");
     delete window.set_window_name_and_image_attempts;
     if (is_abovevtt_page()) {
-      showDebuggingAlert();
+      showError(new Error("set_window_name_and_image has failed after 30 attempts"));
     }
     return;
   }
@@ -277,8 +277,7 @@ function inject_join_button_on_character_list_page() {
       if (sheet) {
         window.open(`https://www.dndbeyond.com${sheet}?abovevtt=true`, '_blank');
       } else {
-        console.error("Failed to find the View link next to thisButton:", thisButton, ", thisButtonSiblings:", thisButtonSiblings, "clickEvent:", e);
-        showDebuggingAlert();
+        showError(new Error("Failed to find the View link"), "thisButton:", thisButton, ", thisButtonSiblings:", thisButtonSiblings, "clickEvent:", e);
       }
     });
   });

--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -127,14 +127,14 @@ class DiceRoll {
         let parsedExpression = expression.replaceAll(/\s+/g, ""); // remove all spaces
         if (!parsedExpression.match(validExpressionRegex)) {
             console.warn("Not parsing expression because it contains an invalid character", expression);
-            throw "Invalid Expression";
+            throw new Error("Invalid Expression");
         }
 
         // find all dice expressions in the expression. converts "1d20+1d4" to ["1d20", "1d4"]
         let separateDiceExpressions = parsedExpression.match(allDiceRegex)
         if (!separateDiceExpressions) {
             console.warn("Not parsing expression because there are no valid dice expressions within it", expression);
-            throw "Invalid Expression";
+            throw new Error("Invalid Expression");
         }
 
         this.#fullExpression = parsedExpression;
@@ -357,6 +357,7 @@ class DiceRoller {
     #wrappedDispatch(message) {
         console.group("DiceRoller.#wrappedDispatch");
         if (!this.#waitingForRoll) {
+            // TODO: update DM rolls with dmAvatarUrl
             console.debug("not capturing: ", message);
             this.ddbDispatch(message);
         } else if (message.eventType === "dice/roll/pending") {

--- a/EncounterHandler.js
+++ b/EncounterHandler.js
@@ -20,7 +20,7 @@ class EncounterHandler {
 			let urlId = window.location.pathname.split("/").pop();
 			this.avttId = urlId;
 		} else {
-			throw `Failed to create EncounterHandler with avttId: ${avttId} on page ${window.location.href}`;
+			throw new Error(`Failed to create EncounterHandler with avttId: ${avttId} on page ${window.location.href}`);
 		}
 		this.encounters = {};
 	}

--- a/Main.js
+++ b/Main.js
@@ -337,7 +337,7 @@ function map_load_error_cb(e) {
  * This removes it. See `Load.js` for the injection of the overlay.
  */
 function remove_loading_overlay() {
-	console.debug("startup remove_loading_overlay")
+	console.debug("remove_loading_overlay")
 	$("#loading_overlay").animate({ "opacity": 0 }, 1000, function() {
 		$("#loading_overlay").hide();
 	});

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1477,8 +1477,8 @@ class MessageBroker {
 
 
 
-		
-		
+
+		remove_loading_overlay();
 		// console.groupEnd()
 	}
 
@@ -1523,20 +1523,16 @@ class MessageBroker {
 	}
 
 	handleCharacterUpdate(msg){
-		let characterId=msg.data.characterId;
-
-		window.pcs.forEach(function(pc){
-			if(!pc.sheet.endsWith(characterId)) // we only poll for the characterId that sent this message
-				return;
-
+		const characterId = msg.data.characterId;
+		const pc = window.pcs.find(pc => pc.sheet.includes(characterId));
+		if (pc) {
 			getPlayerData(pc.sheet, function (playerData) {
 				window.PLAYER_STATS[playerData.id] = playerData;
 				window.MB.sendTokenUpdateFromPlayerData(playerData);
 				update_pclist();
 				send_player_data_to_all_peers(playerData);
 			});
-		});
-		
+		}
 	}
 	
 	inject_chat(injected_data) {

--- a/MonsterDice.js
+++ b/MonsterDice.js
@@ -257,12 +257,13 @@ function scan_player_creature_pane(target) {
 
 	const creatureType = target.find(".ct-sidebar__header .ct-sidebar__header-parent").text(); // wildshape, familiar, summoned, etc
 	const creatureName = target.find(".ct-sidebar__header .ddbc-creature-name").text(); // Wolf, Owl, etc
-	const creatureAvatar = window.pc?.image;
+	let pcSheet = find_currently_open_character_sheet();
+	const pc = find_pc_by_player_id(pcSheet);
+	let creatureAvatar = window.pc?.image;
  	try {
  		// not all creatures have an avatar for some reason
  		creatureAvatar = target.find(".ct-sidebar__header .ct-sidebar__header-preview-image").css("background-image").slice(4, -1).replace(/"/g, "");
  	} catch { }
-	const pc = window.pcs.find(t => t.sheet.includes(find_currently_open_character_sheet()));
 	const displayName = `${pc.name} (${creatureName} ${creatureType})`;
 	
 	const clickHandler = function(clickEvent) {

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -333,19 +333,6 @@ function build_monster_stat_block(statBlock) {
 `;
 }
 
-function fetch_config_json() {
-    window.ajaxQueue.addDDBRequest({
-        url: "https://www.dndbeyond.com/api/config/json",
-        success: function (responseData) {
-            console.log("Successfully fetched config/json from DDB API");
-            window.ddbConfigJson = responseData;
-        },
-        error: function (errorMessage) {
-            console.warn("Failed to fetch config json from DDB API", errorMessage);
-        }
-    })
-}
-
 class MonsterStatBlock {
     constructor(data) {
         this.data = data;

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1430,7 +1430,7 @@ function default_scene_data() {
 		offsety: 0,
 		grid: 0,
 		snap: 0,
-		reveals: [[0, 0, 0, 0, 2, 0]], // SPECIAL MESSAGE TO REVEAL EVERYTHING
+		reveals: [],
 		order: Date.now()
 	};
 }
@@ -1656,7 +1656,7 @@ function rename_scene_folder(item, newName, alertUser) {
 		console.groupEnd();
 		console.warn("rename_scene_folder called with an incorrect item type", item);
 		if (alertUser !== false) {
-			showDebuggingAlert();
+			showError(new Error("rename_scene_folder called with an incorrect item type"), item);
 		}
 		return;
 	}
@@ -1664,7 +1664,7 @@ function rename_scene_folder(item, newName, alertUser) {
 		console.groupEnd();
 		console.warn("rename_scene_folder Not allowed to rename folder", item);
 		if (alertUser !== false) {
-			showDebuggingAlert();
+			showError(new Error("rename_scene_folder Not allowed to rename folder"), item);
 		}
 		return;
 	}

--- a/Settings.js
+++ b/Settings.js
@@ -881,8 +881,7 @@ function export_file() {
 			download(b64EncodeUnicode(JSON.stringify(DataFile,null,"\t")),"DataFile.abovevtt","text/plain");
 		})
 		.catch(error => {
-			console.error("export_scenes failed to fetch from the cloud", error);
-			showDebuggingAlert();
+			showError(error, "export_scenes failed to fetch from the cloud");
 		})
 		.finally(() => {
 			$(".import-loading-indicator").remove();
@@ -1005,9 +1004,8 @@ function import_readfile() {
 					alert("Migration (hopefully) completed. You need to Re-Join AboveVTT");
 					location.reload();
 				})
-				.catch((error) => {
-					console.error("cloud_migration failed", error);
-					showDebuggingAlert();
+				.catch(error => {
+					showError(error, "cloud_migration failed");
 				});
 		});
 	};

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1469,8 +1469,7 @@ function display_sidebar_list_item_configuration_modal(listItem) {
       if (index >= 0) {
         edit_scene_dialog(index);
       } else {
-        console.error("Failed to find scene index for scene with id", listItem.sceneId);
-        showDebuggingAlert();
+        showError("Failed to find scene index for scene with id", listItem.sceneId);
       }
       break;
     case ItemType.Aoe:
@@ -1600,7 +1599,7 @@ function rename_folder(item, newName, alertUser = true) {
   if (!item.isTypeFolder()) {
     console.warn("rename_folder called with an incorrect item type", item);
     if (alertUser !== false) {
-      showDebuggingAlert();
+      showError("rename_folder called with an incorrect item type", item);
     }
     return undefined;
   }
@@ -1614,7 +1613,7 @@ function rename_folder(item, newName, alertUser = true) {
   } else if (item.folderPath.startsWith(RootFolder.Scenes.path)) {
     return rename_scene_folder(item, newName, alertUser);
   } else if (alertUser !== false) {
-    showDebuggingAlert();
+    showError("rename_folder failed to find folderPath", item);
   }
   return undefined;
 }

--- a/Token.js
+++ b/Token.js
@@ -2884,7 +2884,7 @@ function save_custom_monster_image_mapping() {
 }
 
 function copy_to_clipboard(text) {
-	var $temp = $("<input>");
+	var $temp = $("<textarea>");
 	$("body").append($temp);
 	$temp.val(text).select();
 	document.execCommand("copy");

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -135,16 +135,16 @@ class TokenCustomization {
             id = `${id}`; // DDB uses numbers for monster ids, but we want to use strings to keep everything consistent
         }
         if (typeof id !== "string" || id.length === 0) {
-            throw `Invalid id ${id}`;
+            throw new Error(`Invalid id ${id}`);
         }
         if (typeof rootId !== "string" || rootId.length === 0) {
-            throw `Invalid rootId ${rootId}`;
+            throw new Error(`Invalid rootId ${rootId}`);
         }
         if (!TokenCustomization.validTypes.includes(tokenType)) {
-            throw `Invalid Type ${tokenType}`;
+            throw new Error(`Invalid Type ${tokenType}`);
         }
         if (typeof parentId !== "string" || parentId.length === 0) {
-            throw `Invalid parentId ${parentId}`;
+            throw new Error(`Invalid parentId ${parentId}`);
         }
         this.id = id;
         this.tokenType = tokenType;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1806,6 +1806,53 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     margin: 8px;
 }
 
+#above-vtt-error-message {
+    position: fixed;
+    top: 100px;
+    left: 0;
+    right: 0;
+    margin: auto;
+    width: 60%;
+    height: 60%;
+    min-width: 500px;
+    font-size: 16px;
+    border: 5px solid #d54f4f;
+    border-radius: 5px;
+    padding: 10px 50px;
+    z-index: 1000000000000;
+    box-shadow: #5c7080 0px 8px 24px;
+    background: #f9f9f9;
+}
+#above-vtt-error-message #error-message-body {
+    margin: 20px;
+}
+#above-vtt-error-message #error-message-stack {
+    padding: 20px;
+    background: rgb(92, 112, 128, 10%);
+    overflow: scroll;
+    position: absolute;
+    height: calc(100% - 180px);
+    width: calc(100% - 90px);
+}
+#above-vtt-error-message h2 {
+    text-align: center;
+    margin-bottom: 40px;
+}
+#above-vtt-error-message button {
+    float: right;
+    background-color: #fff;
+    border: 1px solid #7f7f7f;
+    border-radius: 3px;
+    padding: 5px 16px 5px 16px;
+    font-family: "Roboto Condensed","Arial Narrow","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-style: normal;
+    font-size: 13px;
+    line-height: 15px;
+    display: flex;
+    align-items: center;
+    text-align: center;
+    text-transform: uppercase;
+}
 
 #btn_add_chapter {
     background: none;


### PR DESCRIPTION
## What
Rather than collecting window.pcs by scraping the campaign page, we now fetch character info from the DDB APIs. This gives us more information like theme, frame, and backdrop. It also tells us if the character has been claimed, and whether the theme is the default theme. This makes it a lot easier to style things based on the character themes.

This also converts `showDebuggingAlert` from just displaying a generic `alert`, to a new `showError` which displays the error to the user in a custom element in the DOM. It also adds a "copy error" button so people can easily share the error with us in Discord. 

## Why
There have been errors reported lately with window.pcs not being populated. This change guarantees that it's populated on startup, and has the added benefit of giving us more details about the character. 

Debugging with users can be very difficult. This will allow users to more easily show us the errors, they encounter.


## Demo
This is what the error message looks like:
<img width="1728" alt="Screenshot 2023-03-03 at 4 15 29 PM" src="https://user-images.githubusercontent.com/584771/222840107-c8949410-f256-42b9-8709-2fba3082c253.png">

This is what the "copy error" button puts in the paste buffer
```
Failed to start AboveVTT on https://www.dndbeyond.com/encounters/0e431cd1-d048-4a75-b542-799b74ac94f0?abovevtt=true
Error: ReferenceError: bar is not defined
    at showError (chrome-extension://npnilipfnlgdkcmbejdmebllefkaphdg/CoreFunctions.js:95:13)
    at chrome-extension://npnilipfnlgdkcmbejdmebllefkaphdg/Startup.js:40:9
```