### PR TITLE
Performance boost for scaled maps - Swap to css scaling again for canvas now that text isn't on the canvas

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -660,8 +660,8 @@ function draw_wizarding_box() {
 
 	var gridCanvas = document.getElementById("grid_overlay");
 	var gridContext = gridCanvas.getContext("2d");
-	gridCanvas.width = $("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor;
-	gridCanvas.height = $("#scene_map").height()*window.CURRENT_SCENE_DATA.scale_factor;
+	gridCanvas.width = $("#scene_map").width();
+	gridCanvas.height = $("#scene_map").height();
 
 	startX = Math.round(window.CURRENT_SCENE_DATA.offsetx);
 	startY = Math.round(window.CURRENT_SCENE_DATA.offsety);
@@ -693,10 +693,12 @@ function draw_wizarding_box() {
 }
 function ctxScale(canvasid){
 	var canvas = document.getElementById(canvasid);
-	var ctx = canvas.getContext("2d");
-	canvas.width = $("#scene_map").width() * window.CURRENT_SCENE_DATA.scale_factor;
-  	canvas.height = $("#scene_map").height() * window.CURRENT_SCENE_DATA.scale_factor;
-	ctx.scale(window.CURRENT_SCENE_DATA.scale_factor, window.CURRENT_SCENE_DATA.scale_factor);
+	canvas.width = $("#scene_map").width();
+  	canvas.height = $("#scene_map").height();
+	$(canvas).css({
+		'transform-origin': 'top left',
+		'transform': 'scale(var(--scene-scale))'
+	});
 }
 
 function reset_canvas() {
@@ -746,8 +748,8 @@ function reset_canvas() {
 		else{
 			$("#VTT").css("--scene-scale", window.CURRENT_SCENE_DATA.scale_factor);
 		}
-		canvas_grid.width = $("#scene_map").width()*window.CURRENT_SCENE_DATA.scale_factor;
-		canvas_grid.height = $("#scene_map").height()*window.CURRENT_SCENE_DATA.scale_factor;
+		canvas_grid.width = $("#scene_map").width();
+		canvas_grid.height = $("#scene_map").height();
 
 		startX = Math.round(window.CURRENT_SCENE_DATA.offsetx);
 		startY = Math.round(window.CURRENT_SCENE_DATA.offsety);

--- a/Fog.js
+++ b/Fog.js
@@ -612,12 +612,12 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 	const gridContext = gridCanvas.getContext("2d");
 	clear_grid();
 	gridContext.setLineDash(dash);
-	let startX = offsetX || window.CURRENT_SCENE_DATA.offsetx;
-	let startY = offsetY || window.CURRENT_SCENE_DATA.offsety;
-	startX = Math.round(startX)
-	startY = Math.round(startY)
-	const incrementX = hpps || window.CURRENT_SCENE_DATA.hpps;
-	const incrementY = vpps|| window.CURRENT_SCENE_DATA.vpps;
+	let startX = offsetX / window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.offsetx / window.CURRENT_SCENE_DATA.scale_factor;
+	let startY = offsetY / window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.offsety / window.CURRENT_SCENE_DATA.scale_factor;
+	startX = Math.round(startX) / window.CURRENT_SCENE_DATA.scale_factor
+	startY = Math.round(startY) / window.CURRENT_SCENE_DATA.scale_factor
+	const incrementX = hpps / window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.hpps / window.CURRENT_SCENE_DATA.scale_factor;
+	const incrementY = vpps / window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.vpps / window.CURRENT_SCENE_DATA.scale_factor;
 	gridContext.lineWidth = lineWidth || window.CURRENT_SCENE_DATA.grid_line_width;
 	gridContext.strokeStyle = color || window.CURRENT_SCENE_DATA.grid_color;
 	let isSubdivided = subdivide === "1" || window.CURRENT_SCENE_DATA.grid_subdivided === "1"


### PR DESCRIPTION
I went to ctx scaling when it was pointed out text was unreadable and it felt like the performance was still there. I was wrong abou the performance. I noticed this when I went to test stuff out in one of my test games that had an old map of nates that was insanely slow. Since text is no longer on a canvas I've adjusted all canvas' that used the ctxScale funtion to now scale with css.

This also has the side benefit of being able to go to larger scale sizes as we don't cap out on canvas size.

Example - first load is current. 2nd load is with css scaling. (Edit: fixed the grid size/offset after this gif)
https://imgur.com/Q8ClJkE