### PR TITLE
Fix: video maps don't always load on startup

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -117,17 +117,23 @@ function showError(error, ...extraInfo) {
 
   $("#copy-error-button").on("click", function () {
     const textToCopy = $("#error-message-stack").html().replaceAll("<br />", "\n").replaceAll("<br/>", "\n").replaceAll("<br>", "\n");
-    copy_to_clipboard("```\n"+textToCopy+"\n```");
+    const environment = JSON.stringify({
+      avttVersion: `${window.AVTT_VERSION}${AVTT_ENVIRONMENT.versionSuffix}`,
+      browser: get_browser(),
+    });
+    copy_to_clipboard("**Error:**\n```\n" + textToCopy + "\n```\n**Environment:**\n```\n" + environment + "\n```\n");
   });
 
   look_for_github_issue(error.message, ...extraStrings)
-    .then(add_issues_to_error_message)
+    .then((issues) => {
+      add_issues_to_error_message(issues, error.message);
+    })
     .catch(githubError => {
       console.error("look_for_github_issue", "Failed to look for github issues", githubError);
     })
 }
 
-function add_issues_to_error_message(issues) {
+function add_issues_to_error_message(issues, errorMessage) {
   if (issues.length > 0) {
 
     let ul = $("#error-issues-list");
@@ -154,9 +160,13 @@ function add_issues_to_error_message(issues) {
     const githubButton = $(`<button id="create-github-button">Create Github Issue</button>`);
     githubButton.click(function() {
       const textToCopy = $("#error-message-stack").html().replaceAll("<br />", "\n").replaceAll("<br/>", "\n").replaceAll("<br>", "\n");
-      const errorBody = "```\n"+textToCopy+"\n```";
-      console.log("look_for_github_issue", `appending createIssueUrl`, error.message, errorBody);
-      open_github_issue(error.message, errorBody);
+      const environment = JSON.stringify({
+        avttVersion: `${window.AVTT_VERSION}${AVTT_ENVIRONMENT.versionSuffix}`,
+        browser: get_browser(),
+      });
+      const errorBody = "**Error:**\n```\n" + textToCopy + "\n```\n**Environment:**\n```\n" + environment + "\n```\n";
+      console.log("look_for_github_issue", `appending createIssueUrl`, errorMessage, errorBody);
+      open_github_issue(errorMessage, errorBody);
     });
     $("#above-vtt-error-message .error-message-buttons").append(githubButton);
   }
@@ -482,7 +492,7 @@ async function look_for_github_issue(...searchTerms) {
   const response = await request.json();
 
   // remove any that have been marked as potential-duplicate
-  const filteredIssues = response.filter(issue => !issue.labels.find(l => l.name === "potential-duplicate")).reverse();
+  const filteredIssues = response.filter(issue => !issue.labels.find(l => l.name === "potential-duplicate" || l.name === "released")).reverse();
 
   // instantiate fuse to fuzzy match parts of the github issues that we just downloaded
   const fuse = new Fuse(filteredIssues, {

--- a/Main.js
+++ b/Main.js
@@ -2473,12 +2473,6 @@ function init_ui() {
 
 	inject_chat_buttons();
 
-	//s = $("<script src='https://meet.jit.si/external_api.js'></script>");
-	//$("#site").append(s);
-
-	s = $("<script src='https://www.youtube.com/iframe_api'></script>");
-	$("#site").append(s);
-
 	$("#site").append(`
 		<script type="text/javascript" src="/content/1-0-2027-0/js/libs/lightbox2/dist/js/lightbox.min.js"></script>
         <link rel="stylesheet" href="/content/1-0-2027-0/js/libs/lightbox2/dist/css/lightbox.min.css">

--- a/Startup.js
+++ b/Startup.js
@@ -41,6 +41,24 @@ $(function() {
   }
 });
 
+function load_external_script(scriptUrl) {
+  return new Promise(function (resolve, reject) {
+    let script = document.createElement('script');
+    script.src = scriptUrl;
+    script.type = 'text/javascript';
+    script.async = true;
+    script.onload = resolve;
+    script.onerror = function () {
+      reject(new Error(`Failed to load external script ${scriptUrl}`));
+    };
+    script.addEventListener('error', function () {
+      reject(new Error(`Failed to load external script ${scriptUrl}`));
+    });
+    script.addEventListener('load', resolve);
+    document.head.appendChild(script);
+  })
+}
+
 async function start_above_vtt_common() {
   console.log("start_above_vtt_common");
   // make sure we have a campaign id
@@ -57,6 +75,7 @@ async function start_above_vtt_common() {
   window.TOKEN_PASTE_BUFFER = [];
   window.TOKEN_SETTINGS = $.parseJSON(localStorage.getItem(`TokenSettings${window.gameId}`)) || {};
 
+  await load_external_script("https://www.youtube.com/iframe_api");
   $("#site").append("<div id='windowContainment'></div>");
 
   startup_step("Gathering player character data");


### PR DESCRIPTION
This injects the youtube script on startup, and waits for the script to load before continuing. It doesn't use the `onYouTubeIframeAPIReady`, but it does make sure the script is fully loaded before moving on.

While testing, I also noticed that the error messaging doesn't exclude `released` bugs so I updated that, and then added environment information to the error data as well.

closes #980 