### PR TITLE
Prevent scene folder structure/buttons from retaining on scene swap.

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -999,7 +999,7 @@ class MessageBroker {
 					
 					$("#tokens .VTTToken").each(
 						function(){
-							var converted = $(this).attr('data-id').replace(/^.*\/([0-9]*)$/, "$1"); // profiles/ciccio/1234 -> 1234
+							let converted = $(this).attr('data-id').replace(/^.*\/([0-9]*)$/, "$1"); // profiles/ciccio/1234 -> 1234
 							if(converted==entityid){
 								ct_add_token(window.TOKEN_OBJECTS[$(this).attr('data-id')]);
 								window.TOKEN_OBJECTS[$(this).attr('data-id')].options.init = total;
@@ -1010,7 +1010,7 @@ class MessageBroker {
 					
 
 					$("#combat_area tr").each(function() {
-						var converted = $(this).attr('data-target').replace(/^.*\/([0-9]*)$/, "$1"); // profiles/ciccio/1234 -> 1234
+						let converted = $(this).attr('data-target').replace(/^.*\/([0-9]*)$/, "$1"); // profiles/ciccio/1234 -> 1234
 						console.log(converted);
 						if (converted == entityid) {
 							$(this).find(".init").val(total);
@@ -1294,7 +1294,7 @@ class MessageBroker {
 		$(".aura-element[id^='aura_'").remove();
 		$(".aura-element-container-clip").remove();
 
-		var old_src = $("#scene_map").attr('src');
+		let old_src = $("#scene_map").attr('src');
 		$("#scene_map").attr('src', data.map);
 
 		if (data.fog_of_war == 1) {

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1378,7 +1378,7 @@ function redraw_scene_list(searchTerm) {
 	// since we don't have root folders like the tokensPanel does, we want to treat the entire list like a subfolder
 	// this will allow us to reuse all the folder traversing functions that the tokensPanel uses
 	let list = $(`<div id="${path_to_html_id(RootFolder.Scenes.path)}" class="folder not-collapsible"><div class="folder-item-list" style="padding: 0;"></div></div>`);
-	scenesPanel.body.empty();
+	scenesPanel.body.find('#_Scenes').remove();
 	scenesPanel.body.append(list);
 	set_full_path(list, RootFolder.Scenes.path);
 

--- a/Token.js
+++ b/Token.js
@@ -956,7 +956,7 @@ class Token {
 				}
 				setTimeout(ct_persist(), 500);
 			});
-			hp_input.click(function(e) {
+			hp_input.on('click', function(e) {
 				$(e.target).select();
 			});
 			maxhp_input.change(function(e) {
@@ -971,7 +971,7 @@ class Token {
 				}
 				setTimeout(ct_persist(), 500);
 			});
-			maxhp_input.click(function(e) {
+			maxhp_input.on('click', function(e) {
 				$(e.target).select();
 			});
 		}
@@ -1190,7 +1190,7 @@ class Token {
 				symbolImage.height(symbolSize + "px");
 				symbolImage.width(symbolSize + "px");
 				conditionContainer.append(symbolImage);
-				conditionContainer.dblclick(() => {
+				conditionContainer.on('dblclick', () => {
 					const data = {
 						player: window.PLAYER_NAME,
 						img: window.PLAYER_IMG,
@@ -2325,7 +2325,7 @@ class Token {
 				tok.removeClass("ui-state-disabled");
 			}
 
-			tok.find(".token-image").dblclick(function(e) {
+			tok.find(".token-image").on('dblclick', function(e) {
 				self.highlight(true); // dont scroll
 				var data = {
 					id: self.options.id
@@ -2333,7 +2333,7 @@ class Token {
 				window.MB.sendMessage('custom/myVTT/highlight', data);
 			})
 
-			tok.find(".token-image").click(function() {
+			tok.find(".token-image").on('click', function() {
 				let parentToken = $(this).parent(".VTTToken");
 				if (parentToken.hasClass("pause_click")) {
 					return;

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -448,7 +448,7 @@ function redraw_token_list(searchTerm, enableDraggable = true) {
     console.group("redraw_token_list");
     update_token_folders_remembered_state();
     let list = $(`<div class="custom-token-list"></div>`);
-    tokensPanel.body.empty();
+    tokensPanel.body.find('.custom-token-list').remove();
     tokensPanel.body.append(list);
 
     let nameFilter = "";


### PR DESCRIPTION
So adjusting it from empty to remove seems to stop the folder structure and buttons in the scene panel from being retained in memory on scene swap. I _think_ based on what I've read this is because remove also gets rid of jquery event listeners. I was seeing some tokens and their conditions after so I made some adjustments there too changing the listeners to jquery ones. This seems to have gotten rid of those as well as remove was being used on them already. 

I tried the same for the token side panel but it still seems to be retaining some of that like the players. So there might be other things retaining it then jquery listeners. 

More info and screenshots in this discord thread https://discord.com/channels/815028457851191326/1091516699217506365
