### PR TITLE
Beta Fix - Token reveal when there is more than 1 light aura in range and reduce polygon points for line of sight polygons

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -422,7 +422,9 @@ function is_token_under_light_aura(tokenid){
 				
 
 			let pixeldata = window.lightAuraClipPolygon[auraId].canvas.getContext('2d').getImageData(parseInt(window.TOKEN_OBJECTS[tokenid].options.left.replace('px', ''))/ window.CURRENT_SCENE_DATA.scale_factor, parseInt(window.TOKEN_OBJECTS[tokenid].options.top.replace('px', ''))/ window.CURRENT_SCENE_DATA.scale_factor, window.TOKEN_OBJECTS[tokenid].sizeWidth()/ window.CURRENT_SCENE_DATA.scale_factor, window.TOKEN_OBJECTS[tokenid].sizeHeight()/ window.CURRENT_SCENE_DATA.scale_factor).data;
-			return pixeldata.some(function(color, index) {return (index) % 4 == 0 && color == 255});
+			
+			if(pixeldata.some(function(color, index) {return (index) % 4 == 0 && color == 255}))
+				return true;
 		}		
 	}
 	return  false;
@@ -2984,9 +2986,7 @@ function particleLook(ctx, walls, lightRadius=100000, fog=false, fogStyle, fogTy
 	    	}
 	    	lightPolygon.push({x: closest.x*window.CURRENT_SCENE_DATA.scale_factor, y: closest.y*window.CURRENT_SCENE_DATA.scale_factor})
 	    } 
-	    else if(closest){
-	    	lightPolygon.push({x: closest.x*window.CURRENT_SCENE_DATA.scale_factor, y: closest.y*window.CURRENT_SCENE_DATA.scale_factor})
-	    }
+
 	    prevClosestPoint = closest;
 	    prevClosestWall = closestWall;
 	}


### PR DESCRIPTION
We still need to check all light auras in range. If they're behind a wall this was returning false too early.

Also reduce the polygon points for line of sight significantly. Only pick 2 points on any given wall instead of for each point of ray contact. 

I'm not sure why I added this else to begin with as the whole point of the first if was to avoid too many points 🤦‍♂️. _Maybe_ I was trying to fix some undefined issue but that's been solved a different way.