### PR TITLE
Fix - Keep light/vision blending consistent whether on the same token or different tokens

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5751,6 +5751,7 @@ div.ddbc-tab-options--layout-pill>button{
 .aura-element[id*='vision_']{
     filter:blur(10px);
     z-index: 9;
+    mix-blend-mode: lighten;
 }
 #scene_map{
     mix-blend-mode: multiply;


### PR DESCRIPTION
Different token light and vision blends with lighten since the containers have lighten blend modes. 

Since light and vision on the same token share a container the container blend mode doesn't affect how they blend with each other. This changes it so that light/vision in containers also blends the same way.