### PR TITLE
QoL - Force update player hp, max hp, ac and conditions shortly after changes when changed by a player using the in game sheet

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -120,16 +120,20 @@ function observe_character_sheet_changes(documentToObserve) {
     mutationList.forEach(mutation => {
       switch (mutation.type) {
         case "attributes":{
-          if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){ // conditions update from sidebar
-            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
-          }        
-        }
-        case "childList":        
-          if(($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
-            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID}) //hp update from inputs
+          if(is_abovevtt_page()){
+            if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){ // conditions update from sidebar
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+            }        
           }
-          if($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
-            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+        }
+        case "childList":   
+          if(is_abovevtt_page()){     
+            if(($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID}) //hp update from inputs
+            }
+            if($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+            }
           }
           mutation.addedNodes.forEach(node => {
             if (typeof node.data === "string" && node.data.match(multiDiceRollCommandRegex)?.[0]) {
@@ -142,18 +146,20 @@ function observe_character_sheet_changes(documentToObserve) {
           });
           break;
         case "characterData":
-          if($(mutation.target).parent().parent().hasClass('ct-health-summary__hp-item-content'))
-          {
-            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label')) // hp update from buttons
+          if(is_abovevtt_page()){
+            if($(mutation.target).parent().parent().hasClass('ct-health-summary__hp-item-content'))
             {
+              if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label')) // hp update from buttons
+              {
+                window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+              }
+              if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-max-label')){ // max_hp update from buttons
+                window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+              }
+            }
+            if($(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){ // ac update from sidebar
               window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
-            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-max-label')){ // max_hp update from buttons
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
-            }
-          }
-          if($(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){ // ac update from sidebar
-            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           if (typeof mutation.target.data === "string") {
             if (mutation.target.data.match(multiDiceRollCommandRegex)?.[0]) {

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -143,7 +143,7 @@ function observe_character_sheet_changes(documentToObserve) {
               }
             }
           });
-          break; 
+          break;
         case "characterData":
           if(!window.DM && $(mutation.target).parent().parent().hasClass('ct-health-summary__hp-item-content'))
           {

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -120,13 +120,13 @@ function observe_character_sheet_changes(documentToObserve) {
     mutationList.forEach(mutation => {
       switch (mutation.type) {
         case "attributes":{
-            if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){ // conditions update from sidebar
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
-            }        
+          if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){ // conditions update from sidebar
+            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+          }        
         }
         case "childList":        
           if(($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID}) //hp update from inputs
+            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID}) //hp update from inputs
           }
           if($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
             window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -120,6 +120,34 @@ function observe_character_sheet_changes(documentToObserve) {
     mutationList.forEach(mutation => {
       switch (mutation.type) {
         case "childList":
+          if(!window.DM && ($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){
+            let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
+            if(tokenID != undefined){
+              let hp = $(mutation.target).parent().parent().find(`[aria-labelledby*='ct-health-summary-current-label']`).text();
+              let max_hp = $(mutation.target).parent().parent().find(`[aria-labelledby*='ct-health-summary-max-label']`).text();
+
+              window.TOKEN_OBJECTS[tokenID].options.hp = hp;
+              window.TOKEN_OBJECTS[tokenID].options.max_hp = max_hp;
+              if(window.PLAYER_STATS[tokenID] != undefined){
+                window.PLAYER_STATS[tokenID].hp = hp;
+                window.PLAYER_STATS[tokenID].max_hp = max_hp;
+              }
+
+              
+              window.TOKEN_OBJECTS[tokenID].place_sync_persist();
+            }
+            
+          }
+          if(!window.DM && $(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){
+            let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
+            if(tokenID != undefined){
+              window.TOKEN_OBJECTS[tokenID].options.hp = '0';
+              if(window.PLAYER_STATS[tokenID] != undefined){
+                window.PLAYER_STATS[tokenID].hp = '0';
+              }
+              window.TOKEN_OBJECTS[tokenID].place_sync_persist();
+            }
+          }
           mutation.addedNodes.forEach(node => {
             if (typeof node.data === "string" && node.data.match(multiDiceRollCommandRegex)?.[0]) {
               try {
@@ -129,8 +157,42 @@ function observe_character_sheet_changes(documentToObserve) {
               }
             }
           });
-          break;
+          break; 
         case "characterData":
+          if(!window.DM && $(mutation.target).parent().parent().hasClass('ct-health-summary__hp-item-content'))
+          {
+            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label'))
+            {
+              let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
+              if(tokenID != undefined){
+                window.TOKEN_OBJECTS[tokenID].options.hp = mutation.target.data;
+                if(window.PLAYER_STATS[tokenID] != undefined){
+                  window.PLAYER_STATS[tokenID].hp = mutation.target.data;
+                }
+                window.TOKEN_OBJECTS[tokenID].place_sync_persist();
+              }
+            }
+            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-max-label')){
+              let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
+              if(tokenID != undefined){
+                window.TOKEN_OBJECTS[tokenID].options.max_hp = mutation.target.data;
+                if(window.PLAYER_STATS[tokenID] != undefined){
+                  window.PLAYER_STATS[tokenID].max_hp = mutation.target.data;
+                }
+                window.TOKEN_OBJECTS[tokenID].place_sync_persist();
+              }
+            }
+          }
+          if(!window.DM && $(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){
+            let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
+            if(tokenID != undefined){
+              window.TOKEN_OBJECTS[tokenID].options.ac = mutation.target.data;
+              if(window.PLAYER_STATS[tokenID] != undefined){
+                window.PLAYER_STATS[tokenID].ac = mutation.target.data;
+              }
+              window.TOKEN_OBJECTS[tokenID].place_sync_persist();
+            }
+          }
           if (typeof mutation.target.data === "string") {
             if (mutation.target.data.match(multiDiceRollCommandRegex)?.[0]) {
               try {

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -119,34 +119,20 @@ function observe_character_sheet_changes(documentToObserve) {
     // handle updates to element changes that would strip our buttons
     mutationList.forEach(mutation => {
       switch (mutation.type) {
-        case "childList":
-          if(!window.DM && ($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){
-            let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
-            if(tokenID != undefined){
-              let hp = $(mutation.target).parent().parent().find(`[aria-labelledby*='ct-health-summary-current-label']`).text();
-              let max_hp = $(mutation.target).parent().parent().find(`[aria-labelledby*='ct-health-summary-max-label']`).text();
-
-              window.TOKEN_OBJECTS[tokenID].options.hp = hp;
-              window.TOKEN_OBJECTS[tokenID].options.max_hp = max_hp;
-              if(window.PLAYER_STATS[tokenID] != undefined){
-                window.PLAYER_STATS[tokenID].hp = hp;
-                window.PLAYER_STATS[tokenID].max_hp = max_hp;
-              }
-
-              
-              window.TOKEN_OBJECTS[tokenID].place_sync_persist();
+        case "attributes":{
+          if(!window.DM){
+            if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
-            
+          }
+        }
+        case "childList":
+          
+          if(!window.DM && ($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           if(!window.DM && $(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){
-            let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
-            if(tokenID != undefined){
-              window.TOKEN_OBJECTS[tokenID].options.hp = '0';
-              if(window.PLAYER_STATS[tokenID] != undefined){
-                window.PLAYER_STATS[tokenID].hp = '0';
-              }
-              window.TOKEN_OBJECTS[tokenID].place_sync_persist();
-            }
+            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           mutation.addedNodes.forEach(node => {
             if (typeof node.data === "string" && node.data.match(multiDiceRollCommandRegex)?.[0]) {
@@ -163,35 +149,14 @@ function observe_character_sheet_changes(documentToObserve) {
           {
             if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label'))
             {
-              let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
-              if(tokenID != undefined){
-                window.TOKEN_OBJECTS[tokenID].options.hp = mutation.target.data;
-                if(window.PLAYER_STATS[tokenID] != undefined){
-                  window.PLAYER_STATS[tokenID].hp = mutation.target.data;
-                }
-                window.TOKEN_OBJECTS[tokenID].place_sync_persist();
-              }
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
             if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-max-label')){
-              let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
-              if(tokenID != undefined){
-                window.TOKEN_OBJECTS[tokenID].options.max_hp = mutation.target.data;
-                if(window.PLAYER_STATS[tokenID] != undefined){
-                  window.PLAYER_STATS[tokenID].max_hp = mutation.target.data;
-                }
-                window.TOKEN_OBJECTS[tokenID].place_sync_persist();
-              }
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
           }
           if(!window.DM && $(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){
-            let tokenID = $(`.token[data-id*='${window.PLAYER_ID}']`).attr('data-id');
-            if(tokenID != undefined){
-              window.TOKEN_OBJECTS[tokenID].options.ac = mutation.target.data;
-              if(window.PLAYER_STATS[tokenID] != undefined){
-                window.PLAYER_STATS[tokenID].ac = mutation.target.data;
-              }
-              window.TOKEN_OBJECTS[tokenID].place_sync_persist();
-            }
+            window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           if (typeof mutation.target.data === "string") {
             if (mutation.target.data.match(multiDiceRollCommandRegex)?.[0]) {
@@ -210,7 +175,7 @@ function observe_character_sheet_changes(documentToObserve) {
   });
 
   const mutation_target = documentToObserve.get(0);
-  const mutation_config = { attributes: false, childList: true, characterData: true, subtree: true };
+  const mutation_config = { attributes: true, childList: true, characterData: true, subtree: true };
   window.dice_roll_observer.observe(mutation_target, mutation_config);
 }
 

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -120,18 +120,15 @@ function observe_character_sheet_changes(documentToObserve) {
     mutationList.forEach(mutation => {
       switch (mutation.type) {
         case "attributes":{
-          if(!window.DM){
             if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){ // conditions update from sidebar
               window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
-            }
-          }
+            }        
         }
-        case "childList":
-          
-          if(!window.DM && ($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
+        case "childList":        
+          if(($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
               window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID}) //hp update from inputs
           }
-          if(!window.DM && $(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
+          if($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
             window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           mutation.addedNodes.forEach(node => {
@@ -145,7 +142,7 @@ function observe_character_sheet_changes(documentToObserve) {
           });
           break;
         case "characterData":
-          if(!window.DM && $(mutation.target).parent().parent().hasClass('ct-health-summary__hp-item-content'))
+          if($(mutation.target).parent().parent().hasClass('ct-health-summary__hp-item-content'))
           {
             if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label')) // hp update from buttons
             {
@@ -155,7 +152,7 @@ function observe_character_sheet_changes(documentToObserve) {
               window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
           }
-          if(!window.DM && $(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){ // ac update from sidebar
+          if($(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){ // ac update from sidebar
             window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           if (typeof mutation.target.data === "string") {

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -115,24 +115,26 @@ function observe_character_sheet_changes(documentToObserve) {
         console.log("inject_dice_roll failed to process element", error);
       }
     });
-
+    const sendCharacterUpdateEvent = mydebounce(() => {
+      window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID});
+    }, 4000);
     // handle updates to element changes that would strip our buttons
     mutationList.forEach(mutation => {
       switch (mutation.type) {
         case "attributes":{
           if(is_abovevtt_page()){
             if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){ // conditions update from sidebar
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+              sendCharacterUpdateEvent();
             }        
           }
         }
         case "childList":   
           if(is_abovevtt_page()){     
             if(($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID}) //hp update from inputs
+              sendCharacterUpdateEvent(); //hp update from inputs
             }
             if($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+              sendCharacterUpdateEvent();
             }
           }
           mutation.addedNodes.forEach(node => {
@@ -151,14 +153,14 @@ function observe_character_sheet_changes(documentToObserve) {
             {
               if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label')) // hp update from buttons
               {
-                window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+                sendCharacterUpdateEvent();
               }
               if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-max-label')){ // max_hp update from buttons
-                window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+                sendCharacterUpdateEvent();
               }
             }
             if($(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){ // ac update from sidebar
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+             sendCharacterUpdateEvent();
             }
           }
           if (typeof mutation.target.data === "string") {

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -4,6 +4,10 @@ $(function() {
   init_characters_pages();
 });
 
+const sendCharacterUpdateEvent = mydebounce(() => {
+  window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID});
+}, 4000);
+
 function init_characters_pages() {
   // this is injected on Main.js when avtt is running. Make sure we set it when avtt is not running
   if (typeof window.EXTENSION_PATH !== "string" || window.EXTENSION_PATH.length <= 1) {
@@ -115,9 +119,7 @@ function observe_character_sheet_changes(documentToObserve) {
         console.log("inject_dice_roll failed to process element", error);
       }
     });
-    const sendCharacterUpdateEvent = mydebounce(() => {
-      window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID});
-    }, 4000);
+
     // handle updates to element changes that would strip our buttons
     mutationList.forEach(mutation => {
       switch (mutation.type) {
@@ -133,8 +135,8 @@ function observe_character_sheet_changes(documentToObserve) {
             if(($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
               sendCharacterUpdateEvent(); //hp update from inputs
             }
-            if($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
-              sendCharacterUpdateEvent();
+            if($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ 
+              sendCharacterUpdateEvent(); //if 0 health update
             }
           }
           mutation.addedNodes.forEach(node => {

--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -121,7 +121,7 @@ function observe_character_sheet_changes(documentToObserve) {
       switch (mutation.type) {
         case "attributes":{
           if(!window.DM){
-            if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){
+            if($(mutation.target).parent().hasClass('ct-condition-manage-pane__condition-toggle') && $(mutation.target).hasClass('ddbc-toggle-field')){ // conditions update from sidebar
               window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
           }
@@ -129,9 +129,9 @@ function observe_character_sheet_changes(documentToObserve) {
         case "childList":
           
           if(!window.DM && ($(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-item-input') && $(mutation.target).hasClass('ct-health-summary__hp-item-content')) || ($(mutation.removedNodes[0]).hasClass('ct-health-summary__deathsaves-label') && $(mutation.target).hasClass('ct-health-summary__hp-item'))){ 
-              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
+              window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID}) //hp update from inputs
           }
-          if(!window.DM && $(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){
+          if(!window.DM && $(mutation.removedNodes[0]).hasClass('ct-health-summary__hp-group') && $(mutation.target).hasClass('ct-health-summary__deathsaves')){ //if 0 health update
             window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           mutation.addedNodes.forEach(node => {
@@ -147,15 +147,15 @@ function observe_character_sheet_changes(documentToObserve) {
         case "characterData":
           if(!window.DM && $(mutation.target).parent().parent().hasClass('ct-health-summary__hp-item-content'))
           {
-            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label'))
+            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-current-label')) // hp update from buttons
             {
               window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
-            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-max-label')){
+            if($(mutation.target).parent().attr('aria-labelledby').includes('ct-health-summary-max-label')){ // max_hp update from buttons
               window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
             }
           }
-          if(!window.DM && $(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){
+          if(!window.DM && $(mutation.target).parent().hasClass('ddbc-armor-class-box__value')){ // ac update from sidebar
             window.MB.sendMessage("custom/myVTT/character-update", {characterId: window.PLAYER_ID})
           }
           if (typeof mutation.target.data === "string") {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -472,10 +472,18 @@ class MessageBroker {
 				self.handleAudioPlayingSync(msg);
 			}
 			if(msg.eventType.includes('character-update')){
-				if(window.DM && !window.characterUpdatedRecently) {
-					self.handleCharacterUpdate(msg);
-					window.characterUpdatedRecently = true;
-					setTimeout(function(){window.characterUpdatedRecently = false}, 4000) // only update once per 4 seconds if we receive two messages (one custom + one ddb or user spamming). Prevent spam to ddb.
+				if(window.DM) {
+					
+					if(window.characterUpdatedRecently == undefined){
+						window.characterUpdatedRecently = [];
+					}
+					if(!window.characterUpdatedRecently[msg.data.characterId]){
+						self.handleCharacterUpdate(msg);
+					}
+					window.characterUpdatedRecently[msg.data.characterId] = true;
+					setTimeout(function(){window.characterUpdatedRecently[msg.data.characterId] = false}, 4000) // only update once per 4 seconds per character if we receive two messages (one custom + one ddb or user spamming). Prevent spam to ddb.
+					
+
 				}
 				
 			}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -347,7 +347,6 @@ class MessageBroker {
 		this.latestVersionSeen = abovevtt_version;
 
 		this.onmessage = function(event,tries=0) {
-
 			if (event.data == "pong")
 				return;
 			if (event.data == "ping")

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -471,21 +471,9 @@ class MessageBroker {
 				self.handleAudioPlayingSync(msg);
 			}
 			if(msg.eventType.includes('character-update')){
-				if(window.DM) {
-					
-					if(window.characterUpdatedRecently == undefined){
-						window.characterUpdatedRecently = [];
-					}
-					if(!window.characterUpdatedRecently[msg.data.characterId]){
+				if(window.DM) {			
 						self.handleCharacterUpdate(msg);
-						window.characterUpdatedRecently[msg.data.characterId] = true;
-					}
-
-					setTimeout(function(){window.characterUpdatedRecently[msg.data.characterId] = false}, 4000) // only update once per 4 seconds per character if we receive two messages (one custom + one ddb or user spamming). Prevent spam to ddb.
-					
-
-				}
-				
+				}		
 			}
 
 			if (msg.eventType == "custom/myVTT/reveal") {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -478,8 +478,9 @@ class MessageBroker {
 					}
 					if(!window.characterUpdatedRecently[msg.data.characterId]){
 						self.handleCharacterUpdate(msg);
+						window.characterUpdatedRecently[msg.data.characterId] = true;
 					}
-					window.characterUpdatedRecently[msg.data.characterId] = true;
+
 					setTimeout(function(){window.characterUpdatedRecently[msg.data.characterId] = false}, 4000) // only update once per 4 seconds per character if we receive two messages (one custom + one ddb or user spamming). Prevent spam to ddb.
 					
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -347,6 +347,7 @@ class MessageBroker {
 		this.latestVersionSeen = abovevtt_version;
 
 		this.onmessage = function(event,tries=0) {
+
 			if (event.data == "pong")
 				return;
 			if (event.data == "ping")
@@ -470,9 +471,13 @@ class MessageBroker {
 			if (msg.eventType == "custom/myVTT/audioPlayingSyncMe") {
 				self.handleAudioPlayingSync(msg);
 			}
-			if(msg.eventType == "character-sheet/character-update/fulfilled"){
-				if(window.DM)
+			if(msg.eventType.includes('character-update')){
+				if(window.DM && !window.characterUpdatedRecently) {
 					self.handleCharacterUpdate(msg);
+					window.characterUpdatedRecently = true;
+					setTimeout(function(){window.characterUpdatedRecently = false}, 4000) // only update once per 4 seconds if we receive two messages (one custom + one ddb or user spamming). Prevent spam to ddb.
+				}
+				
 			}
 
 			if (msg.eventType == "custom/myVTT/reveal") {

--- a/Token.js
+++ b/Token.js
@@ -520,7 +520,7 @@ class Token {
 	 */
 	munge_token_data(){
 		if (window.PLAYER_STATS[this.options.id]) {
-			return {...window.PLAYER_STATS[this.options.id], ...this.options}
+			return {...this.options, ...window.PLAYER_STATS[this.options.id]}
 		}
 		return {...this.options}
 	}

--- a/Token.js
+++ b/Token.js
@@ -520,7 +520,7 @@ class Token {
 	 */
 	munge_token_data(){
 		if (window.PLAYER_STATS[this.options.id]) {
-			return {...this.options, ...window.PLAYER_STATS[this.options.id]}
+			return {...window.PLAYER_STATS[this.options.id], ...this.options}
 		}
 		return {...this.options}
 	}


### PR DESCRIPTION
Using @vlaminck's idea - This adds checks to our character sheet observer for hp, max hp, ac and conditions. If changed while in game it should force an update. It seems the reason updates aren't happening consistently is we aren't always receiving a character updated message from ddb. I send our own message and limit individual character updates to once every 4 seconds so we don't spam ddb with character data requests.

The DM and other tabs still rely on the current method of updating player hp but it's a step to making it better imo.

Example
https://www.youtube.com/watch?v=BxWLnbOv5vQ