### PR TITLE
Fix - Grid size input in edit scene

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -708,7 +708,8 @@ div#scene_selector,
 }
 
 
-input[type="number"][name='darkness_filter_number']{
+input[type="number"][name='darkness_filter_number'],
+input[type="number"][name='gridStrokeNumberInput']{
     width:50px;
     font-size:12px;
 }


### PR DESCRIPTION
I missed the grid size input when draw grid is enabled in the edit scene dialog.