### PR TITLE
QoL - Smoother token movement when dropped and regrabbed in a short time to continue movement.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -40,6 +40,8 @@ const availableToAoe = [
 
 
 const debounceLightChecks = mydebounce(() => {		
+		if(window.DRAGGING)
+			return;
 		if(window.walls?.length < 5){
 			redraw_light_walls();	
 		}
@@ -1941,7 +1943,8 @@ class Token {
 						if (get_avtt_setting_value("allowTokenMeasurement")){
 							WaypointManager.fadeoutMeasuring()
 						}	
-						debounceLightChecks();
+						setTimeout(debounceLightChecks, 500)
+
 						self.update_and_sync(event, false);
 						if (self.selected ) {
 							for (let tok of $(".token.tokenselected")){


### PR DESCRIPTION
When dragging a token across multiple moves sometimes it will look like it pauses and jumps when you pick it up quickly and continue movement.

This is a small QoL - when finishing a token drag wait 500ms before running light checks. Return light checks if the token is dragging after those 500ms. 

If anyone thinks another time would feel better for a balance in token drag vs light checking on the final drop let me know. I felt this was an ok balance between the light check being run at the end drop vs how long I have to pick it up to keep the drag smooth. 