### PR TITLE
Beta Fix - Token Darkvision range customization was being ignored if another customization was set without changing darkvision range

### DIFF
--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1515,19 +1515,19 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
 
     if(customization.tokenOptions.vision == undefined){
         customization.tokenOptions.vision = {
-            feet: 60,
+            feet: '60',
             color: 'rgba(255, 255, 255, 0.5)'
         }
     }
     if(customization.tokenOptions.light1 == undefined){
         customization.tokenOptions.light1 = {
-            feet: 0,
+            feet: '0',
             color: 'rgba(255, 255, 255, 0.8)'
         }
     }
      if(customization.tokenOptions.light2 == undefined){
         customization.tokenOptions.light2 = {
-            feet: 0,
+            feet: '0',
             color: 'rgba(255, 255, 255, 0.5)'
         }
     }


### PR DESCRIPTION
When settings token customizations if you set a color, token size or any customization without setting the darkvision range the range was ignored. 

It wanted a string instead of a number and it works.