### PR TITLE
Add larger margin so we can center maps

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1059,8 +1059,8 @@ function is_rgba_fully_transparent(rgba){
 }
 
 function get_event_cursor_position(event){
-	const pointX = Math.round(((event.pageX - 200) * (1.0 / window.ZOOM)));
-	const pointY = Math.round(((event.pageY - 200) * (1.0 / window.ZOOM)));
+	const pointX = Math.round(((event.pageX - window.VTTMargin) * (1.0 / window.ZOOM)));
+	const pointY = Math.round(((event.pageY - window.VTTMargin) * (1.0 / window.ZOOM)));
 	return [pointX, pointY]
 }
 
@@ -1277,10 +1277,10 @@ function drawing_mousemove(e) {
 			if(window.DRAWFUNCTION == "draw_text")
 			{
 				drawRect(context,
-					Math.round(((window.BEGIN_MOUSEX - 200 + window.scrollX))) * (1.0 / window.ZOOM),
-					Math.round(((window.BEGIN_MOUSEY - 200 + window.scrollY))) * (1.0 / window.ZOOM),
-					((e.clientX - 200 + window.scrollX) * (1.0 / window.ZOOM)) - ((window.BEGIN_MOUSEX - 200 + window.scrollX) * (1.0 / window.ZOOM)),
-					((e.clientY - 200 + window.scrollY) * (1.0 / window.ZOOM)) - ((window.BEGIN_MOUSEY - 200 + window.scrollY) * (1.0 / window.ZOOM)),
+					Math.round(((window.BEGIN_MOUSEX - window.VTTMargin + window.scrollX))) * (1.0 / window.ZOOM),
+					Math.round(((window.BEGIN_MOUSEY - window.VTTMargin + window.scrollY))) * (1.0 / window.ZOOM),
+					((e.clientX - window.VTTMargin + window.scrollX) * (1.0 / window.ZOOM)) - ((window.BEGIN_MOUSEX - window.VTTMargin + window.scrollX) * (1.0 / window.ZOOM)),
+					((e.clientY - window.VTTMargin + window.scrollY) * (1.0 / window.ZOOM)) - ((window.BEGIN_MOUSEY - window.VTTMargin + window.scrollY) * (1.0 / window.ZOOM)),
 					window.DRAWCOLOR,
 					isFilled,
 					window.LINEWIDTH);
@@ -1623,10 +1623,10 @@ function drawing_mouseup(e) {
 				let textImageRect = $("#text_div svg[id='" + curr+ "'] text")[0].getBoundingClientRect();	
 
 				
-				var texttop = (parseInt(textImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM);
-				var textleft = (parseInt(textImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
-				var textright = (parseInt(textImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM);
-				var textbottom = (parseInt(textImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
+				var texttop = (parseInt(textImageRect.top) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
+				var textleft = (parseInt(textImageRect.left)  + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
+				var textright = (parseInt(textImageRect.right) + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
+				var textbottom = (parseInt(textImageRect.bottom) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
 				let scaledRemainderTop = (textbottom-texttop-textImageRect.height)/2;
 				let scaledRemainderLeft = (textright-textleft-textImageRect.width)/2;
 
@@ -1904,10 +1904,10 @@ function drawing_mouseup(e) {
 
 			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();	
 			let size = window.TOKEN_OBJECTS[curr.options.id].options.size;	
-			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - 200) * (1.0 / window.ZOOM);
-			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - 200) * (1.0 / window.ZOOM);
-			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - 200) * (1.0 / window.ZOOM);
-			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - 200) * (1.0 / window.ZOOM);
+			var toktop = (parseInt(tokenImageRect.top) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
+			var tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
+			var tokright = (parseInt(tokenImageRect.right) + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
+			var tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
 			let scaledRemainderTop = (tokbottom-toktop-size)/2;
 			let scaledRemainderLeft = (tokright-tokleft-size)/2;
 			if(window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'circle' || window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'square' || $("#tokens>div[data-id='" + curr.options.id + "']").hasClass("isAoe")){

--- a/Main.js
+++ b/Main.js
@@ -132,12 +132,12 @@ function change_zoom(newZoom, x, y) {
 	console.log("zoom", newZoom, x , y)
 	var zoomCenterX = x || $(window).width() / 2
 	var zoomCenterY = y || $(window).height() / 2
-	// 200 is the size of the black area to the left and top of the map
-	var centerX = Math.round((($(window).scrollLeft() + zoomCenterX) - 200) * (1.0 / window.ZOOM));
-	var centerY = Math.round((($(window).scrollTop() + zoomCenterY) - 200) * (1.0 / window.ZOOM));
+	// window.VTTMargin is the size of the black area to the left and top of the map
+	var centerX = Math.round((($(window).scrollLeft() + zoomCenterX) - window.VTTMargin) * (1.0 / window.ZOOM));
+	var centerY = Math.round((($(window).scrollTop() + zoomCenterY) - window.VTTMargin) * (1.0 / window.ZOOM));
 	window.ZOOM = newZoom;
-	var pageX = Math.round(centerX * window.ZOOM - zoomCenterX) + 200;
-	var pageY = Math.round(centerY * window.ZOOM - zoomCenterY) + 200;
+	var pageX = Math.round(centerX * window.ZOOM - zoomCenterX) + window.VTTMargin;
+	var pageY = Math.round(centerY * window.ZOOM - zoomCenterY) + window.VTTMargin;
 
 	//Set scaling token names CSS variable this variable can be used with anything in #tokens
 	$("#tokens").get(0).style.setProperty("--font-size-zoom", Math.max(12 * Math.max((3 - window.ZOOM), 0), 8.5) + "px");
@@ -278,8 +278,8 @@ function reset_zoom() {
 		block: 'center',
 		inline: 'center'
 	});
-	if($('#hide_rightpanel').hasClass('point-right') &&  ($("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor)*window.ZOOM+200 > $(window).width()-340)
-		$(window).scrollLeft(200);
+	if($('#hide_rightpanel').hasClass('point-right') &&  ($("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor)*window.ZOOM+window.VTTMargin > $(window).width()-340)
+		$(window).scrollLeft($("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor*window.ZOOM/2 + 170);
 	// Don't store any zoom for this scene as we default to map fit on load
 	remove_zoom_from_storage();
 	console.groupEnd();
@@ -497,8 +497,8 @@ function set_pointer(data, dontscroll = false) {
 		var pageY = Math.round(data.y * window.ZOOM - ($(window).height() / 2));
 		var sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
 		$("html,body").animate({
-			scrollTop: pageY + 200,
-			scrollLeft: pageX + 200 + sidebarSize/2,
+			scrollTop: pageY + window.VTTMargin,
+			scrollLeft: pageX + window.VTTMargin + sidebarSize/2,
 		}, 500);
 	}
 }
@@ -2476,6 +2476,8 @@ Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 function init_ui() {
 	console.log("init_ui");
 
+	window.VTTMargin = 1000;
+
 	// ATTIVA GAMELOG
 	$(".sidebar__control").click(); // 15/03/2022 .. DDB broke the gamelog button.
 	$(".sidebar__control--lock").closest("span.sidebar__control-group.sidebar__control-group--lock > button").click(); // lock it open immediately. This is safe to call multiple times
@@ -2573,8 +2575,8 @@ function init_ui() {
 			return;
 		e.preventDefault();
 
-		var mousex = Math.round((e.pageX - 200) * (1.0 / window.ZOOM));
-		var mousey = Math.round((e.pageY - 200) * (1.0 / window.ZOOM));
+		var mousex = Math.round((e.pageX - window.VTTMargin) * (1.0 / window.ZOOM));
+		var mousey = Math.round((e.pageY - window.VTTMargin) * (1.0 / window.ZOOM));
 
 		console.log("mousex " + mousex + " mousey " + mousey);
 
@@ -2635,9 +2637,11 @@ function init_ui() {
 	VTT.append(rayCasting);
 	mapContainer.append(darknessLayer);
 
+
+
 	wrapper = $("<div id='VTTWRAPPER'/>");
-	wrapper.css("margin-left", "200px");
-	wrapper.css("margin-top", "200px");
+	wrapper.css("margin-left", `${window.VTTMargin}px`);
+	wrapper.css("margin-top", `${window.VTTMargin}px`);
 	wrapper.css("paddning-right", "200px");
 	wrapper.css("padding-bottom", "200px");
 	wrapper.css("position", "absolute");

--- a/Text.js
+++ b/Text.js
@@ -470,8 +470,8 @@ function handle_draw_text_submit(event) {
     );
     // textbox doesn't have left or top so use the wrapper
     // with 25 being the bar height
-    const rectX = Math.round(((parseInt($(textBox).parent().css("left"))-200+window.scrollX))) * (1.0 / window.ZOOM);
-    const rectY = Math.round(((parseInt($(textBox).parent().css("top"))-200+window.scrollY)) + 25) * (1.0 / window.ZOOM);
+    const rectX = Math.round(((parseInt($(textBox).parent().css("left"))-window.VTTMargin+window.scrollX))) * (1.0 / window.ZOOM);
+    const rectY = Math.round(((parseInt($(textBox).parent().css("top"))-window.VTTMargin+window.scrollY)) + 25) * (1.0 / window.ZOOM);
     const rectColor = $(textBox).css("background-color")
 
     const text = textBox.val();

--- a/Token.js
+++ b/Token.js
@@ -448,8 +448,8 @@ class Token {
 			
 			if(!dontscroll){
 			$("html,body").animate({
-				scrollTop: pageY + 200,
-				scrollLeft: pageX + 200
+				scrollTop: pageY + window.VTTMargin,
+				scrollLeft: pageX + window.VTTMargin
 			}, 500);
 			}
 
@@ -2311,8 +2311,8 @@ function dragging_right_click_mouseup(event) {
 	if (window.DRAGGING && event.button == 2) {
 		event.preventDefault();
 		event.stopPropagation();
-		var mousex = (event.pageX - 200) * (1.0 / window.ZOOM);
-		var mousey = (event.pageY - 200) * (1.0 / window.ZOOM);
+		var mousex = (event.pageX - window.VTTMargin) * (1.0 / window.ZOOM);
+		var mousey = (event.pageY - window.VTTMargin) * (1.0 / window.ZOOM);
 		WaypointManager.checkNewWaypoint(mousex, mousey);
 	}
 }
@@ -2395,8 +2395,8 @@ function convert_point_from_view_to_map(pageX, pageY, forceNoSnap = false) {
 	// adjust for map offset and zoom
 	const startX = window.CURRENT_SCENE_DATA.offsetx;
 	const startY = window.CURRENT_SCENE_DATA.offsety;
-	let mapX = ((pageX - 200) * (1.0 / window.ZOOM)) - startX;
-	let mapY = ((pageY - 200) * (1.0 / window.ZOOM)) - startY;
+	let mapX = ((pageX - window.VTTMargin) * (1.0 / window.ZOOM)) - startX;
+	let mapY = ((pageY - window.VTTMargin) * (1.0 / window.ZOOM)) - startY;
 	if (forceNoSnap === true) {
 		return { x: mapX, y: mapY };
 	}
@@ -2408,8 +2408,8 @@ function convert_point_from_view_to_map(pageX, pageY, forceNoSnap = false) {
 }
 
 function convert_point_from_map_to_view(mapX, mapY) {
-	let pageX = mapX / (1 / window.ZOOM) + 200;
-	let pageY = mapY / (1 / window.ZOOM) + 200;
+	let pageX = mapX / (1 / window.ZOOM) ;
+	let pageY = mapY / (1 / window.ZOOM) ;
 	return { x: pageX, y: pageY };
 }
 


### PR DESCRIPTION
Pretty sure I caught everything, drawings, text, walls, tokens all should be in the same place as they were on live. Zoom to fit centers the map as expected - still taking into account the side bar. Placing tokens/aoe is still correct. 

Probably a good idea to give it a good run through of testing next week either way though.

 I've created a single variable we can use to adjust this window.VTTMargin in init_ui(). Currently set to 1000.