### PR TITLE
Fix - Fog on some imported scenes (DDB scenes especially)

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -386,10 +386,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				dm_map_is_video: "0",
 				scale: "100",
 				dm_map_usable: "0",
-				fog_of_war: "0",
 				thumb: thumb,
 				tokens: {},
-				reveals: [],
 			});		
 		}
 
@@ -437,9 +435,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 					thumb: thumb,
 					scale: "100",
 					dm_map_usable: "0",
-					fog_of_war: "0",
 					tokens: {},
-					reveals: [],
 				});
 			});
 
@@ -483,10 +479,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 						dm_map_is_video: "0",
 						scale: "100",
 						dm_map_usable: "0",
-						fog_of_war: "0",
 						thumb: thumb,
 						tokens: {},
-						reveals: [],
 					});
 				});
 			} else if (compendiumWithoutSubtitle.length > 0) {
@@ -525,10 +519,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 						dm_map_is_video: "0",
 						scale: "100",
 						dm_map_usable: "0",
-						fog_of_war: "0",
 						thumb: thumb,
 						tokens: {},
-						reveals: [],
 					});
 
 				});

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1244,7 +1244,8 @@ function default_scene_data() {
 		grid: 0,
 		snap: 0,
 		reveals: [[0, 0, 0, 0, 2, 0, 1]],
-		order: Date.now()
+		order: Date.now(),
+		darkness_filter: '0'
 	};
 }
 


### PR DESCRIPTION
Looks like we were setting fog_of_war to 0 for these scenes. I removed this and reveals and let the default settings apply. 

We should remove fog_of_war 0 (or the setting in general) at this point I believe it's really unlikely anyone still is using scenes with this setting not 1. We'll have to double check doing this doesn't mess with the grid wizard but otherwise shouldn't have a noticeable impact.

I also added the darkness_filter to the defaults incase it does come up an issue again.