### PR TITLE
attempt to fix label-prs

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,18 +1,13 @@
 name: label-prs
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronized]
 
 jobs:
   add-label-based-on-title:
-    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.changes.title != '' }}
+    # if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.changes.title != '' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
       - name: find labels to remove and/or add
         run: |
           find_label() {
@@ -37,10 +32,11 @@ jobs:
             echo $label_to_output
           }
 
-          label_to_remove=$(find_label "${{ github.event.changes.title.from }}")
-          echo "label_to_remove: $label_to_remove"
           label_to_add=$(find_label "${{ github.event.pull_request.title }}")
           echo "label_to_add: $label_to_add"
+
+          label_to_remove=$(find_label "${{ github.event.changes.title.from }}")
+          echo "label_to_remove: $label_to_remove"
           
           if [[ $label_to_remove == $label_to_add ]]
           then


### PR DESCRIPTION
I don't know why, but after my last update, this workflow started getting this error from the Github API

```
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/reference/issues#add-labels-to-an-issue"
}
```