### PR TITLE
Add disable token vision/light as a scene option.

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -741,10 +741,10 @@ function reset_canvas() {
  	delete window.lightAuraClipPolygon;
  	delete window.lineOfSightPolygons;
 
-	redraw_fog();
 	redraw_drawings();
 	redraw_light_walls();
 	redraw_light();
+	redraw_fog();
 	redraw_text();
 	
 
@@ -3043,35 +3043,23 @@ function lineLine(x1, y1, x2, y2, x3, y3, x4, y4) {
   }
   return false;
 }
-function detectWallCollision(x1, y1, x2, y2){
-	let walls = window.DRAWINGS.filter(d => (d[1] == "wall" && d[0].includes("line") && !d[2].includes('rgba(255, 100, 255, 0.5)')));
-	for(let i=0; i<walls.length; i++){
 
-		let wallInitialScale = walls[8];
-		let scale_factor = window.CURRENT_SCENE_DATA.scale_factor != undefined ? window.CURRENT_SCENE_DATA.scale_factor : 1;
-		let adjustedScale = walls[i][8]/window.CURRENT_SCENE_DATA.scale_factor;			
-		let wallLine = [{
-			a: {
-				x: walls[i][3]/adjustedScale,
-				y: walls[i][4]/adjustedScale
-			},
-			b: {
-				x: walls[i][5]/adjustedScale,
-				y: walls[i][6]/adjustedScale
-			}			
-		}]
-
-		let intersect = lineLine(wallLine[0].a.x, wallLine[0].a.y, wallLine[0].b.x, wallLine[0].b.y, x1, y1, x2, y2);
-	
-		if(intersect != false){					
-			return intersect;	
-		}
-		
+//Checks if a pixel is in line of current line of sight
+function detectInLos(x, y) {
+	let canvas = document.getElementById("raycastingCanvas");
+	let ctx = canvas.getContext("2d");
+	const pixeldata = ctx.getImageData(x, y, 1, 1).data;
+	if (pixeldata[2] == 0)
+	{	
+		return false;			
 	}
-	return false;
+	else{
+		return true;
+	}
 }
 
 function redraw_light(){
+
 	let canvas = document.getElementById("raycastingCanvas");
 	let canvasWidth = canvas.width;
 	let canvasHeight = canvas.height;
@@ -3094,6 +3082,12 @@ function redraw_light(){
 	offscreenCanvasMask.height = canvasHeight;
 
 	context.clearRect(0,0,canvasWidth,canvasHeight);
+
+	if(window.CURRENT_SCENE_DATA.disableSceneVision == true){
+		context.fillStyle = "white";
+		context.fillRect(0,0,canvasWidth,canvasHeight);
+		return;
+	}
 
 	context.fillStyle = "black";
 	context.fillRect(0,0,canvasWidth,canvasHeight);

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -312,7 +312,7 @@ function edit_scene_dialog(scene_id) {
 						darknessFilterRange)
 	);
 	form.append(form_row('disableSceneVision',
-			'Disable token vision/light on this scene',
+			'Disable token vision/light',
 			form_toggle("disableSceneVision",null, false,  function(event) {
 				handle_basic_form_toggle_click(event);
 			})

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -311,6 +311,13 @@ function edit_scene_dialog(scene_id) {
 						'Darkness filter',
 						darknessFilterRange)
 	);
+	form.append(form_row('disableSceneVision',
+			'Disable token vision/light on this scene',
+			form_toggle("disableSceneVision",null, false,  function(event) {
+				handle_basic_form_toggle_click(event);
+			})
+		)
+	);
 	form.find('#darknessFilter_row').attr('title', `This will darken the map by the percentage indicated. This filter interacts with light auras. Any light aura on the map will reveal the darkness. Fully opaque white light will completely eliminate the darkness in it's area.`)
 	darknessFilterRange.after(darknessNumberInput);
 	form.append(form_row('snapToGrid', 'Snap to Grid',form_toggle("snap", null, false, function(event) {

--- a/Settings.js
+++ b/Settings.js
@@ -209,17 +209,6 @@ function token_setting_options() {
 				{ value: "max", label: "Max", description: "Monster Max HP will be set to the maximum value." }
 			],
 			defaultValue: "average"
-		},
-		{
-			name: "disableLight",
-			label: "Disable all token vision/light",
-			type: 'toggle',
-			options: [
-				{ value: true, label: 'All token light/vision is disabled', description: "The token will not have light/vision" },
-				{ value: false, label: 'token light/vision is enabled', description: "The token will  have light/vision" }
-			],
-			defaultValue: false,
-			hideinContextOnly: true
 		}
 	];
 }

--- a/Settings.js
+++ b/Settings.js
@@ -209,6 +209,17 @@ function token_setting_options() {
 				{ value: "max", label: "Max", description: "Monster Max HP will be set to the maximum value." }
 			],
 			defaultValue: "average"
+		},
+		{
+			name: "disableLight",
+			label: "Disable all token vision/light",
+			type: 'toggle',
+			options: [
+				{ value: true, label: 'All token light/vision is disabled', description: "The token will not have light/vision" },
+				{ value: false, label: 'token light/vision is enabled', description: "The token will  have light/vision" }
+			],
+			defaultValue: false,
+			hideinContextOnly: true
 		}
 	];
 }

--- a/Token.js
+++ b/Token.js
@@ -2861,7 +2861,7 @@ function setTokenAuras (token, options) {
 	}
 }
 function setTokenLight (token, options) {
-	if (!options.light1) return;
+	if (!options.light1 || options.disableLight == true) return;
 
 	const innerlightSize = options.light1.feet.length > 0 ? (options.light1.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
 	const outerlightSize = options.light2.feet.length > 0 ? (options.light2.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;

--- a/Token.js
+++ b/Token.js
@@ -469,16 +469,16 @@ class Token {
 	moveUp() {	
 		let newTop = `${parseFloat(this.options.top) - parseFloat(window.CURRENT_SCENE_DATA.vpps)}px`;
 		let halfWidth = parseFloat(this.options.size)/2;
-		let intersect = detectWallCollision(parseFloat(this.options.left)+halfWidth, parseFloat(this.options.top)+halfWidth, parseFloat(this.options.left)+halfWidth, parseFloat(newTop)+halfWidth);
-		if(intersect== false){
+		let inLos = detectInLos(parseFloat(this.options.left)+halfWidth, parseFloat(newTop)+halfWidth);
+		if(inLos){
 			this.move(newTop, this.options.left)	
 		}
 	}
 	moveDown() {
 		let newTop = `${parseFloat(this.options.top) + parseFloat(window.CURRENT_SCENE_DATA.vpps)}px`;
 		let halfWidth = parseFloat(this.options.size)/2;
-		let intersect = detectWallCollision(parseFloat(this.options.left)+halfWidth, parseFloat(this.options.top)+halfWidth, parseFloat(this.options.left)+halfWidth, parseFloat(newTop)+halfWidth);
-		if(intersect== false){
+		let inLos = detectInLos(parseFloat(this.options.left)+halfWidth, parseFloat(newTop)+halfWidth);
+		if(inLos){
 			this.move(newTop, this.options.left)	
 		}
 
@@ -486,16 +486,16 @@ class Token {
 	moveLeft() {
 		let newLeft = `${parseFloat(this.options.left) - parseFloat(window.CURRENT_SCENE_DATA.hpps)}px`;
 		let halfWidth = parseFloat(this.options.size)/2;
-		let intersect = detectWallCollision(parseFloat(this.options.left)+halfWidth, parseFloat(this.options.top)+halfWidth, parseFloat(newLeft)+halfWidth, parseFloat(this.options.top)+halfWidth);
-		if(intersect== false){
+		let inLos = detectInLos(parseFloat(newLeft)+halfWidth, parseFloat(this.options.top)+halfWidth);
+		if(inLos){
 			this.move(this.options.top, newLeft)	
 		}
 	}
 	moveRight() {
 		let newLeft = `${parseFloat(this.options.left) + parseFloat(window.CURRENT_SCENE_DATA.hpps)}px`;
 		let halfWidth = parseFloat(this.options.size)/2;
-		let intersect = detectWallCollision(parseFloat(this.options.left)+halfWidth, parseFloat(this.options.top)+halfWidth, parseFloat(newLeft)+halfWidth, parseFloat(this.options.top)+halfWidth);
-		if(intersect== false){
+		let inLos = detectInLos(parseFloat(newLeft)+halfWidth, parseFloat(this.options.top)+halfWidth);
+		if(inLos){
 			this.move(this.options.top, newLeft)	
 		}
 	}
@@ -2861,7 +2861,7 @@ function setTokenAuras (token, options) {
 	}
 }
 function setTokenLight (token, options) {
-	if (!options.light1 || options.disableLight == true) return;
+	if (!options.light1 || window.CURRENT_SCENE_DATA.disableSceneVision == true) return;
 
 	const innerlightSize = options.light1.feet.length > 0 ? (options.light1.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
 	const outerlightSize = options.light2.feet.length > 0 ? (options.light2.feet / 5) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -359,7 +359,7 @@ function token_context_menu_expanded(tokenIds, e) {
 			flyout.append(build_token_light_inputs(tokenIds));
 		})
 	});
-	if(tokens[0].options.disableLight != true && (window.DM || (tokens.length == 1 && (tokens[0].options.player_owned == true || tokens[0].isPlayer())))){
+	if(window.CURRENT_SCENE_DATA.disableSceneVision != true && (window.DM || (tokens.length == 1 && (tokens[0].options.player_owned == true || tokens[0].isPlayer())))){
 		if (!someTokensAreAoe) {
 			body.append(lightRow);
 		}
@@ -1490,7 +1490,7 @@ function build_options_flyout_menu(tokenIds) {
 		let setting = token_settings[i];
 		if (allTokensAreAoe && !availableToAoe.includes(setting.name)) {
 			continue;
-		} else if(setting.hiddenSetting || setting.name == 'defaultmaxhptype' || setting.hideinContextOnly) {
+		} else if(setting.hiddenSetting || setting.name == 'defaultmaxhptype') {
 			continue;
 		}
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -359,7 +359,7 @@ function token_context_menu_expanded(tokenIds, e) {
 			flyout.append(build_token_light_inputs(tokenIds));
 		})
 	});
-	if(window.DM || (tokens.length == 1 && (tokens[0].options.player_owned == true || tokens[0].isPlayer()))){
+	if(tokens[0].options.disableLight != true && (window.DM || (tokens.length == 1 && (tokens[0].options.player_owned == true || tokens[0].isPlayer())))){
 		if (!someTokensAreAoe) {
 			body.append(lightRow);
 		}
@@ -1490,7 +1490,7 @@ function build_options_flyout_menu(tokenIds) {
 		let setting = token_settings[i];
 		if (allTokensAreAoe && !availableToAoe.includes(setting.name)) {
 			continue;
-		} else if(setting.hiddenSetting || setting.name == 'defaultmaxhptype') {
+		} else if(setting.hiddenSetting || setting.name == 'defaultmaxhptype' || setting.hideinContextOnly) {
 			continue;
 		}
 


### PR DESCRIPTION
adds a quick and simple option to default token options in settings. This option doesn't appear in the token context menu for now. I'm not sure this is how we'd like it to work in the end but this should entirely disable the feature when on for new token drops. It disables the light context menu in general on tokens drop with this setting on.