### PR TITLE
Beta Fix - invisible walls due to height/width swap

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -956,8 +956,8 @@ function redraw_light_walls(clear=true){
 
 	window.walls =[];
 	let sceneMapContainer = $('#scene_map_container');
-	let sceneMapHeight = sceneMapContainer.width();
-	let sceneMapWidth =  sceneMapContainer.height();
+	let sceneMapHeight = sceneMapContainer.height();
+	let sceneMapWidth = sceneMapContainer.width();
 
 	let wall5 = new Boundary(new Vector(0, 0), new Vector(sceneMapHeight, 0));
 	window.walls.push(wall5);


### PR DESCRIPTION
Reported on discord by ostrichwrangler - there were invisible walls that were appearing due to height/width being swapped in redraw_light_walls.