### PR TITLE
Fix - Prevent dark light from creating 'shadow' auras.

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5733,6 +5733,7 @@ div.ddbc-tab-options--layout-pill>button{
     height: 100%;
     position: absolute;
     z-index: 9;
+    mix-blend-mode: lighten;
 }
 .aura-element.islight{
     filter:blur(10px);


### PR DESCRIPTION
It was pointed out to me that dark light colors make 'shadow' auras. This is due to the blend mode. Similar to photoshop it was acting like an overlay - where less than 50% grey made it darker. We only want light to make it brighter. 

Making the blend mode 'lighten' should solve this. I cycle through some of the modes below to show the difference. This is probably Nate's wheelhouse so if this doesn't fully solve it I might pick his brain. I did quite a few tests and it seems to solve the issue.

https://cdn.discordapp.com/attachments/1078120562053886021/1082470658237284372/blend_mode.gif