### PR TITLE
Feat - Player tokens should now also sync during a session when dropped from the sidepanel

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -323,7 +323,8 @@ class Token {
 		$(selector).remove();
 		delete window.CURRENT_SCENE_DATA.tokens[id];
 		delete window.TOKEN_OBJECTS[id];
-		delete window.all_token_objects[id];
+		if(!is_player_id(this.options.id))
+			delete window.all_token_objects[id];
 		$("#aura_" + id.replaceAll("/", "")).remove();
 		$(`.aura-element-container-clip[id='${id}']`).remove()
 		if (persist == true) {

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -840,6 +840,9 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
             }
             let playerData = window.PLAYER_STATS[listItem.sheet];
             options.id = listItem.sheet;
+            if(window.all_token_objects[options.id] != undefined){
+                options = {...options, ...window.all_token_objects[options.id].options}
+            }
             tokenSizeSetting = options.tokenSize;
             tokenSize = parseInt(tokenSizeSetting);
             if (tokenSizeSetting === undefined || typeof tokenSizeSetting !== 'number') {


### PR DESCRIPTION
I've got a few bug reports of token settings swapping randomly. Since swapping scenes, or editting tokens syncs them across 'active' scene's during a session - this has come up a few times. Especially with aura's/light recently. 

This is due to swapping to a scene to set it up while players are on another scene. Dropping the player tokens from the side panel and setting up their settings before bringing the players over. This should prevent what appears like bug behaviour and make things more intuitive in the sense that player tokens carry data from one scene to another no matter where they are dropped from. 