### PR TITLE
minor error message cleanup

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -67,11 +67,12 @@ function is_gamelog_popout() {
 
 function removeError() {
   $("#above-vtt-error-message").remove();
+  remove_loading_overlay(); // in case there was an error starting up, remove the loading overlay, so they're not completely stuck
 }
 
 /** Displays an error to the user
  * @param {Error} error an error object to be parsed and displayed
- * @param {(string|*[])[]} extraInfo other relevant information */
+ * @param {string|*[]} extraInfo other relevant information */
 function showError(error, ...extraInfo) {
 
   let container = $("#above-vtt-error-message");
@@ -79,7 +80,6 @@ function showError(error, ...extraInfo) {
     const container = $(`
       <div id="above-vtt-error-message">
         <h2>An unexpected error occurred!</h2>
-        <div id="error-message-body">An unexpected error occurred.</div>
         <pre id="error-message-stack"></pre>
         <div id="error-github-issue"></div>
         <div class="error-message-buttons">

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2021,8 +2021,6 @@ body:not(.body-rpgcampaign-details) .sidebar__pane-content {
     font-size: 24px;
     font-weight: bold;
 }
-#above-vtt-error-message #error-message-body {
-}
 #above-vtt-error-message #error-message-stack {
     padding: 20px;
     background: rgb(92, 112, 128, 10%);


### PR DESCRIPTION
1. Call `remove_loading_overlay()` when the error dialog is dismissed. Without this, anyone experiencing errors on startup is completely stuck. They might need to change settings or something, and they can't do that if the loading overlay is up.
2. Remove duplicate `An unexpected error occurred` text
3. Remove unused css
4. Clean up documentation comment