### PR TITLE
internal - Update label-prs workflow

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,37 +1,57 @@
 name: label-prs
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, reopened]
 
 jobs:
   add-label-based-on-title:
+    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.changes.title != '' }}
     runs-on: ubuntu-latest
     steps:
-      - name : Add label to PR based on title
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
-          echo "github.event.pull_request.title=${{ github.event.pull_request.title }}"
-          echo "github.event.pull_request.number=${{ github.event.pull_request.number }}"
-          title=$(echo "${{ github.event.pull_request.title }}" | tr "[:upper:]" "[:lower:]") 
-          echo "title=${title}"
-          label_to_add=''
-          if [[ "${title}" == fix* ]]
-          then
-            label_to_add='bug'
-          elif [[ "${title}" == feat* ]]
-          then
-            label_to_add='enhancement'
-          elif [[ "${title}" == beta* ]]
-          then
-            label_to_add='beta-regression'
-          elif [[ "${title}" == internal* ]]
-          then
-            label_to_add='internal'
-          elif [[ "${title}" == chore* ]]
-          then
-            label_to_add='chore'
-          fi
+          echo "$GITHUB_CONTEXT"
+      - name: find labels to remove and/or add
+        run: |
+          find_label() {
+            local lowercase_title=$(echo "$1" | tr "[:upper:]" "[:lower:]") 
+            local label_to_output=''
+            if [[ "${lowercase_title}" == fix* ]]
+            then
+              label_to_output='bug'
+            elif [[ "${lowercase_title}" == feat* ]]
+            then
+              label_to_output='enhancement'
+            elif [[ "${lowercase_title}" == beta* ]]
+            then
+              label_to_output='beta-regression'
+            elif [[ "${lowercase_title}" == internal* ]]
+            then
+              label_to_output='internal'
+            elif [[ "${lowercase_title}" == chore* ]]
+            then
+              label_to_output='chore'
+            fi
+            echo $label_to_output
+          }
+
+          label_to_remove=$(find_label "${{ github.event.changes.title.from }}")
+          echo "label_to_remove: $label_to_remove"
+          label_to_add=$(find_label "${{ github.event.pull_request.title }}")
+          echo "label_to_add: $label_to_add"
           
-          if [[ ! -z "$label_to_add" ]]
+          if [[ $label_to_remove == $label_to_add ]]
           then
-            curl -o /dev/null --request POST --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{github.event.pull_request.number}}/labels" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" --header 'Content-Type: application/json' -d "{\"labels\":[\"${label_to_add}\"]}"
+            echo "No need to change labels"
+          else
+            if [[ ! -z "$label_to_add" ]]
+            then
+              curl --request POST --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{github.event.pull_request.number}}/labels" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}" --header 'Content-Type: application/json' -d "{\"labels\":[\"${label_to_add}\"]}"
+            fi
+            if [[ ! -z "$label_to_remove" ]]
+            then
+              curl --request DELETE --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{github.event.pull_request.number}}/labels/${label_to_remove}" --header "Authorization: Bearer ${{secrets.GITHUB_TOKEN}}"
+            fi
           fi


### PR DESCRIPTION
It now only runs when a PR is opened, reopened, or when the title is changed. The old version would run when a commit is pushed or when the body is changed.

This also removes labels if you change the prefix. For example, if a PR has the title `Fix - this thing`, it would get the `bug` label added to it. Then, if you change the title to `Internal - thing`, the `bug` label would be removed and the `internal` label will be added. It will only remove a label if the old title had a prefix that matches. It will not remove any other labels.