### PR TITLE
Fix - Draw grid section height in edit dialog

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -736,10 +736,12 @@ input[type="number"][name='gridStrokeNumberInput']{
 }
 label[for='grid_line_width'] {
     font-size: 10px;
-    position: relative;
+    position: absolute;
     font-weight: bold;
     top: -7px;
     left: -83px;
+    top: -5px;
+    left: 71px;
     color: #555;
 }
 
@@ -753,7 +755,9 @@ input[name='gridStrokeNumberInput'] {
     position: relative;
     top: 3px;
     left: -57px;
-    width: 50px;
+    position: absolute;
+    top: 8px;
+    left: 170px;
 }
 
 .isvideotogglelabel {


### PR DESCRIPTION
I thought I had fixed this but I only fixed the width of the input not the height of the area when toggled on. 

Main
![image](https://user-images.githubusercontent.com/65363489/224650780-068e4bfe-2b38-4701-b05f-b2ee0ddb7723.png)
Fix
![image](https://user-images.githubusercontent.com/65363489/224650671-e0f2f694-9170-4481-a87e-d4e11eadff98.png)


