### PR TITLE
Fix - initiative sometimes not updating to the correct number for players

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1002,6 +1002,7 @@ class MessageBroker {
 							let converted = $(this).attr('data-id').replace(/^.*\/([0-9]*)$/, "$1"); // profiles/ciccio/1234 -> 1234
 							if(converted==entityid){
 								ct_add_token(window.TOKEN_OBJECTS[$(this).attr('data-id')]);
+								window.all_token_objects[$(this).attr('data-id')].options.init = total;
 								window.TOKEN_OBJECTS[$(this).attr('data-id')].options.init = total;
 								window.TOKEN_OBJECTS[$(this).attr('data-id')].update_and_sync();
 							}
@@ -1014,6 +1015,7 @@ class MessageBroker {
 						console.log(converted);
 						if (converted == entityid) {
 							$(this).find(".init").val(total);
+							window.all_token_objects[$(this).attr('data-target')].options.init = total;
 							window.TOKEN_OBJECTS[$(this).attr('data-target')].options.init = total;
 							window.TOKEN_OBJECTS[$(this).attr('data-target')].update_and_sync();
 						}


### PR DESCRIPTION
Reported in discord by Gawly and DM-Seraphim.

Since we pull data from all_token_objects to look at tokens not on the scene, we need to update those options when we receive initiative messages as well. 

I'm not sure why this works sometimes and not others - but this resolves the issue.

