### PR TITLE
Beta Fix: cursor streaming broke

### DIFF
--- a/PeerCommunication.js
+++ b/PeerCommunication.js
@@ -449,7 +449,11 @@ function init_peer_fade_functions() {
     window.PEER_FADE_RULER_FUNCTIONS = {};
   }
   if (window.pcs) {
-    window.pcs.forEach(pc => init_peer_fade_function(pc.id.toString()));
+    window.pcs.forEach(pc => {
+      if (pc.characterId) {
+        init_peer_fade_function(pc.characterId.toString())
+      }
+    });
   }
 }
 


### PR DESCRIPTION
The problem was that I was initializing the fade functions using `pc.id` which no longer exists. It was throwing an exception which caused the cursor streaming to not finish setting up.