### PR TITLE
Fix - Remove light containers properly when light is removed. Reduce DM selected token darkness.

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3076,7 +3076,7 @@ function redraw_light(){
 	let selectedTokens = $('.tokenselected');
 	if(selectedTokens.length>0){
 	  	if(window.DM && window.CURRENT_SCENE_DATA.darkness_filter >= 75){
-	  		$('#VTT').css('--darkness-filter', `${100-window.CURRENT_SCENE_DATA.darkness_filter}%`)
+	  		$('#VTT').css('--darkness-filter', `${Math.max(100-window.CURRENT_SCENE_DATA.darkness_filter, 40)}%`)
 	  		$('#raycastingCanvas').css('opacity', '');
 	  	}
   		

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -74,6 +74,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		$(".VTTToken").each(function() {
 			$("#aura_" + $(this).attr("data-id").replaceAll("/", "")).remove();
 			$("#light_" + $(this).attr("data-id").replaceAll("/", "")).remove();
+			$(`.aura-element-container-clip[id='${$(this).attr("data-id")}']`).remove();
 		});
 		$(".VTTToken").remove();
 

--- a/Token.js
+++ b/Token.js
@@ -2723,7 +2723,7 @@ function setTokenLight (token, options) {
 	} else {
 		const tokenId = token.attr("data-id").replaceAll("/", "");
 		token.parent().parent().find("#light_" + tokenId).remove();
-		token.parent().parent().find(`.aura-element-container-clip[id='${tokenId}']`).remove();
+		token.parent().parent().find(`.aura-element-container-clip[id='${token.attr("data-id")}']`).remove();
 	}
 	if(!window.DM){
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");


### PR DESCRIPTION
Light aura containers weren't being removed properly in all situations. 

I decided to reduce the darkness on DM selected token to see if that's a better in between then setting a hotkey. If feedback is still bad I'll consider a hotkey or other options. I do agree that DM's should continue to see the map as best as possible. 