### PR TITLE
QoL - Move token vision check to a hotkey (SHIFT+V) so both DM's and Players can fully check vision when wanted

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3057,7 +3057,7 @@ function detectWallCollision(x1, y1, x2, y2){
 	return false;
 }
 
-function redraw_light(){
+function redraw_light(checkVision=false){
 
 
 	let canvas = document.getElementById("raycastingCanvas");
@@ -3082,10 +3082,12 @@ function redraw_light(){
 	let selectedIds = [];
 	let selectedTokens = $('.tokenselected');
 	if(selectedTokens.length>0){
-	  	if(window.DM && window.CURRENT_SCENE_DATA.darkness_filter >= 75){
-	  		$('#VTT').css('--darkness-filter', `${Math.max(100-window.CURRENT_SCENE_DATA.darkness_filter, 20)}%`)
-	  		$('#raycastingCanvas').css('opacity', '0');
+	
+		if(checkVision){
+	  		$('#VTT').css('--darkness-filter', `${Math.max(100-window.CURRENT_SCENE_DATA.darkness_filter)}%`)
+	  		$('#raycastingCanvas').css('opacity', '1');
 	  	}
+	  	
   		
 		for(j = 0; j < selectedTokens.length; j++){
 		  	let tokenId = $(selectedTokens[j]).attr('data-id');
@@ -3119,19 +3121,28 @@ function redraw_light(){
 	}
 	$(`.aura-element-container-clip[id='${auraId}']`).css('clip-path', `path('${path}')`)
 
+	
+	if(checkVision){
+		$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).css('visibility', 'hidden');
+	}
+	
+	if(window.DM && !checkVision){
+		$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).css('visibility', 'visible'); 
+	}
 
-	$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).css('visibility', 'hidden');
-  	if(selectedIds.length == 0 || found){	
+  	if(selectedIds.length == 0 || found || !checkVision){	
   		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-  		if(!auraId.includes(window.PLAYER_ID) && !window.DM && window.TOKEN_OBJECTS[auraId].options.share_vision != true && playerTokenId != undefined )
+  		if(!auraId.includes(window.PLAYER_ID) && !window.DM && window.TOKEN_OBJECTS[auraId].options.share_vision != true && playerTokenId != undefined)
   			continue; 
   		
   		if(playerTokenId == undefined && window.TOKEN_OBJECTS[auraId].options.share_vision != true && !window.DM && window.TOKEN_OBJECTS[auraId].options.itemType != 'pc')
   			continue;
+V
 
-  		
-  		$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).css('visibility', 'visible');
-  		
+		
+		$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).css('visibility', 'visible'); 		
+		
+  	
 
   		drawPolygon(context, lightPolygon, 'rgba(255, 255, 255, 1)', true);
   	

--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -69,8 +69,12 @@ Mousetrap.bind('s', function () {       //video fullscreen toggle
 });
 
 
-Mousetrap.bind('v', function () {       //video fullscreen toggle
+Mousetrap.bind('v', function () {       //video fullscreen toggle 
     $('#jitsi_switch').click()
+});
+
+Mousetrap.bind('shift+v', function () {       //check token vision
+    redraw_light(true);
 });
 
 Mousetrap.bind('=', function () {       //zoom plus

--- a/Main.js
+++ b/Main.js
@@ -3092,6 +3092,10 @@ function init_help_menu() {
 							<dd>Hide buttons from screen (spectator mode)</dd>
 						<dl>
 						<dl>
+							<dt>SHIFT+V</dt>
+							<dd>Check token vision.</dd>
+						<dl>
+						<dl>
 							<dt>SHIFT+Click</dt>
 							<dd>Select multiple tokens</dd>
 						<dl>


### PR DESCRIPTION
This puts the vision check on a hotkey. Since there are various opinions on how the vision check should appear and if it should darken so much on token select. 

I feel this gives a better experience on both ends. You still have your general vision view where you can see everything as DM but can look at the exact vision of a token with shift+v. Or players can look at a specific tokens vision if they have more than 1 token with vision available.

