### PR TITLE
Fix - Remove edit scene container on wizard

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -897,7 +897,7 @@ function edit_scene_dialog(scene_id) {
 
 			$("#VTT").css("--scene-scale", 1)
 
-			$("#edit_dialog").remove();
+			$("#sources-import-main-container").remove();
 			$("#scene_selector").removeAttr("disabled");
 			$("#scene_selector_toggle").click();
 			$("#scene_selector_toggle").hide();


### PR DESCRIPTION
The edit dialog was being removed but not the container on starting the grid wizard.