### PR TITLE
Fix - Text and drawings/walls sometimes jumping after map scale changes

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -876,8 +876,10 @@ function redraw_text() {
 		if(shape == 'text' && hidden == undefined){
 			window.DRAWINGS[drawing].push(false);
 		}
-   		if(shape == 'text')
-			draw_text(undefined, ...window.DRAWINGS[drawing]);	
+   		if(shape == 'text'){
+   			let text_clone = $.extend(true, [], window.DRAWINGS[drawing]);
+			draw_text(undefined, ...text_clone);	
+		}
 	}
 }
 
@@ -890,8 +892,8 @@ function redraw_drawings() {
 	const drawings = window.DRAWINGS.filter(d => !d[0].includes("text") && d[1] !==  "wall")
 
 	for (var i = 0; i < drawings.length; i++) {
-
-		let [shape, fill, color, x, y, width, height, lineWidth, scale] = drawings[i];
+		let drawing_clone = $.extend(true, [], drawings[i]);
+		let [shape, fill, color, x, y, width, height, lineWidth, scale] = drawing_clone;
 		const isFilled = fill === "filled"
 
 		scale = (scale == undefined) ? window.CURRENT_SCENE_DATA.scale_factor : scale;
@@ -965,7 +967,8 @@ function redraw_light_walls(clear=true){
 	}
 	$('.door-button').remove();
 	for (var i = 0; i < drawings.length; i++) {
-		let [shape, fill, color, x, y, width, height, lineWidth, scale] = drawings[i];
+		let drawing_clone = $.extend(true, [], drawings[i]);
+		let [shape, fill, color, x, y, width, height, lineWidth, scale] = drawing_clone;
 
 		if(lineWidth == undefined || lineWidth == null){
 			lineWidth = 6;

--- a/Text.js
+++ b/Text.js
@@ -701,8 +701,8 @@ function draw_text(
             for(drawing in window.DRAWINGS){
                 if(window.DRAWINGS[drawing][9] != id)
                     continue;
-                window.DRAWINGS[drawing][1] = parseInt($(this).css('left'));
-                window.DRAWINGS[drawing][2] = parseInt($(this).css('top')) + parseInt(font.size);     
+                window.DRAWINGS[drawing][1] = parseInt($(this).css('left'))*adjustScale;
+                window.DRAWINGS[drawing][2] = parseInt($(this).css('top'))*adjustScale + parseInt(font.size)*adjustScale;    
             }
                         
             sync_drawings();


### PR DESCRIPTION
Putting text, drawings or walls on the map then after changing scale causing redraws (eg text hide on right click) would cause it to jump as if it was being scaled again. This is due to changing values in the window.DRAWINGS but not the scale. In this I replaced the window.DRAWINGS pointers with clones and make a few other necesarry adjustments to prevent this from happening. 

I don't think it's terribly common so it can wait until next beta.