### PR TITLE
Fix - Move sheet resize button over

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1447,7 +1447,7 @@ function init_sheet() {
 			toggle_player_sheet();
 		});
 		var sheet_resize_button = $("<div id='sheet_resize_button' class='hasTooltip button-icon hideable ddbc-tab-options--layout-pill' data-name='Resize character sheet'><div class='ddbc-tab-options__header-heading'>Toggle Sheet Size</div></div>");
-		sheet_resize_button.css({ "position": "absolute", "top": "-3px", "left": "-285px", "z-index": "999" });
+		sheet_resize_button.css({ "position": "absolute", "top": "-3px", "left": "-314px", "z-index": "999" });
 		sheet_resize_button.find(".ddbc-tab-options__header-heading").css({ "padding": "6px" });
 		$(".avtt-sidebar-controls").append(sheet_resize_button);
 		// $(".ct-character-sheet__inner").append(sheet_resize_button);


### PR DESCRIPTION
Move the toggle sheet size button to the left a bit so it isn't hidden behind the `selected token vision` button.