### PR TITLE
Beta - Audio, loop off by default, reset non-looping sounds to 0 when  finished (sound effects), an add button to add a track to mixer without playing

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -6803,7 +6803,8 @@ button.channel-loop-button{
 .track-remove-button,
 .add-track-ok-button,
 .add-track-cancel-button,
-.channel-remove-button {
+.channel-remove-button,
+.track-add-to-mixer {
     box-shadow: 1px 1px 1px 1px #0003, 1px 2px 0px -2px #0003;
     border: 1px solid transparent;
     box-sizing: border-box;
@@ -6827,7 +6828,8 @@ button.channel-loop-button{
 .track-remove-button:focus,
 .add-track-ok-button:focus,
 .add-track-cancel-button:focus,
-.channel-remove-button:focus {
+.channel-remove-button:focus,
+.track-add-to-mixer:focus {
     outline: none;
 }
 
@@ -6839,7 +6841,8 @@ button.channel-loop-button{
 .track-remove-button:hover,
 .add-track-ok-button:hover,
 .add-track-cancel-button:hover,
-.channel-remove-button:hover  {
+.channel-remove-button:hover,
+.track-add-to-mixer:hover  {
     cursor: pointer;
     background: rgb(245, 248, 250);
     border: 1px solid rgb(206, 217, 224);
@@ -6853,11 +6856,20 @@ button.channel-loop-button{
 .track-remove-button:active,
 .add-track-ok-button:active,
 .add-track-cancel-button:active,
-.channel-remove-button:active {
+.channel-remove-button:active,
+.track-add-to-mixer:active {
     background-color: rgb(245, 248, 250);
     box-shadow: inset #000 1px 1px 3px 1px;
     transform: translate(1px, 2px) scale(0.8);
 }
+.track-add-to-mixer{
+   fill:#000;
+   padding: 5px 4px 5px 4px; 
+}
+.track-add-to-mixer svg path{
+    fill:#000;
+}
+
 .channel-play-pause-button,
 .channel-loop-button,
 .channel-remove-button{

--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -435,6 +435,7 @@ class Mixer extends EventTarget {
     channelProgressBar(id) {
         const progress = document.createElement("div");
         progress.className = "channel-progress-bar-progress";
+        progress.setAttribute('data-id', id)
 
         const total = document.createElement("div");
         total.setAttribute('data-id', id);
@@ -445,7 +446,17 @@ class Mixer extends EventTarget {
         if (!player) {
             throw `failed to player for channel ${id}`
         }
-        player.ontimeupdate = (e) => progress.style.width = e.target.currentTime / e.target.duration * 100 + "%";
+        player.ontimeupdate = (e) => {
+            progress.style.width = e.target.currentTime / e.target.duration * 100 + "%";
+           
+        
+            if(e.target.currentTime == e.target.duration && e.target.loop == false && $(`.audio-row[data-id='${id}'] .channel-play-pause-button.playing`).length>0){
+                const id = progress.getAttribute('data-id')
+                e.target.currentTime = 0;
+                $(`.audio-row[data-id='${id}'] .channel-play-pause-button.playing`).click();
+                $(progress).css('width', '');
+            }
+        }
 
         return total
     }

--- a/audio/ui.js
+++ b/audio/ui.js
@@ -266,11 +266,22 @@ function init_trackLibrary() {
             track_play_button.on('click', function(){
                 const channel = new Channel(track.name, track.src);
                 channel.paused = false;
-                channel.loop = true;
+                channel.loop = false;
+                window.MIXER.addChannel(channel);
+            });
+            let track_add_button = $('<button class="track-add-to-mixer"></button>');          
+            let add_svg = $('<svg viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" class=""><path fill-rule="evenodd" clip-rule="evenodd" d="M7.2 10.8V18h3.6v-7.2H18V7.2h-7.2V0H7.2v7.2H0v3.6h7.2z"></path></svg>');               
+            track_add_button.append(add_svg);
+            track_add_button.on('click', function(){
+                const channel = new Channel(track.name, track.src);
+                channel.paused = true;
+                channel.loop = false;
                 window.MIXER.addChannel(channel);
             });
 
-            $(item).append(track_remove_button, track_play_button); 
+
+
+            $(item).append(track_remove_button, track_play_button, track_add_button); 
             trackList.append(item);
         });
     });


### PR DESCRIPTION
Looping on by default makes sound effects hard to play. Same with them not resetting when reaching the end. You'd have to double click to pause then play - this presses pause for you and resets the progress bar to 0.

Also by request of nate a button to add to the mixer without playing right away.