### PR TITLE
QoL/Fix - Images sent with a url to chat will be sized the same as send to gamelog images (slightly larger/fill the available space); clean up an error on send to gamelog images

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -290,8 +290,11 @@ class MessageBroker {
 								if (img[0]) {
 									img[0].onload = () => {
 										if (img[0].naturalWidth > 0) {
-											li.find('.chat-link')[0].style.display = 'none';
-											img[0].style.display = 'block';
+											li.find('.chat-link').css('display', 'none');
+											img.css({
+												'display': 'block',
+												'width': '100%'
+											});
 										}
 									}
 								}


### PR DESCRIPTION
This sets the image width to 100% of the available space went sent to chat. 

It also stops an error from firing when a chat-link didn't exist like when sending from a monster stat block.