### PR TITLE
Attempt to reconnect PeerManager when we find a stale connection

### DIFF
--- a/PeerCommunication.js
+++ b/PeerCommunication.js
@@ -237,6 +237,16 @@ function disable_peer_manager() {
   window.PeerManager.enabled = false;
 }
 
+/** when we receive catastrophic errors, we need to tear down and rebuild PeerManager */
+function rebuild_peerManager() {
+  console.log("rebuild_peerManager starting");
+  disable_peer_manager();
+  window.PeerManager.tearDown();
+  window.PeerManager = new PeerManager();
+  enable_peer_manager();
+  console.log("rebuild_peerManager finished");
+}
+
 /** Called when a new connection is opened
  * @param {string} peerId the id of the peerjs peer that we connected to
  * @param {string} playerId the id of the DDB player that we connected to */

--- a/PeerManager.js
+++ b/PeerManager.js
@@ -82,11 +82,20 @@ class PeerManager {
       });
       conn.on("error", (error) => {
         console.error("PeerManager connection error", error);
+        // should we call rebuild_peerManager() here?
       });
     });
     this.peer.on('error', function (error) {
       console.error("PeerManager peer error", error);
+      rebuild_peerManager();
     });
+  }
+
+  tearDown() {
+    this.disconnectAllPeers();
+    this.peer.disconnect();
+    this.peer.destroy();
+    this.connections = [];
   }
 
   /** handles the peerjs connection.open event */


### PR DESCRIPTION
We already check for stale connections, and try to clean them up, but we don't try to reconnect any that we find. This sends another `peerReady` event after cleaning up connections in case the other peer is still online. 

This should wait for the 0.87 betas