### PR TITLE
QoL - Always act as select tool in grid wizard regardless of menu selected

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -2031,6 +2031,12 @@ function deselect_all_top_buttons(buttonSelectedClasses) {
  * as well as any other selected buttons/required options, such as color/line width, or font family/fontsize
  */
 function get_draw_data(button, menu){
+	if($("#prewiz").length > 0 || $("#wizard_popup").length>0){
+		return {
+			shape:'rect',
+			function:'select'
+		}
+	}
 	if (!$(button).hasClass("menu-option") && !$(button).hasClass("menu-button")){
 		console.groupEnd()
 		return {


### PR DESCRIPTION
I've found myself on the wrong tool many times in this. Also today it was reported that walls can be overridden if you are on the wall tool by accident and go to select the aligners. This might also be true for drawings and text if that is the case. This forces the select tool no matter which tool you happen to have selected.