### PR TITLE
Stop defining window.self to be the MB

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1565,7 +1565,7 @@ class MessageBroker {
 	}
 
 	sendPing() {
-		self = this;
+		let self = this;
 		if (this.ws.readyState == this.ws.OPEN) {
 			this.ws.send("{\"data\": \"ping\"}");
 		}
@@ -1577,7 +1577,7 @@ class MessageBroker {
 	}
 
 	sendAbovePing(){
-		self = this;
+		let self = this;
 		if(this.abovews.readyState == this.abovews.OPEN){
 			this.abovews.send(JSON.stringify({action:"keepalive",eventType:"custom/myVTT/keepalive"}));
 		}

--- a/SceneData.js
+++ b/SceneData.js
@@ -3,7 +3,7 @@ function export_free() {
 	console.log("----" + window.CURRENT_SCENE_DATA.title + "-----");
 
 
-	data = "";
+	let data = "";
 	data += "\t\tsnap: \"" + window.CURRENT_SCENE_DATA.snap + "\",\n";
 	data += "\t\thpps: \"" + window.CURRENT_SCENE_DATA.hpps + "\",\n";
 	data += "\t\tvpps: \"" + window.CURRENT_SCENE_DATA.vpps + "\",\n";
@@ -17,7 +17,7 @@ function export_free() {
 
 function export_ddb() {
 
-	data = "\t\"" + window.CURRENT_SCENE_DATA.uuid + "\": {\n";
+	let data = "\t\"" + window.CURRENT_SCENE_DATA.uuid + "\": {\n";
 	data += "\t\tdm_map_usable: \"" + window.CURRENT_SCENE_DATA.dm_map_usable + "\",\n";
 	data += "\t\tsnap: \"" + window.CURRENT_SCENE_DATA.snap + "\",\n";
 	data += "\t\thpps: \"" + window.CURRENT_SCENE_DATA.hpps + "\",\n";


### PR DESCRIPTION
I _think_ this is unintentional. I don't think we call window.self as the message broker anywhere. Just noticed it trying to do more memory test stuff.