### PR TITLE
Internal - Add labels to PRs based on title prefix

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -26,6 +26,9 @@ jobs:
           elif [[ "${title}" == internal* ]]
           then
             label_to_add='internal'
+          elif [[ "${title}" == chore* ]]
+          then
+            label_to_add='chore'
           fi
           
           if [[ ! -z "$label_to_add" ]]


### PR DESCRIPTION
# What
This will add a label to PRs based on the title of the PR (case-incensitive). The following are supported title prefixes:
* `fix` adds the `bug` label
* `feat` adds the `enhancement` label
* `beta` adds the `beta-regression` label
* `internal` adds  the `internal` label
* `chore` adds  the `chore` label

# Why
When a new release is published, the generated release notes are categorized based on labels. Here's a breakdown of the categorization:
* `bug` and `beta-regression` labeled PRs are added under a `Bug Fixes 🛠` header
* `enhancement` labeled PRs are added under a `New Features 🎉` header
* `internal` and `chore` labeled PRs are excluded
