### PR TITLE
QoL - Auto set player and monster `darkvision` by setting it to their largest sense range.

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1704,6 +1704,13 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 			.ct-character-sheet-mobile__header{
 				top: 0px !important; 
 			}
+			#mega-menu-target,
+			.site-bar,
+			.page-header,
+			.homebrew-comments,
+			.mega-menu__fallback{
+				display:none;
+			}
 
 			@media (min-width: 1200px){
 				html body#site.body-rpgcharacter-sheet{
@@ -1713,11 +1720,7 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 			</style>
 		`);
 		console.log("removing headers");
-		$(event.target).contents().find("#mega-menu-target").remove();
-		$(event.target).contents().find(".site-bar").remove();
-		$(event.target).contents().find(".page-header").remove();
-		$(event.target).contents().find(".homebrew-comments").remove();
-		$(event.target).contents().find(".mega-menu__fallback").remove();
+
 
 		$(event.target).contents().on("DOMNodeInserted", function(addedEvent) {
 			let addedElement = $(addedEvent.target);

--- a/Token.js
+++ b/Token.js
@@ -1562,9 +1562,47 @@ class Token {
 				}
 			}
 			if(this.options.vision == undefined){
-				this.options.vision = {
-					feet: 60,
-					color: 'rgba(255, 255, 255, 0.5)'
+				if(this.isPlayer()){
+		            let pcData = window.pcs.filter((d) => this.options.id.includes(d.id))[0];
+		            let darkvision = 0;
+		            if(pcData.senses.length > 0)
+		            {
+		                for(i=0; i < pcData.senses.length; i++){
+		                    const ftPosition = pcData.senses[i].distance.indexOf('ft.');
+		                    const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
+		                    if(range > darkvision)
+		                        darkvision = range;
+		                }
+		            }
+		            this.options.vision = {
+		                feet: darkvision.toString(),
+		                color: 'rgba(255, 255, 255, 0.5)'
+		            }
+		        }
+		        else if(this.isMonster() && window.monsterListItems.filter((d) => this.options.monster == d.id).length == 1){
+		            let darkvision = 0;
+		            let monsterSidebarListItem = window.monsterListItems.filter((d) => this.options.monster == d.id)[0];
+		            if(monsterSidebarListItem.monsterData.senses.length > 0)
+		            {
+		                for(i=0; i < monsterSidebarListItem.monsterData.senses.length; i++){
+		                    const ftPosition = monsterSidebarListItem.monsterData.senses[i].notes.indexOf('ft.')
+		                    const range = parseInt(monsterSidebarListItem.monsterData.senses[i].notes.slice(0, ftPosition));
+		                    if(range > darkvision)
+		                        darkvision = range;
+		                }
+		            }
+
+		            this.options.vision = {
+		                feet: darkvision.toString(),
+		                color: 'rgba(255, 255, 255, 0.5)'
+		            }
+		        }
+				else{
+					this.options.vision = {
+						feet: 60,
+						color: 'rgba(255, 255, 255, 0.5)'
+					}
+				
 				}
 			}
 
@@ -2441,12 +2479,7 @@ function default_options() {
 		light2: {
 			feet: "0",
 			color: "rgba(255, 255, 255, 0.5)"
-		},
-		vision:{
-			feet: '60',
-			color: "rgba(255, 255, 255, 0.5)"
-		}
-		
+		}		
 	};
 }
 

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1514,9 +1514,45 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
     }
 
     if(customization.tokenOptions.vision == undefined){
-        customization.tokenOptions.vision = {
-            feet: '60',
-            color: 'rgba(255, 255, 255, 0.5)'
+        if(listItem.isTypePC()){
+            let pcData = window.pcs.filter((d) => listItem.id.includes(d.id))[0];
+            let darkvision = 0;
+            if(pcData.senses.length > 0)
+            {
+                for(i=0; i < pcData.senses.length; i++){
+                    const ftPosition = pcData.senses[i].distance.indexOf('ft.');
+                    const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
+                    if(range > darkvision)
+                        darkvision = range;
+                }
+            }
+            customization.tokenOptions.vision = {
+                feet: darkvision.toString(),
+                color: 'rgba(255, 255, 255, 0.5)'
+            }
+        }
+        else if(listItem.isTypeMonster()){
+            let darkvision = 0;
+            if(listItem.monsterData.senses.length > 0)
+            {
+                for(i=0; i < listItem.monsterData.senses.length; i++){
+                    const ftPosition = listItem.monsterData.senses[i].notes.indexOf('ft.')
+                    const range = parseInt(listItem.monsterData.senses[i].notes.slice(0, ftPosition));
+                    if(range > darkvision)
+                        darkvision = range;
+                }
+            }
+
+            customization.tokenOptions.vision = {
+                feet: darkvision.toString(),
+                color: 'rgba(255, 255, 255, 0.5)'
+            }
+        }
+        else{
+            customization.tokenOptions.vision = {
+                feet: '60',
+                color: 'rgba(255, 255, 255, 0.5)'
+            }
         }
     }
     if(customization.tokenOptions.light1 == undefined){
@@ -1525,7 +1561,7 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
             color: 'rgba(255, 255, 255, 0.8)'
         }
     }
-     if(customization.tokenOptions.light2 == undefined){
+    if(customization.tokenOptions.light2 == undefined){
         customization.tokenOptions.light2 = {
             feet: '0',
             color: 'rgba(255, 255, 255, 0.5)'


### PR DESCRIPTION
Closes #986

This automatically sets up for both places tokens and token customizations the largest sense range players or monsters have as their darkvision. All the senses listed generally grant a version of sight in the dark. 

This also fixes an error that fires on click when the DM is looking at player sheets and clicks inside them. I think this was preventing updates from being seen in the side panel after updating a character sheet as the DM. When we remove the window on click it looks for it and finds null causing an error - I hide them with this instead. I just left the fix in this PR but can separate it if you'd like.