### PR TITLE
Fix - Combat turn order jank on scene swap and an error on all_token_objects being undefined

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -408,10 +408,10 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	if (typeof(token.options.ct_show) == 'undefined'){
 		if(token.options.hidden) {
 			token.options.ct_show = false;
-			if(typeof window.all_token_objects != 'undefined') {
-				window.all_token_objects[token.options.id].options.ct_show = false;
-				window.all_token_objects[token.options.id].update_and_sync();
-			}
+	
+			window.all_token_objects[token.options.id].options.ct_show = false;
+			window.all_token_objects[token.options.id].update_and_sync();
+			
 		}
 		else {		
 			if(typeof window.all_token_objects[token.options.id].options.ct_show != 'undefined') {
@@ -445,15 +445,13 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	init.css('width','20px');
 	init.css('-webkit-appearance','none');
 	if(window.DM && typeof(token.options.init) == 'undefined'){
-		if(typeof window.all_token_objects != 'undefined') {
-			if(typeof window.all_token_objects[token.options.id] != 'undefined')	{
-				if (typeof window.all_token_objects[token.options.id].options.init != 'undefined'){
-			 		token.options.init = window.all_token_objects[token.options.id].options.init;
-			 		window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
-					init.val(token.options.init);
-				}
-			}
-		}
+
+
+		if (typeof window.all_token_objects[token.options.id].options.init != 'undefined'){
+	 		token.options.init = window.all_token_objects[token.options.id].options.init;
+	 		window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
+			init.val(token.options.init);
+		}	
 		else{
 			init.val(0);
 		}
@@ -467,13 +465,13 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	}
 	if(window.DM){
 		init.change(function(){
-				if(typeof window.all_token_objects != 'undefined') 
-				{
-					window.all_token_objects[token.options.id].options.init = init.val()
-					window.all_token_objects[token.options.id].sync = function(e) {				
-						window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[token.options.id].options);
-					}
+				 
+				
+				window.all_token_objects[token.options.id].options.init = init.val()
+				window.all_token_objects[token.options.id].sync = function(e) {				
+					window.MB.sendMessage('custom/myVTT/token', window.all_token_objects[token.options.id].options);
 				}
+			
 				token.options.init = init.val();
 				if(window.TOKEN_OBJECTS[token.options.id] != undefined){
 					window.TOKEN_OBJECTS[token.options.id].options.init = init.val();
@@ -654,7 +652,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 				stat.css("visibility", "hidden");
 			}
 
-			ct_show_checkbox = $(`<input id="`+token.options.id+`hideCombatTrackerInput"type='checkbox' class="combatHideFromPlayerInput" style="font-size:10px; class='hideInPlayerCombatCheck' target_id='`+token.options.id+`' checked='`+token.options.ct_show+`'/>`);
+			ct_show_checkbox = $(`<input id="`+token.options.id+`hideCombatTrackerInput"type='checkbox' class="combatHideFromPlayerInput" style="font-size:10px;" "class='hideInPlayerCombatCheck' target_id='`+token.options.id+`' checked='`+token.options.ct_show+`'/>`);
 
 			eye_button = $('<button class="hideFromPlayerCombatButton" style="font-size:10px;"></button>');
 
@@ -795,6 +793,7 @@ function ct_update_popout(){
 function ct_load(data=null){
 	// any time the combat tracker changes, we need to make sure we adjust our cursor streaming for anyone that only wants streaming during "combatTurn"
 	// make sure we do this before the `data` object gets changed below
+	$("#combat_area").empty();
 	update_peer_communication_with_combat_tracker_data(data);
 
 	if(!data.loading){	

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1054,7 +1054,6 @@ class MessageBroker {
 	}
 
   handleCT(data){
-  	$("#combat_area").empty();
 		ct_load(data);
 	}
 
@@ -1235,23 +1234,21 @@ class MessageBroker {
 			} else {
 				data.size = window.CURRENT_SCENE_DATA.hpps;
 			}
-			if (window.all_token_objects != undefined) {
-				if (data.id in window.all_token_objects) {
-					for (var property in window.all_token_objects[data.id].options) {		
-						if(property == "left" || property == "top" || property == "hidden")
-							continue;
-						if(msg.loading){
-							data[property] = window.all_token_objects[data.id].options[property];
-						}
-						else if(property in data){
-						 window.all_token_objects[data.id].options[property] = data[property]; 
-						}
+			if (data.id in window.all_token_objects) {
+				for (var property in window.all_token_objects[data.id].options) {		
+					if(property == "left" || property == "top" || property == "hidden")
+						continue;
+					if(msg.loading){
+						data[property] = window.all_token_objects[data.id].options[property];
 					}
-
-
-					if (!data.hidden)
-						delete window.all_token_objects[data.id].options.hidden;
+					else if(property in data){
+					 window.all_token_objects[data.id].options[property] = data[property]; 
+					}
 				}
+
+
+				if (!data.hidden)
+					delete window.all_token_objects[data.id].options.hidden;
 			}
 		}
 			
@@ -1263,6 +1260,9 @@ class MessageBroker {
 			}
 			if(data.ct_show == undefined){
 				delete window.TOKEN_OBJECTS[data.id].options.ct_show;
+			}
+			if(data.current == undefined){
+				delete window.TOKEN_OBJECTS[data.id].options.current;
 			}
 			if (!data.hidden && msg.sceneId == window.CURRENT_SCENE_DATA.id)
 				delete window.TOKEN_OBJECTS[data.id].options.hidden;
@@ -1283,6 +1283,9 @@ class MessageBroker {
 			}
 			let t = new Token(data);
 			window.TOKEN_OBJECTS[data.id] = t;
+			if(window.all_token_objects[data.id] == undefined){
+				window.all_token_objects[data.id] = t;
+			}
 			t.sync = function(e) { // VA IN FUNZIONE SOLO SE IL TOKEN NON ESISTE GIA					
 				window.MB.sendMessage('custom/myVTT/token', t.options);
 			};
@@ -1415,7 +1418,7 @@ class MessageBroker {
 				});
 			}
 
-			$("#combat_area").empty();
+
 			ct_load({
 				loading: true,
 				current: $("#combat_area [data-current]").attr('data-target')

--- a/Startup.js
+++ b/Startup.js
@@ -78,6 +78,7 @@ async function start_above_vtt_common() {
   window.TOKEN_OBJECTS_RECENTLY_DELETED = {};
   window.TOKEN_PASTE_BUFFER = [];
   window.TOKEN_SETTINGS = $.parseJSON(localStorage.getItem(`TokenSettings${window.gameId}`)) || {};
+  window.all_token_objects = {};
 
   await load_external_script("https://www.youtube.com/iframe_api");
   $("#site").append("<div id='windowContainment'></div>");

--- a/Token.js
+++ b/Token.js
@@ -2540,16 +2540,16 @@ function place_token_at_map_point(tokenObject, x, y) {
 			options.size = Math.round(window.CURRENT_SCENE_DATA.hpps) * 1;
 		}
 	}
-	if(window.all_token_objects !== undefined){
-		if(window.all_token_objects[options.id] !== undefined){
-			if(window.all_token_objects[options.id].options.ct_show !== undefined){
-				options = window.all_token_objects[options.id].options;
-			  	$(`#combat_area tr[data-target='${options.id}'] .findSVG`).remove();
-		       	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
-		        $(`#combat_area tr[data-target='${options.id}'] .findTokenCombatButton`).append(findSVG);
-			}
+
+	if(window.all_token_objects[options.id] !== undefined){
+		if(window.all_token_objects[options.id].options.ct_show !== undefined){
+			options = window.all_token_objects[options.id].options;
+		  	$(`#combat_area tr[data-target='${options.id}'] .findSVG`).remove();
+	       	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
+	        $(`#combat_area tr[data-target='${options.id}'] .findTokenCombatButton`).append(findSVG);
 		}
 	}
+	
 	options.left = `${x - options.size/2}px`;
 	options.top = `${y - options.size/2}px`;
 	// set reasonable defaults for any global settings that aren't already set


### PR DESCRIPTION
Not sure if this has been a bug that's been around forever and I just didn't notice or not.

Reported in discord sometimes all_token_objects errors on undefined. 

While fixing this I also noticed there was a current turn issue when swapping scenes. It wasn't sending the current turn as the combat tracker was getting emptied before looking for that data - making current turn id always undefined. Now the combat tracker gets emptied inside ct_load instead of before it. 