### PR TITLE
Add hide aura option to replace old aura light options that would allow auras to be hidden

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -441,7 +441,8 @@ function check_single_token_visibility(id){
 			else if (!window.TOKEN_OBJECTS[id].options.hidden) {
 				$(selector).css('opacity', 1);
 				$(selector).show();
-				$(auraSelector).show();
+				if(!window.TOKEN_OBJECTS[id].options.hideaura && id != playerTokenId)
+					$(auraSelector).show();
 				//console.log('SHOW '+id);
 			}
 }
@@ -497,7 +498,8 @@ function do_check_token_visibility() {
 		else if (!window.TOKEN_OBJECTS[id].options.hidden) {
 			$(selector).css('opacity', 1);
 			$(selector).show();
-			$(auraSelector).show();
+			if(!window.TOKEN_OBJECTS[id].options.hideaura && id != playerTokenId)
+				$(auraSelector).show();
 			//console.log('SHOW '+id);
 		}
 	}

--- a/Token.js
+++ b/Token.js
@@ -2713,7 +2713,7 @@ function setTokenAuras (token, options) {
 			: token.parent().parent().find("#aura_" + tokenId).css("opacity", 1)
 		}
 		else{
-			(options.hidden || showAura == 'none') ? token.parent().parent().find("#aura_" + tokenId).hide()
+			(options.hidden || options.hideaura || showAura == 'none') ? token.parent().parent().find("#aura_" + tokenId).hide()
 						: token.parent().parent().find("#aura_" + tokenId).show()
 		}
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -443,7 +443,14 @@ function build_token_auras_inputs(tokenIds) {
 	if (uniqueAuraVisibleValues.length === 1) {
 		auraIsEnabled = uniqueAuraVisibleValues[0];
 	}
+
+	let hideAuraFromPlayers = tokens.map(t => t.options.hideaura);
+	let uniqueHideAuraFromPlayers = [...new Set(hideAuraFromPlayers)];
 	
+	let hideAuraIsEnabled = null;
+	if (uniqueHideAuraFromPlayers.length === 1) {
+		hideAuraIsEnabled = uniqueHideAuraFromPlayers[0];
+	}
 
 	let aura1Feet = tokens.map(t => t.options.aura1.feet);
 	let uniqueAura1Feet = aura1Feet.length === 1 ? aura1Feet[0] : ""
@@ -520,7 +527,26 @@ function build_token_auras_inputs(tokenIds) {
 	} else {
 		wrapper.find(".token-config-aura-wrapper").hide();
 	}
-
+	const hideAura = {
+		name: "hideaura",
+		label: "Hide aura from players",
+		type: "toggle",
+		options: [
+			{ value: true, label: "Hidden", description: "The token's aura is hidden from players." },
+			{ value: false, label: "Visible", description: "The token's aura is visible to players." }
+		],
+		defaultValue: false
+	};
+	const hideAuraInput = build_toggle_input(hideAura, hideAuraIsEnabled, function(name, newValue) {
+		console.log(`${name} setting is now ${newValue}`);
+		tokens.forEach(token => {
+			token.options[name] = newValue;
+			token.place_sync_persist();
+		});
+	});
+	if(window.DM) {
+		wrapper.find(".token-config-aura-wrapper").prepend(hideAuraInput);
+	}
 	let radiusInputs = wrapper.find('input.aura-radius');
 	radiusInputs.on('keyup', function(event) {
 		let newRadius = event.target.value;


### PR DESCRIPTION
This is to replace the old light option for auras that would allow you to hide auras via only allowing players to see their own aura. 

I think this offers more flexibility in which auras are hidden and which are visible while retaining the original capability.