### PR TITLE
Simplify vision/light - add darkvision range add a share vision toggle, remove reveal light dropdown

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3082,7 +3082,7 @@ function redraw_light(){
   		
 		for(j = 0; j < selectedTokens.length; j++){
 		  	let tokenId = $(selectedTokens[j]).attr('data-id');
-			if(window.TOKEN_OBJECTS[tokenId].options.player_owned || tokenId.includes(window.PLAYER_ID) || window.DM || (window.TOKEN_OBJECTS[tokenId].options.itemType == "pc" && window.TOKEN_OBJECTS[tokenId].options.reveal_light == 'always'))
+			if(tokenId.includes(window.PLAYER_ID) || window.DM || window.TOKEN_OBJECTS[tokenId].options.share_vision == true)
 		  		selectedIds.push(tokenId)
 		}	  	
 	 }
@@ -3112,25 +3112,15 @@ function redraw_light(){
 	}
 	$(`.aura-element-container-clip[id='${auraId}']`).css('clip-path', `path('${path}')`)
 
- 	if(!found && window.DM && window.TOKEN_OBJECTS[auraId].options.reveal_light != 'always' && window.TOKEN_OBJECTS[auraId].options.reveal_light != 'los'){
-  		$(light_auras[i]).css("visibility", "hidden");
-  	}
-  	if(selectedIds.length == 0 || found){
-  		if(selectedIds.length == 0 && !auraId.includes(window.PLAYER_ID) && !window.DM && window.TOKEN_OBJECTS[auraId].options.reveal_light != 'always')
-  			continue; 		
-  		if(window.TOKEN_OBJECTS[auraId].options.reveal_light == 'los' && !auraId.includes(window.PLAYER_ID) && !window.DM && window.TOKEN_OBJECTS[auraId].options.reveal_light != 'always')
+
+  	if(selectedIds.length == 0 || found){	
+  		if(!auraId.includes(window.PLAYER_ID) && !window.DM && window.TOKEN_OBJECTS[auraId].options.share_vision != true)
   			continue; 
   		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-  		if(playerTokenId == undefined && window.TOKEN_OBJECTS[auraId].options.reveal_light != 'always' && !window.DM)
+  		if(playerTokenId == undefined && window.TOKEN_OBJECTS[auraId].options.share_vision != true && !window.DM && window.TOKEN_OBJECTS[auraId].options.share_vision)
   			continue;
-	  	if(window.DM){
-	  		$(light_auras[i]).css("visibility", "visible");
-	  	}
 
-  		if(window.TOKEN_OBJECTS[auraId].options.reveal_light == 'always' && !window.TOKEN_OBJECTS[auraId].options.player_owned && window.TOKEN_OBJECTS[auraId].options.itemType != 'pc'){
-  			let visibleRadius = ($(`.aura-element.islight[data-id='${auraId}']`).width()/2)+10;
-  			particleLook(context, walls, visibleRadius, undefined, undefined, undefined, false);
-  		}
+
 		drawPolygon(context, lightPolygon, 'rgba(255, 255, 255, 1)', true);
 
 	

--- a/Token.js
+++ b/Token.js
@@ -306,7 +306,6 @@ class Token {
 		delete window.TOKEN_OBJECTS[id];
 		delete window.all_token_objects[id];
 		$("#aura_" + id.replaceAll("/", "")).remove();
-		$("#light_" + id.replaceAll("/", "")).remove();
 		$(`.aura-element-container-clip[id='${id}']`).remove()
 		if (persist == true) {
 			if (sync) {
@@ -1470,6 +1469,12 @@ class Token {
 					color: 'rgba(255, 255, 255, 0.5)'
 				}
 			}
+			if(this.options.vision == undefined){
+				this.options.vision = {
+					feet: 0,
+					color: 'rgba(255, 255, 255, 0.5)'
+				}
+			}
 			if((!window.DM && this.options.restrictPlayerMove && this.options.name != window.PLAYER_NAME) || this.options.locked){
 				old.draggable("disable");
 				old.removeClass("ui-state-disabled"); // removing this manually.. otherwise it stops right click menu
@@ -1524,14 +1529,21 @@ class Token {
 					color: 'rgba(255, 255, 255, 0.5)'
 				}
 			}
-			if(this.options.player_owned && this.options.reveal_light != 'never' && this.options.reveal_light != 'los'){
-				this.options.reveal_light = 'always'
+			if(this.options.vision == undefined){
+				this.options.vision = {
+					feet: 0,
+					color: 'rgba(255, 255, 255, 0.5)'
+				}
 			}
-			if(this.options.reveal_light == undefined || this.options.reveal_light == false){
-				this.options.reveal_light = 'never';
-			}
-			if(this.options.reveal_light == true){
-				this.options.reveal_light = 'los'
+
+			if(this.options.reveal_light != undefined){
+				if(this.options.reveal_light == 'always' || this.options.reveal_light == true){
+					this.options.share_vision = true;
+				}
+				else{
+					this.options.share_vision = false;
+				}
+				delete this.options.reveal_light;
 			}
 
 			let tokenImage
@@ -1710,6 +1722,13 @@ class Token {
 								el.css("top", `${selectedNewtop/window.CURRENT_SCENE_DATA.scale_factor  - ((auraSize - self.sizeHeight()/window.CURRENT_SCENE_DATA.scale_factor ) / 2)}px`);
 								el.css("left", `${selectedNewleft/window.CURRENT_SCENE_DATA.scale_factor  - ((auraSize  - self.sizeWidth()/window.CURRENT_SCENE_DATA.scale_factor ) / 2)}px`);
 							}
+							el = token.parent().parent().find("#vision_" + token.attr("data-id").replaceAll("/", ""));
+							if (el.length > 0) {
+								const auraSize = parseInt(el.css("width"));
+
+								el.css("top", `${selectedNewtop/window.CURRENT_SCENE_DATA.scale_factor  - ((auraSize - self.sizeHeight()/window.CURRENT_SCENE_DATA.scale_factor ) / 2)}px`);
+								el.css("left", `${selectedNewleft/window.CURRENT_SCENE_DATA.scale_factor  - ((auraSize  - self.sizeWidth()/window.CURRENT_SCENE_DATA.scale_factor ) / 2)}px`);
+							}
 
 							for (let tok of $(".token.tokenselected")){
 								let id = $(tok).attr("data-id");
@@ -1736,6 +1755,13 @@ class Token {
 										selEl.css("left", `${newleft/window.CURRENT_SCENE_DATA.scale_factor - ((auraSize - window.TOKEN_OBJECTS[id].sizeWidth()/window.CURRENT_SCENE_DATA.scale_factor) / 2)}px`);
 									}
 									selEl = $(tok).parent().parent().find("#light_" + id.replaceAll("/", ""));
+									if (selEl.length > 0) {
+										const auraSize = parseInt(selEl.css("width")/window.CURRENT_SCENE_DATA.scale_factor);
+
+										selEl.css("top", `${newtop/window.CURRENT_SCENE_DATA.scale_factor - ((auraSize - window.TOKEN_OBJECTS[id].sizeHeight()/window.CURRENT_SCENE_DATA.scale_factor) / 2)}px`);
+										selEl.css("left", `${newleft/window.CURRENT_SCENE_DATA.scale_factor - ((auraSize - window.TOKEN_OBJECTS[id].sizeWidth()/window.CURRENT_SCENE_DATA.scale_factor) / 2)}px`);
+									}
+									selEl = $(tok).parent().parent().find("#vision_" + id.replaceAll("/", ""));
 									if (selEl.length > 0) {
 										const auraSize = parseInt(selEl.css("width")/window.CURRENT_SCENE_DATA.scale_factor);
 
@@ -1848,6 +1874,11 @@ class Token {
 									el.attr("data-left", el.css("left").replace("px", ""));
 									el.attr("data-top", el.css("top").replace("px", ""));
 								}
+								el = $("#vision_" + id.replaceAll("/", ""));
+								if (el.length > 0) {
+									el.attr("data-left", el.css("left").replace("px", ""));
+									el.attr("data-top", el.css("top").replace("px", ""));
+								}
 							}
 
 						}												
@@ -1859,6 +1890,11 @@ class Token {
 						el.attr("data-top", el.css("top").replace("px", ""));
 					}
 					el = $("#light_" + self.options.id.replaceAll("/", ""));
+					if (el.length > 0) {
+						el.attr("data-left", el.css("left").replace("px", ""));
+						el.attr("data-top", el.css("top").replace("px", ""));
+					}
+					el = $("#vision_" + self.options.id.replaceAll("/", ""));
 					if (el.length > 0) {
 						el.attr("data-left", el.css("left").replace("px", ""));
 						el.attr("data-top", el.css("top").replace("px", ""));
@@ -2006,6 +2042,15 @@ class Token {
 						el.css('left', (currLeft + (offsetLeft/window.CURRENT_SCENE_DATA.scale_factor)) + "px");
 						el.css('top', (currTop + (offsetTop/window.CURRENT_SCENE_DATA.scale_factor))  + "px");
 					}
+					el = ui.helper.parent().parent().find("#vision_" + ui.helper.attr("data-id").replaceAll("/", ""));
+					if (el.length > 0) {
+						let currLeft = parseFloat(el.attr("data-left"));
+						let currTop = parseFloat(el.attr("data-top"));
+						let offsetLeft = Math.round(ui.position.left - parseInt(self.orig_left));
+						let offsetTop = Math.round(ui.position.top - parseInt(self.orig_top));
+						el.css('left', (currLeft + (offsetLeft/window.CURRENT_SCENE_DATA.scale_factor)) + "px");
+						el.css('top', (currTop + (offsetTop/window.CURRENT_SCENE_DATA.scale_factor))  + "px");
+					}
 
 
 
@@ -2071,6 +2116,15 @@ class Token {
 									selEl.css('top', (currTop + (offsetTop/window.CURRENT_SCENE_DATA.scale_factor)) + "px");
 								}
 								selEl = $(tok).parent().parent().find("#light_" + id.replaceAll("/", ""));
+								if (selEl.length > 0) {
+									let currLeft = parseFloat(selEl.attr("data-left"));
+									let currTop = parseFloat(selEl.attr("data-top"));
+									let offsetLeft = Math.round(ui.position.left - parseInt(self.orig_left));
+									let offsetTop = Math.round(ui.position.top - parseInt(self.orig_top));
+									selEl.css('left', (currLeft + (offsetLeft/window.CURRENT_SCENE_DATA.scale_factor))  + "px");
+									selEl.css('top', (currTop + (offsetTop/window.CURRENT_SCENE_DATA.scale_factor)) + "px");
+								}
+								selEl = $(tok).parent().parent().find("#vision_" + id.replaceAll("/", ""));
 								if (selEl.length > 0) {
 									let currLeft = parseFloat(selEl.attr("data-left"));
 									let currTop = parseFloat(selEl.attr("data-top"));
@@ -2298,6 +2352,10 @@ function default_options() {
 		},
 		lightVisible: false,
 		lightOwned: false,
+		vision:{
+			feet: '0',
+			color: "rgba(255, 255, 255, 0.5)"
+		}
 		
 	};
 }
@@ -2681,6 +2739,7 @@ function setTokenLight (token, options) {
 
 	const innerlightSize = options.light1.feet.length > 0 ? (options.light1.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
 	const outerlightSize = options.light2.feet.length > 0 ? (options.light2.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
+	const visionSize = options.vision.feet.length > 0 ? (options.vision.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
 	if (options.auraislight) {
 		// use sizeWidth and sizeHeight???
 		const totallight = innerlightSize + outerlightSize;
@@ -2696,45 +2755,55 @@ function setTokenLight (token, options) {
 							left:${parseFloat(options.left.replace('px', ''))/window.CURRENT_SCENE_DATA.scale_factor - ((totalSize - options.size/window.CURRENT_SCENE_DATA.scale_factor) / 2)}px;
 							top:${parseFloat(options.top.replace('px', ''))/window.CURRENT_SCENE_DATA.scale_factor - ((totalSize - options.size/window.CURRENT_SCENE_DATA.scale_factor) / 2)}px;
 							`;
+
+
+
+		const visionRadius = visionSize ? (visionSize + (options.size/window.CURRENT_SCENE_DATA.scale_factor / 2)) : 0;
+		const visionBg = `radial-gradient(${options.vision.color} ${visionRadius}px, #00000000 ${visionRadius}px)`;
+		const totalVisionSize = parseInt(options.size)/window.CURRENT_SCENE_DATA.scale_factor+ (2 * visionSize);
+		const visionAbsPosOffset = (options.size/window.CURRENT_SCENE_DATA.scale_factor - totalVisionSize) / 2;
+		const visionStyles = `width:${totalVisionSize }px;
+							height:${totalVisionSize }px;
+							left:${visionAbsPosOffset}px;
+							top:${visionAbsPosOffset}px;
+							background-image:${visionBg};
+							left:${parseFloat(options.left.replace('px', ''))/window.CURRENT_SCENE_DATA.scale_factor - ((totalVisionSize - options.size/window.CURRENT_SCENE_DATA.scale_factor) / 2)}px;
+							top:${parseFloat(options.top.replace('px', ''))/window.CURRENT_SCENE_DATA.scale_factor - ((totalVisionSize - options.size/window.CURRENT_SCENE_DATA.scale_factor) / 2)}px;
+							`;
 		const tokenId = token.attr("data-id").replaceAll("/", "");
 		if (token.parent().parent().find("#light_" + tokenId).length > 0) {
 			token.parent().parent().find("#light_" + tokenId).attr("style", lightStyles);	
+			token.parent().parent().find("#vision_" + tokenId).attr("style", visionStyles);	
 		} else {
-			const lightElement = $(`<div class='aura-element-container-clip' id='${token.attr("data-id")}'><div class='aura-element' id="light_${tokenId}" data-id='${token.attr("data-id")}' style='${lightStyles}' /></div>`);
+			const lightElement = $(`<div class='aura-element-container-clip' id='${token.attr("data-id")}'><div class='aura-element' id="light_${tokenId}" data-id='${token.attr("data-id")}' style='${lightStyles}'></div><div class='aura-element' id="vision_${tokenId}" data-id='${token.attr("data-id")}' style='${visionStyles}'></div></div>`);
 			lightElement.contextmenu(function(){return false;});
 			$("#scene_map_container").prepend(lightElement);
 		}
 		if(window.DM){
-			(options.hidden && options.reveal_light == 'never') ? token.parent().parent().find("#light_" + tokenId).css("opacity", 0.5)
-			: token.parent().parent().find("#light_" + tokenId).css("opacity", 1)
+			(options.hidden && options.reveal_light == 'never') ? token.parent().parent().find("#vision_" + tokenId).css("opacity", 0.5)
+			: token.parent().parent().find("#vision_" + tokenId).css("opacity", 1)
 		}
 		else{
-			options.hidden && !options.auraislight ? token.parent().parent().find("#light_" + tokenId).hide()
-						: token.parent().parent().find("#light_" + tokenId).show()
+			options.hidden ? token.parent().parent().find("#vision_" + tokenId).hide()
+						: token.parent().parent().find("#vision_" + tokenId).show()
 		}
-		if(options.auraislight){		
-			token.parent().parent().find("#light_" + tokenId).toggleClass("islight", true);
-		}
-		else{
-			token.parent().parent().find("#light_" + tokenId).toggleClass("islight", false);
-		}
-
+		token.parent().parent().find("#light_" + tokenId).show()
+		token.parent().parent().find("#light_" + tokenId).toggleClass("islight", true);
 		
 	} else {
 		const tokenId = token.attr("data-id").replaceAll("/", "");
-		token.parent().parent().find("#light_" + tokenId).remove();
 		token.parent().parent().find(`.aura-element-container-clip[id='${token.attr("data-id")}']`).remove();
 	}
 	if(!window.DM){
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 		
-		let lights = $("[id^='light_']");
-		for(let i = 0; i < lights.length; i++){
-			if(!lights[i].id.endsWith(window.PLAYER_ID) && window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light != 'always' && window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.reveal_light != 'los'){
-				$(lights[i]).css("visibility", "hidden");
+		let vision = $("[id^='vision']");
+		for(let i = 0; i < vision.length; i++){
+			if(!vision[i].id.endsWith(window.PLAYER_ID) && window.TOKEN_OBJECTS[$(vision[i]).attr("data-id")].options.share_vision != true){
+				$(vision[i]).css("visibility", "hidden");
 			}		
-			if(playerTokenId == undefined && window.TOKEN_OBJECTS[$(lights[i]).attr("data-id")].options.itemType == 'pc'){
-				$(lights[i]).css("visibility", "visible");
+			if(playerTokenId == undefined && window.TOKEN_OBJECTS[$(vision[i]).attr("data-id")].options.itemType == 'pc'){
+				$(vision[i]).css("visibility", "visible");
 			}	
 		}
 	}

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -474,14 +474,6 @@ function build_token_auras_inputs(tokenIds) {
 
 			<div class="token-config-aura-wrapper">
 				<div class="token-image-modal-footer-select-wrapper">
-					<div class="token-image-modal-footer-title">Preset</div>
-					<select class="token-config-aura-preset">
-						<option value="none"></option>
-						<option value="candle">Candle (5/5)</option>
-						<option value="torch">Torch / Light (20/20)</option>
-						<option value="lamp">Lamp (15/30)</option>
-						<option value="lantern">Lantern (30/30)</option>
-					</select>
 				</div>
 				<div class="menu-inner-aura">
 					<h3 style="margin-bottom:0px;">Inner Aura</h3>
@@ -714,17 +706,19 @@ function build_token_light_inputs(tokenIds) {
 	let auraLightValues = tokens.map(t => t.options.auraislight);
 	let uniqueAuraLightValues = [...new Set(auraLightValues)];
 
-	let auraRevealLightValues = tokens.map(t => t.options.reveal_light);
-	let uniqueAuraRevealLightValues = [...new Set(auraRevealLightValues)];
+	let auraRevealVisionValues = tokens.map(t => t.options.share_vision);
+	let uniqueAuraRevealVisionValues = [...new Set(auraRevealVisionValues)];
 
 	let auraIsLightEnabled = null;
 	if (uniqueAuraLightValues.length === 1) {
 		auraIsLightEnabled = uniqueAuraLightValues[0];
 	}
 
-	let auraRevealLightEnabled = null;
-	if (uniqueAuraRevealLightValues.length === 1) {
-		auraRevealLightEnabled = uniqueAuraRevealLightValues[0];
+
+
+	let auraRevealVisionEnabled = null;
+	if (uniqueAuraRevealVisionValues.length === 1) {
+		auraRevealVisionEnabled = uniqueAuraRevealVisionValues[0];
 	}
 
 	let aura1Feet = tokens.map(t => t.options.light1.feet);
@@ -735,6 +729,10 @@ function build_token_light_inputs(tokenIds) {
 	let uniqueAura1Color = aura1Color.length === 1 ? aura1Color[0] : ""
 	let aura2Color = tokens.map(t => t.options.light2.color);
 	let uniqueAura2Color = aura2Color.length === 1 ? aura2Color[0] : ""
+	let visionFeet = tokens.map(t => t.options.vision.feet);
+	let uniqueVisionFeet = visionFeet.length === 1 ? visionFeet[0] : ""
+	let visionColor = tokens.map(t => t.options.vision.color);
+	let uniqueVisionColor = visionColor.length === 1 ? visionColor[0] : ""
 
 	let upsq = 'ft';
 	if (window.CURRENT_SCENE_DATA.upsq !== undefined && window.CURRENT_SCENE_DATA.upsq.length > 0) {
@@ -745,19 +743,30 @@ function build_token_light_inputs(tokenIds) {
 
 			<div class="token-config-aura-wrapper">
 				<div class="token-image-modal-footer-select-wrapper">
-					<div class="token-image-modal-footer-title">Preset</div>
+					
+				
+				<div class="token-image-modal-footer-title">Preset</div>
 					<select class="token-config-aura-preset">
 						<option value="none"></option>
 						<option value="candle">Candle (5/5)</option>
 						<option value="torch">Torch / Light (20/20)</option>
 						<option value="lamp">Lamp (15/30)</option>
 						<option value="lantern">Lantern (30/30)</option>
-						<option value="60ftdark">60ft Darkvision (60/0)</option>
-						<option value="120ftdark">120ft Darkvision (120/0)</option>
 					</select>
 				</div>
+				<div class="menu-vision-aura">
+					<h3 style="margin-bottom:0px;">Darkvision</h3>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Radius (${upsq})</div>
+						<input class="vision-radius" name="vision" type="text" value="${uniqueVisionFeet}" style="width: 3rem" />
+					</div>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Color</div>
+						<input class="spectrum" name="visionColor" value="${uniqueVisionColor}" >
+					</div>
+				</div>
 				<div class="menu-inner-aura">
-					<h3 style="margin-bottom:0px;">Inner Aura</h3>
+					<h3 style="margin-bottom:0px;">Inner Light</h3>
 					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
 						<div class="token-image-modal-footer-title">Radius (${upsq})</div>
 						<input class="light-radius" name="light1" type="text" value="${uniqueAura1Feet}" style="width: 3rem" />
@@ -768,7 +777,7 @@ function build_token_light_inputs(tokenIds) {
 					</div>
 				</div>
 				<div class="menu-outer-aura">
-					<h3 style="margin-bottom:0px;">Outer Aura</h3>
+					<h3 style="margin-bottom:0px;">Outer Light</h3>
 					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
 						<div class="token-image-modal-footer-title">Radius (${upsq})</div>
 						<input class="light-radius" name="light2" type="text" value="${uniqueAura2Feet}" style="width: 3rem" />
@@ -804,28 +813,28 @@ function build_token_light_inputs(tokenIds) {
 			wrapper.find(".token-config-aura-wrapper").hide();
 		}
 	});
-	const reveallightOption = {
-		name: "reveal_light",
-		label: "Reveal light to players",
-		type: "dropdown",
+
+	const revealvisionOption = {
+		name: "share_vision",
+		label: "Share vision with all players",
+		type: "toggle",
 		options: [
-			{ value: 'never', label: "Never", description: "Token light is revealed to players." },
-			{ value: 'los', label: "When in line of sight", description: "Token light is revealed to players when in line of sight." },
-			{ value: 'always', label: "Always", description: "Token light is revealed to players always." },
+			{ value: false, label: "Disabled", description: "Token vision is not shared." },
+			{ value: true, label: "Enabled", description: "Token vision is shared with all players." },
 		],
 		defaultValue: false
 	};
-	let revealLightInput = build_dropdown_input(reveallightOption, auraRevealLightEnabled, function(name, newValue) {
+	let revealVisionInput = build_toggle_input(revealvisionOption, auraRevealVisionEnabled, function(name, newValue) {
 		console.log(`${name} setting is now ${newValue}`);
 		tokens.forEach(token => {
 			token.options[name] = newValue;
 			token.place_sync_persist();
 		});
 	});
-	
+
 	wrapper.prepend(enabledLightInput);
 
-	wrapper.find(".token-config-aura-wrapper").prepend(revealLightInput);
+	wrapper.find(".token-config-aura-wrapper").prepend(revealVisionInput);
 	
 
 	wrapper.find("h3.token-image-modal-footer-title").after(enabledLightInput);
@@ -835,7 +844,7 @@ function build_token_light_inputs(tokenIds) {
 		wrapper.find(".token-config-aura-wrapper").hide();
 	}
 
-	let radiusInputs = wrapper.find('input.light-radius');
+	let radiusInputs = wrapper.find('input.light-radius, input.vision-radius');
 	radiusInputs.on('keyup', function(event) {
 		let newRadius = event.target.value;
 		if (event.key == "Enter" && newRadius !== undefined && newRadius.length > 0) {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4492,13 +4492,15 @@ div#selectedTokensBorderRotationGrabberConnector  {
 .token-config-aura-wrapper .token-image-modal-footer-select-wrapper,
 .token-image-modal-footer-title,
 .menu-outer-aura,
-.menu-inner-aura {
+.menu-inner-aura,
+.menu-vision-aura {
     display: flex;
     align-self: center;
     line-height: 20px;
 }   
 .menu-outer-aura,
-.menu-inner-aura{
+.menu-inner-aura,
+.menu-vision-aura{
     margin: 2px 0px;
 }
 #tokenOptionsContainer div.token-image-modal-url-label-wrapper{
@@ -4525,8 +4527,9 @@ div#selectedTokensBorderRotationGrabberConnector  {
 }
 
 .menu-outer-aura h3,
-.menu-inner-aura h3{
-    min-width: 50px;
+.menu-inner-aura h3,
+.menu-vision-aura h3{
+    min-width: 51px;
     margin-top: 0px;
 }
 


### PR DESCRIPTION
Based on feedback I think this will be easier to understand for users as it simplifies the options for light/vision.

Essentially what I've done is:

Add a toggle to share tokens vision with players,
Add a darkvision radius,
Remove the dropdown to determine what's light or vision etc. - remove the need for an owned token to share vision. 

It also simplifies the code as a side benefit.

It doesn't do any extra checks for vision or light it just adds another div that acts as the Darkvision. I just added the vision to the same container that cuts off light since the walls etc are all the same no need to do the calculation twice. So it should have near no performance impact since it uses the same vision check as the light/vision did before. 

In this example I use different colors for the 3 auras on the one token just for ease of seeing what's happening.

![simplfy light](https://user-images.githubusercontent.com/65363489/223587028-4025ebab-8e33-4cc4-935f-bfca52858fc6.gif)
