### PR TITLE
Fix - Only show shadow/line of sight layer when walls are on darkness 0 maps

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -728,15 +728,18 @@ function reset_canvas() {
  	else if(window.DM){
  		$('#raycastingCanvas').css('opacity', '');
  	}
- 	if(darknessfilter == 0){
- 		$('#light_container').css('mix-blend-mode', 'unset');
- 		$('#light_container').css('background', '#0000');
- 		$('#light_container').css('opacity', '0.3');
- 	}
+ 	if(darknessfilter == 0 && window.walls.length>4){
+ 		$('#light_container').css({
+ 			'mix-blend-mode': 'unset',
+ 			'background':  '#0000',
+ 			'opacity': '0.3'
+ 		});
  	else{
- 		$('#light_container').css('mix-blend-mode', '');
- 		$('#light_container').css('background', '');
- 		$('#light_container').css('opacity', '');
+ 		$('#light_container').css({
+ 			'mix-blend-mode': '',
+ 			'background': '',
+ 			'opacity': ''
+ 		});
  	}
  	$('#VTT').css('--darkness-filter', darknessPercent + "%");
 
@@ -1017,8 +1020,21 @@ function redraw_light_walls(clear=true){
 		}
 		let drawnWall = new Boundary(new Vector(x/adjustedScale/window.CURRENT_SCENE_DATA.scale_factor, y/adjustedScale/window.CURRENT_SCENE_DATA.scale_factor), new Vector(width/adjustedScale/window.CURRENT_SCENE_DATA.scale_factor, height/adjustedScale/window.CURRENT_SCENE_DATA.scale_factor))
 		window.walls.push(drawnWall);
-
 	}
+	let darknessfilter = (window.CURRENT_SCENE_DATA.darkness_filter != undefined) ? window.CURRENT_SCENE_DATA.darkness_filter : 0;
+ 	if(darknessfilter == 0 && window.walls.length>4){
+ 		$('#light_container').css({
+ 			'mix-blend-mode': 'unset',
+ 			'background': '#0000',
+ 			'opacity': '0.3'
+ 		});
+ 	else{
+ 		$('#light_container').css({
+ 			'mix-blend-mode': '',
+ 			'background': '',
+ 			'opacity': ''
+ 		});
+ 	}
 }
 function open_close_door(x1, y1, x2, y2){
 	let doors = window.DRAWINGS.filter(d => (d[1] == "wall" && (d[2] == "rgba(255, 100, 255, 1)" || d[2] == "rgba(255, 100, 255, 0.5)")  && d[3] == x1 && d[4] == y1 && d[5] == x2 && d[6] == y2)) 


### PR DESCRIPTION
Reported in discord full brightness maps are darkened until a token is placed on the map. Even with no walls.

This was due to the shadow/line of sight layer being visible even when no walls are placed. No tokens = no line of sight, made a slightly dark map even without walls. This ensures there are more walls then just the border of the map before creating LoS shadows.