### PR TITLE
Fix - on hover combat log buttons are being clipped in the VTT and popout

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4877,6 +4877,8 @@ input.max_hp[disabled]{
     opacity: 1;
     color: #fff;
     pointer-events: none;
+    right: 8px;
+    border-radius: 5px;
 }
 
 .import-loading-indicator,


### PR DESCRIPTION
While looking at @Ellasar742's PR #948 I noticed that hover text for the combat tracker are being clipped. 

This fixes it so that they are always in view, both in the VTT window and Popped out.

![image](https://user-images.githubusercontent.com/65363489/224590839-1cd62c1e-6273-43f3-bb50-a796b822af99.png)


I think if we prefer the style of @Ellasar742's it would be easier to make these look the same rather then deal with adding them to the popout but whichever you guys prefer to do.