### PR TITLE
Fix: ping color doesn't update without peer streaming enabled

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -275,11 +275,27 @@ function debounced_handle_character_update(msg) {
       update_window_pc(playerId)
         .then(() => {
           console.log("debounced_handle_character_update called update_window_pc", playerId);
+          const pc = find_pc_by_player_id(playerId);
+          if (window.DM && pc) {
+            const tokenObject = window.TOKEN_OBJECTS[pc.sheet];
+            if (tokenObject) {
+              const color = color_from_pc_object(pc);
+              tokenObject.options.color = color;
+              $(`#combat_area tr[data-target='${tokenObject.options.id}'] img[class*='Avatar']`).css("border-color", color);
+              const alternativeImages = tokenObject.options.alternativeImages || [];
+              if (typeof pc.image === "string" && pc.image.length > 0 && alternativeImages && alternativeImages.indexOf(tokenObject.options.imgsrc) < 0) {
+                // the token is not using a custom image so update it with whatever the player has set
+                tokenObject.options.imgsrc = pc.image;
+              }
+              tokenObject.place_sync_persist();
+            }
+          }
         })
         .catch(error => {
           console.warn("debounced_handle_character_update failed to update_window_pc", playerId, error);
         });
 
+      // old way of updating character data that's still being used
       if (window.DM) {
         const pc = window.pcs.find(pc => pc.sheet.includes(playerId));
         if (pc) {

--- a/Main.js
+++ b/Main.js
@@ -2561,17 +2561,12 @@ function init_ui() {
 
 		console.log("mousex " + mousex + " mousey " + mousey);
 
-		let dataName = window.PLAYER_NAME.replace(/\"/g,'\\"')
-
-		let borderColor = $(`.token[data-name="`+dataName+`"]`).attr(`data-border-color`)
-		let pingColor = (typeof borderColor === 'undefined') ? "#000e #fffe #000e #fffe" : borderColor;
-
 		data = {
 			x: mousex,
 			y: mousey,
 			from: window.PLAYER_NAME,
 			dm: window.DM,
-			color: pingColor,
+			color: color_for_player_id(my_player_id()),
 			center_on_ping: $('#ping_center .ddbc-tab-options__header-heading').hasClass('ddbc-tab-options__header-heading--is-active')
 		}
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -8,6 +8,17 @@ function mydebounce(func, timeout = 800){
   };
 }
 
+function throttle(func, timeFrame = 800) {
+	var lastTime = 0;
+	return function (...args) {
+		var now = new Date();
+		if (now - lastTime >= timeFrame) {
+			func(...args);
+			lastTime = now;
+		}
+	};
+}
+
 function clearFrame(){
 	$(".streamer-canvas").each(function() {
 		let canvas=$(this).get(0);
@@ -471,10 +482,7 @@ class MessageBroker {
 				self.handleAudioPlayingSync(msg);
 			}
 			if(msg.eventType.includes('character-update')){
-				if(window.DM) {			
-						debounced_handle_character_update(msg);
-				}		
-
+					debounced_handle_character_update(msg);
 			}
 
 			if (msg.eventType == "custom/myVTT/reveal") {

--- a/PlayerPanel.js
+++ b/PlayerPanel.js
@@ -210,7 +210,7 @@ function find_and_set_player_color() {
 
 function change_player_color(color) {
 	const playerId = my_player_id();
-	// window.color = color; // TODO: stop using window.color
+	window.color = color;
 	WaypointManager.drawStyle.color = color;
 	// window.PeerManager.send(PeerEvent.preferencesChange());
 	const peerConnected = is_peer_connected(playerId);


### PR DESCRIPTION
We pass color information over PeerManager, and I was using that to update other things, but now I'm piggybacking on the new `sendCharacterUpdateEvent` function. 

As long as I was cleaning up some peer streaming logic, I played around with throttling the streams. I introduced a 20 millisecond delay to sending cursor and ruler events, and then animate the movement on the receiving side by the same amount of time. If the network hangs, it can look a little odd, but for the most part it's still pretty smooth while reducing network usage by a bunch.