### PR TITLE
Fix - Some maps (Video especially) loading fully fogged until interacted with, walls staying between scenes.

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1353,7 +1353,6 @@ class MessageBroker {
 			
 
 			reset_canvas();
-			redraw_light_walls();
 			redraw_fog();
 			redraw_drawings();
 
@@ -1429,16 +1428,7 @@ class MessageBroker {
 			window.FOG_OF_WAR = true;
 			window.REVEALED = data.reveals;
 			reset_canvas();
-			redraw_light_walls();
-			let waitForWalls = function(){
-			    if(typeof window.walls !== "undefined"){
-			        redraw_fog();
-			        redraw_light();
-			    }
-			    else{
-			        setTimeout(waitForWalls, 250);
-			    }
-			}
+			redraw_fog();
 			//$("#fog_overlay").show();
 		}
 		else {
@@ -1454,7 +1444,8 @@ class MessageBroker {
 			window.DRAWINGS = [];
 		}
 
-
+		redraw_light_walls();
+		redraw_light();
 
 
 		remove_loading_overlay();


### PR DESCRIPTION
I'm not sure what I was thinking when I originally made this timeout waiting for walls - but it was messing with fog. Some maps would load with full fog until the map was interacted with which would create the walls. Certainly don't know why I put fog in there with it.


Also some walls persisted between scenes due to it not being below the window.drawings check/reset - maybe I put in the timeout for this reason 🤷 but this should fix both issues.