### PR TITLE
Internal - fix discord message parsing in release-build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -169,7 +169,8 @@ jobs:
       - name: "Generate Discord changelog message"
         if: ${{ inputs.release_type == 'beta' }}
         run: |
-          changelog=$(cat release.json | jq '.body' | xargs echo)
+          changelog=$(cat release.json | jq '.body')
+          changelog=${changelog:1:-1}
           echo $changelog > changelog.txt
           discord_message="**${version_name}**"
           while read -r line; do


### PR DESCRIPTION
It was choking on the `xargs echo` pipe. I was doing that to remove the surrounding quotation marks, but now I'm just assigning the `changelog` variable to a substring from index 1 to index -1.