### PR TITLE
Better DDBApi error handling

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -110,6 +110,7 @@ function showError(error, ...extraInfo) {
 
   $("#error-message-stack")
     .append(extraStrings.join(`<br />`))
+    .append(`<br />${error.message}`) // this is duplicative on Chrome, but not anywhere else. I'd rather have duplicate info on Chrome than missing info in other browsers.
     .append(`<br />`)
     .append(stack);
 


### PR DESCRIPTION
The stacktrace is a bit much, but the actual API error is displayed. In this example, startup failed because the user had too many Encounters. 

## Before

![bad-DDBApi-error](https://user-images.githubusercontent.com/584771/226112823-dbc01b07-26ba-412e-ab47-59c246a0cf91.png)

## After
<img width="1154" alt="Screenshot 2023-03-18 at 9 33 22 AM" src="https://user-images.githubusercontent.com/584771/226112837-efbf184e-5507-4192-a535-b1510c79a8e2.png">


