### PR TITLE
Fix - Error when dragging journal notes

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -150,7 +150,7 @@ class JournalManager{
 		           	let sender_index = sender.attr('data-index');
 		           	let new_folder_index = ui.item.parent().closest('.folder').attr('data-index');
 		          	const old_index = self.chapters[sender_index].notes.findIndex(function(note) {
-						return self.notes[note].title == ui.item.find(".sidebar-list-item-row-details-title").text();
+						return note == ui.item.attr('data-id');
 					});
 					// Find the new index of the dragged element
 					const new_index = ui.item.index();
@@ -167,7 +167,7 @@ class JournalManager{
 					// Find the old index of the dragged element
 					if(sender==undefined){
 						const old_index = self.chapters[i].notes.findIndex(function(note) {
-							return self.notes[note].title == ui.item.find(".sidebar-list-item-row-details-title").text();
+							return note == ui.item.attr('data-id')
 						});
 						// Find the new index of the dragged element
 						const new_index = ui.item.index();
@@ -337,8 +337,8 @@ class JournalManager{
 				if( (! window.DM) && (! self.notes[note_id].player) )
 					continue;
 				
-				let entry=$("<div class='sidebar-list-item-row-item sidebar-list-item-row'></div>");
-				let entry_title=$("<div class='sidebar-list-item-row-details sidebar-list-item-row-details-title'></div>");
+				let entry=$(`<div class='sidebar-list-item-row-item sidebar-list-item-row' data-id='${note_id}'></div>`);
+				let entry_title=$(`<div class='sidebar-list-item-row-details sidebar-list-item-row-details-title'></div>`);
 
 				entry_title.text(self.notes[note_id].title);
 				entry_title.click(function(){


### PR DESCRIPTION
This has been reported a few times.
![image](https://user-images.githubusercontent.com/65363489/227794481-545d62fe-ab94-4ac7-bffa-be7757b1b4a5.png)


When moving notes sometimes it errors out on `window.JOURNAL.notes[id]` being undefined when trying to get it's title. I'm able to manually make this error happen but I haven't figured out how the users are getting to that position.

This however is a work around - I add the `note_id` to the ui item so we can compare it directly to the id in `window.JOURNAL.chapters[i].notes`. This allows the drag operation to happen correctly even if the user has got into the state of a note id being in a chapter but not window.JOURNAL.notes.

I'm going to try to figure out how the users are getting there but no luck so far and at least they will be able to use it for now. I'm going to create an issue for this so I can remember later.