### PR TITLE
Allow players to end turn of `player accessible stats` tokens

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -826,7 +826,7 @@ function ct_load(data=null){
 				
 				if(data[i]['current']){
 					$("#combat_area tr[data-target='"+data[i]['data-target']+"']").attr("data-current","1");
-					if(window.all_token_objects[data[i]['data-target']].options.name == window.PLAYER_NAME.replace(/\"/g,'\\"')){
+					if(window.all_token_objects[data[i]['data-target']].options.name == window.PLAYER_NAME.replace(/\"/g,'\\"') || window.all_token_objects[data[i]['data-target']].options.player_owned){
 						$("#endplayerturn").toggleClass('enabled', true);
 						$("#endplayerturn").prop('disabled', false);
 					}
@@ -865,7 +865,7 @@ function ct_load(data=null){
 				window.TOKEN_OBJECTS[data.current].update_and_sync();
 			}
 			if(window.all_token_objects[data.current] != undefined){
-				if(window.all_token_objects[data.current].options.name == window.PLAYER_NAME.replace(/\"/g,'\\"')){
+				if(window.all_token_objects[data.current].options.name == window.PLAYER_NAME.replace(/\"/g,'\\"') || window.all_token_objects[data[i]['data-target']].options.player_owned){
 					$("#endplayerturn").toggleClass('enabled', true);
 					$("#endplayerturn").prop('disabled', false);
 				}

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -681,7 +681,8 @@ class MessageBroker {
 				}
 			}
 			if(msg.eventType == "custom/myVTT/endplayerturn" && window.DM){
-				if($("#combat_area tr[data-current=1]").attr('data-target').endsWith(`characters/${msg.data.from}`))
+				let tokenId = $("#combat_area tr[data-current=1]").attr('data-target');
+				if(tokenId.endsWith(`characters/${msg.data.from}`) || window.all_token_objects[tokenId].options.player_owned)
 					$("#combat_next_button").click();				
 
 			}


### PR DESCRIPTION
Requested in discord by Musashi to be able to end turn of companions/pets. This allows players to end turn on player owned tokens.

Let's put this in the next beta after this release if we like the option.