### PR TITLE
fix older characters are missing from window.pcs

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -72,7 +72,7 @@ function inject_dice_roll(element) {
   let updatedInnerHtml = element.text();
   for (const command of slashCommands) {
     try {
-      const diceRoll = DiceRoll.fromSlashCommand(command[0], window.PLAYER_NAME, window.PLAYER_IMG);
+      const diceRoll = DiceRoll.fromSlashCommand(command[0], window.PLAYER_NAME, window.PLAYER_IMG, "character", window.PLAYER_ID); // TODO: add gamelog_send_to_text() once that's available on the characters page without avtt running
       updatedInnerHtml = updatedInnerHtml.replace(command[0], `<button class='avtt-roll-formula-button integrated-dice__container' title="${diceRoll.action?.toUpperCase() ?? "CUSTOM"}: ${diceRoll.rollType?.toUpperCase() ?? "ROLL"}" data-slash-command="${command[0]}">${diceRoll.expression}</button>`);
     } catch (error) {
       console.warn("inject_dice_roll failed to parse slash command. Removing the command to avoid infinite loop", command, command[0]);
@@ -85,7 +85,7 @@ function inject_dice_roll(element) {
   element.find("button.avtt-roll-formula-button").click(function(clickEvent) {
     clickEvent.stopPropagation();
     const slashCommand = $(clickEvent.currentTarget).attr("data-slash-command");
-    const diceRoll = DiceRoll.fromSlashCommand(slashCommand, window.PLAYER_NAME, window.PLAYER_IMG);
+    const diceRoll = DiceRoll.fromSlashCommand(slashCommand, window.PLAYER_NAME, window.PLAYER_IMG, "character", window.PLAYER_ID); // TODO: add gamelog_send_to_text() once that's available on the characters page without avtt running
     window.diceRoller.roll(diceRoll);
   });
 }

--- a/ChatObserver.js
+++ b/ChatObserver.js
@@ -61,7 +61,7 @@ class ChatObserver {
 
     #parseSlashCommand(text) {
         let diceRoll = DiceRoll.fromSlashCommand(text);
-        let didSend = window.diceRoller.roll(diceRoll);
+        let didSend = window.diceRoller.roll(diceRoll); // TODO: update this with more details?
         if (didSend === false) {
             // it was too complex so try to send it through rpgDiceRoller
             let expression = text.replace(diceRollCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -254,16 +254,26 @@ function find_pc_by_player_id(idOrSheet) {
 async function rebuild_window_pcs() {
   const campaignCharacters = await DDBApi.fetchCampaignCharacterDetails(window.gameId);
   window.pcs = campaignCharacters.map(characterData => {
+    // we are not making a shortcut for `color` because the logic is too complex. See color_from_pc_object for details
     return {
-      decorations: characterData.decorations,
-      id: characterData.characterId,
-      image: characterData.decorations?.avatar?.avatarUrl || defaultAvatarUrl,
-      isAssignedToPlayer: characterData.isAssignedToPlayer,
-      name: characterData.name,
-      sheet: `/profile/${characterData.userId}/characters/${characterData.characterId}`,
-      userId: characterData.userId,
+      ...characterData,
+      image: characterData.decorations?.avatar?.avatarUrl || characterData.avatarUrl || defaultAvatarUrl,
+      sheet: `/profile/${characterData.userId}/characters/${characterData.characterId}`
     }
   });
+}
+
+async function update_window_pc(characterId) {
+  const allCharacterDetails = await DDBApi.fetchCharacterDetails([characterId]);
+  const characterData = allCharacterDetails[0];
+  const index = window.pcs.findIndex(pc => pc.id.toString() === characterId.toString());
+  const oldData = window.pcs[index];
+  window.pcs[index] = {
+    ...oldData,
+    ...characterData,
+    image: characterData.decorations?.avatar?.avatarUrl || defaultAvatarUrl,
+    sheet: `/profile/${characterData.userId}/characters/${characterData.characterId}`
+  };
 }
 
 async function harvest_game_id() {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1502,6 +1502,9 @@ class MessageBroker {
 	}
 
 	handleCharacterUpdate(msg){
+		update_window_pc(msg.data.characterId).catch(error => {
+			console.warn("handleCharacterUpdate failed to update_window_pc", msg, error);
+		});
 		const characterId = msg.data.characterId;
 		const pc = window.pcs.find(pc => pc.sheet.includes(characterId));
 		if (pc) {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -471,8 +471,7 @@ class MessageBroker {
 				self.handleAudioPlayingSync(msg);
 			}
 			if(msg.eventType == "character-sheet/character-update/fulfilled"){
-				if(window.DM)
-					self.handleCharacterUpdate(msg);
+				debounced_handle_character_update(msg);
 			}
 
 			if (msg.eventType == "custom/myVTT/reveal") {
@@ -1501,22 +1500,6 @@ class MessageBroker {
 		}
 	}
 
-	handleCharacterUpdate(msg){
-		update_window_pc(msg.data.characterId).catch(error => {
-			console.warn("handleCharacterUpdate failed to update_window_pc", msg, error);
-		});
-		const characterId = msg.data.characterId;
-		const pc = window.pcs.find(pc => pc.sheet.includes(characterId));
-		if (pc) {
-			getPlayerData(pc.sheet, function (playerData) {
-				window.PLAYER_STATS[playerData.id] = playerData;
-				window.MB.sendTokenUpdateFromPlayerData(playerData);
-				update_pclist();
-				send_player_data_to_all_peers(playerData);
-			});
-		}
-	}
-	
 	inject_chat(injected_data) {
 		var msgid = this.chat_id + this.chat_counter++;
 


### PR DESCRIPTION
ostrichwrangler on Discord helped me track this down. They had a character that wasn't showing up in the tokens sidebar. The root cause of it was the DDB API endpoint that I was using to fetch window.pcs didn't include the character. We were able to find a different (probably newer) endpoint that did. Changing to this endpoint fixes the problem, but it also gives us way more information. I updated DiceRoller to use the abilities in window.pcs if it exists, and I think we can clean up a lot of `DDBCharacterData` now, too. I'm going to start doing that in a different PR, though, because that will be a larger change.

Side Note: If you edit a character, the old DDB API endpoint will start sending the updated character data. I've seen this happen in other places as well. That hopefully won't be a problem for us, but if we have odd issues with characters not updating or showing up in some places, I think a workaround could be to change the character portrait, save, then change the portrait back, and save again.