### PR TITLE
Fix - Check vision on all light checks, Stop tokes from hiding behind twigs

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -377,22 +377,22 @@ class WaypointManagerClass {
 function is_token_under_fog(tokenid){
 	if(window.DM)
 		return false;
-	var canvas = document.getElementById("fog_overlay");
-	var ctx = canvas.getContext("2d");
+	let canvas = document.getElementById("fog_overlay");
+	let ctx = canvas.getContext("2d");
 	let canvas2 = document.getElementById("raycastingCanvas");
 	let ctx2 = canvas2.getContext("2d");
 
 
-	var left = (parseInt(window.TOKEN_OBJECTS[tokenid].options.left.replace('px', '')) + (window.TOKEN_OBJECTS[tokenid].options.size / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
-	var top = (parseInt(window.TOKEN_OBJECTS[tokenid].options.top.replace('px', '')) + (window.TOKEN_OBJECTS[tokenid].options.size / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
-	var pixeldata = ctx.getImageData(left, top, 1, 1).data;
-	var pixeldata2 = ctx2.getImageData(left, top, 1, 1).data;
-
+	let left = (parseInt(window.TOKEN_OBJECTS[tokenid].options.left.replace('px', '')) + (window.TOKEN_OBJECTS[tokenid].options.size / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
+	let top = (parseInt(window.TOKEN_OBJECTS[tokenid].options.top.replace('px', '')) + (window.TOKEN_OBJECTS[tokenid].options.size / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
+	let pixeldata = ctx.getImageData(left, top, 1, 1).data;
+	let pixeldata2 = ctx2.getImageData(parseInt(window.TOKEN_OBJECTS[tokenid].options.left.replace('px', ''))/ window.CURRENT_SCENE_DATA.scale_factor, parseInt(window.TOKEN_OBJECTS[tokenid].options.top.replace('px', ''))/ window.CURRENT_SCENE_DATA.scale_factor, window.TOKEN_OBJECTS[tokenid].sizeWidth()/ window.CURRENT_SCENE_DATA.scale_factor, window.TOKEN_OBJECTS[tokenid].sizeHeight()/ window.CURRENT_SCENE_DATA.scale_factor).data;
+		
 	let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 	let playerTokenAuraIsLight = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+	pixeldata2 = pixeldata2.filter(function(color, index) {return (index + 1) % 4 != 0});
 
-
-	if (!window.TOKEN_OBJECTS[tokenid].options.revealInFog && (pixeldata[3] == 255 || (pixeldata2[2] == 0 && playerTokenAuraIsLight && (window.CURRENT_SCENE_DATA.darkness_filter > 0 || window.walls.length>4))))
+	if (!window.TOKEN_OBJECTS[tokenid].options.revealInFog && (pixeldata[3] == 255 || (!pixeldata2.some(color => color == 255) && playerTokenAuraIsLight && (window.CURRENT_SCENE_DATA.darkness_filter > 0 || window.walls.length>4))))
 		return true;
 	else
 		return false;
@@ -473,25 +473,27 @@ function do_check_token_visibility() {
 	console.log("do_check_token_visibility");
 	if (window.DM || $("#fog_overlay").is(":hidden"))
 		return;
-	var canvas = document.getElementById("fog_overlay");
-	var ctx = canvas.getContext("2d");
+	let canvas = document.getElementById("fog_overlay");
+	let ctx = canvas.getContext("2d");
 	let canvas2 = document.getElementById("raycastingCanvas");
 	let ctx2 = canvas2.getContext("2d");
 
-	for (var id in window.TOKEN_OBJECTS) {
-		var left = (parseInt(window.TOKEN_OBJECTS[id].options.left.replace('px', '')) + (window.TOKEN_OBJECTS[id].sizeWidth() / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
-		var top = (parseInt(window.TOKEN_OBJECTS[id].options.top.replace('px', '')) + (window.TOKEN_OBJECTS[id].sizeHeight() / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
-		var pixeldata = ctx.getImageData(left, top, 1, 1).data;
-		let pixeldata2 = ctx2.getImageData(left, top, 1, 1).data;
+	for (let id in window.TOKEN_OBJECTS) {
+		let left = (parseInt(window.TOKEN_OBJECTS[id].options.left.replace('px', '')) + (window.TOKEN_OBJECTS[id].sizeWidth() / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
+		let top = (parseInt(window.TOKEN_OBJECTS[id].options.top.replace('px', '')) + (window.TOKEN_OBJECTS[id].sizeHeight() / 2)) / window.CURRENT_SCENE_DATA.scale_factor;
+		let pixeldata = ctx.getImageData(left, top, 1, 1).data;
+		let pixeldata2 = ctx2.getImageData(parseInt(window.TOKEN_OBJECTS[id].options.left.replace('px', ''))/ window.CURRENT_SCENE_DATA.scale_factor, parseInt(window.TOKEN_OBJECTS[id].options.top.replace('px', ''))/ window.CURRENT_SCENE_DATA.scale_factor, window.TOKEN_OBJECTS[id].sizeWidth()/ window.CURRENT_SCENE_DATA.scale_factor, window.TOKEN_OBJECTS[id].sizeHeight()/ window.CURRENT_SCENE_DATA.scale_factor).data;
 		let auraSelectorId = $(".token[data-id='" + id + "']").attr("data-id").replaceAll("/", "");
 		let auraSelector = ".aura-element[id='aura_" + auraSelectorId + "']";
-		var selector = "div.token[data-id='" + id + "']";
+		let selector = "div.token[data-id='" + id + "']";
 
 
 		let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 		let playerTokenHasVision = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
-			
-		if (!window.TOKEN_OBJECTS[id].options.revealInFog && (pixeldata[3] == 255 || (pixeldata2[2] == 0 && playerTokenHasVision && (window.CURRENT_SCENE_DATA.darkness_filter > 0 || window.walls.length>4)) || (playerTokenHasVision && window.CURRENT_SCENE_DATA.darkness_filter > 0  && (!is_token_under_light_aura(id) && pixeldata[2] == 0 && window.CURRENT_SCENE_DATA.darkness_filter > 0)))) {
+
+		pixeldata2 = pixeldata2.filter(function(color, index) {return (index + 1) % 4 != 0});
+		
+		if (!window.TOKEN_OBJECTS[id].options.revealInFog && (pixeldata[3] == 255 || (!pixeldata2.some(color => color == 255) && playerTokenHasVision && (window.CURRENT_SCENE_DATA.darkness_filter > 0 || window.walls.length>4)) || (playerTokenHasVision && window.CURRENT_SCENE_DATA.darkness_filter > 0  && (!is_token_under_light_aura(id) && pixeldata[2] == 0 && window.CURRENT_SCENE_DATA.darkness_filter > 0)))) {
 			$(selector).hide();
 			$(auraSelector).hide();
 		}

--- a/Token.js
+++ b/Token.js
@@ -35,6 +35,10 @@ const availableToAoe = [
 	"revealname"
 ];
 
+
+
+
+
 const debounceLightChecks = mydebounce(() => {		
 		if(window.walls != undefined){
 			if(window.walls.length < 5){
@@ -44,7 +48,10 @@ const debounceLightChecks = mydebounce(() => {
 		else{
 			redraw_light_walls();	
 		}
-		redraw_light();	}, 100);
+		redraw_light();
+		if(!window.DM)
+			check_token_visibility();
+}, 100);
 
 
 function random_token_color() {
@@ -1349,9 +1356,6 @@ class Token {
 					}, { duration: animationDuration, queue: true, complete: function() {
 						draw_selected_token_bounding_box();
 						debounceLightChecks();
-						if(!window.DM){
-									check_token_visibility();											
-							}
 						}
 						
 					});


### PR DESCRIPTION
Currently when dragging tokens at stop it does a light check but doesn't check vision until you click off the token. This corrects that by adding the vision check to the debounced light check.

It also now stops tokens from hiding behind twigs/small bars of walls. As long as there is a non black pixel on the raycast when in vision range it will be shown. It might be a little on the over shown side as it's checking the token size (a square) and some tokens are round. I might make it a slightly smaller square then the token size if it feels that way to a lot of people.