### PR TITLE
Fix - Reset selected token vision on player deselect token, fix wall shadows getting darker

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3089,7 +3089,9 @@ function redraw_light(){
 	if(selectedTokens.length>0){
 	
 		if(window.SelectedTokenVision){
-	  		$('#VTT').css('--darkness-filter', `${Math.max(100-window.CURRENT_SCENE_DATA.darkness_filter)}%`)
+			if(window.CURRENT_SCENE_DATA.darkness_filter > 0){
+				$('#VTT').css('--darkness-filter', `0%`)
+			}
 	  		$('#raycastingCanvas').css('opacity', '1');
 	  	}
 	  	

--- a/Token.js
+++ b/Token.js
@@ -2686,13 +2686,12 @@ function deselect_all_tokens() {
 	let darknessPercent = 100 - parseInt(darknessFilter); 	
 	if(window.DM && darknessPercent < 40){
    	 	darknessPercent = 40; 	
-   	 	$('#VTT').css('--darkness-filter', darknessPercent + "%");
    	 	$('#raycastingCanvas').css('opacity', 0);
    	}
-	else if(window.DM){
-   		$('#VTT').css('--darkness-filter', darknessPercent + "%");
+	else{
    		$('#raycastingCanvas').css('opacity', '');
    	}
+   		$('#VTT').css('--darkness-filter', darknessPercent + "%");
    	if(window.DM){
    		$("[id^='light_']").css('visibility', "visible");
    	}

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5799,7 +5799,7 @@ div.ddbc-tab-options--layout-pill>button{
 
 }
 #raycastingCanvas{
-    opacity: max(calc(100% - var(--darkness-filter)), var(--walls-up-shadow-percent));
+    opacity: min(var(--darkness-filter), var(--walls-up-shadow-percent));
 }
 
 


### PR DESCRIPTION
Currently once players have enabled selected token vision deselect doesn't set the canvas opacity back to default. It was in an if(window.DM) when it shouldn't be.

Also when checking tokens vision only make the darkness 100% regardless of darkness of the map - sometimes it looks like they should see the whole area when they shouldn't be able to on less dark maps.

I think I had the css max-min backwards here a couple times for wall shadows. There's no need for the shadows to get darker as the darkness gets darker. That just doubles up on the darkness and creates an odd visual at high darkness levels. This changes it so as there is more scene light (less darkness filter) the shadows get darker up to the 30% (this is the same as full brightness maps on live). This considerably lessens the darkness double up. This does change how I approach the hiding behind twigs issue but I think I have to redo that anyway due to realizing it won't work well on maps less than 100% darkness.
