### PR TITLE
Fix - Animated map audio, make sure a default volume is set so the DM doesn't have to change volume to get audio to play for players.

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -862,7 +862,7 @@ function ct_load(data=null){
 				window.TOKEN_OBJECTS[data.current].update_and_sync();
 			}
 			if(window.all_token_objects[data.current] != undefined){
-				if(window.all_token_objects[data.current].options.name == window.PLAYER_NAME.replace(/\"/g,'\\"') || window.all_token_objects[data[i]['data-target']].options.player_owned){
+				if(window.all_token_objects[data.current].options.name == window.PLAYER_NAME.replace(/\"/g,'\\"') || window.all_token_objects[data.current].options.player_owned){
 					$("#endplayerturn").toggleClass('enabled', true);
 					$("#endplayerturn").prop('disabled', false);
 				}

--- a/Main.js
+++ b/Main.js
@@ -382,7 +382,13 @@ function load_scenemap(url, is_video = false, width = null, height = null, callb
 			playerVars: { 'autoplay': 1, 'controls': 0 },
 			events: {
 				'onStateChange': function(event) {  if (event.data == 0) window.YTPLAYER.seekTo(0); },
-				'onReady': function(e) { window.YTPLAYER.setVolume($("#youtube_volume").val()); }
+				'onReady': function(e) { 
+					let ytvolume= $("#youtube_volume").val();
+					if(ytvolume)
+						window.YTPLAYER.setVolume(ytvolume); 
+					else
+						window.YTPLAYER.setVolume(50);
+				}			
 			}
 		});
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -703,9 +703,7 @@ class MessageBroker {
 				audio_changesettings(msg.data.channel,msg.data.volume,msg.data.loop);
 			}
 			if(msg.eventType=="custom/myVTT/changeyoutube"){
-				if(window.YTPLAYER){
-					window.YTPLAYER.volume = msg.data.volume;
-					if(window.YTPLAYER)
+				if(window.YTPLAYER.setVolume){
 						window.YTPLAYER.setVolume(msg.data.volume*$("#master-volume input").val());
 				}
 			}
@@ -1408,6 +1406,14 @@ class MessageBroker {
 	        const state = window.MIXER.remoteState();
           console.log('pushing mixer state to players', state);
           window.MB.sendMessage('custom/myVTT/mixer', state);
+          if (window.YTPLAYER) {
+          		window.YTPLAYER.volume = $("#youtube_volume").val();
+              window.YTPLAYER.setVolume(window.YTPLAYER.volume*$("#master-volume input").val());
+              data={
+                  volume: window.YTPLAYER.volume
+              };
+              window.MB.sendMessage("custom/myVTT/changeyoutube",data);
+          }
 			}
 			// also sync the journal
 			window.JOURNAL?.sync();

--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -555,10 +555,12 @@ class Mixer extends EventTarget {
             let percentClick = (e.clientX - progressRect.left) / $(this).width();
 
             const channel = window.MIXER.readChannel(id);
-            player.currentTime = player.duration * percentClick;
-            channel.currentTime = player.currentTime;
-
-            window.MIXER.updateChannel(id, channel);
+            if(!isNaN(player.duration)){
+                player.currentTime = player.duration * percentClick;
+                channel.currentTime = player.currentTime;
+                window.MIXER.updateChannel(id, channel);
+            }
+       
         });
         return total
     }

--- a/audio/ui.js
+++ b/audio/ui.js
@@ -59,8 +59,9 @@ function init_mixer() {
         $(youtube_section).append(channelNameDiv, youtube_volume);
         $(mixerChannels).append(youtube_section);
         youtube_volume.on("change", function() {
-            window.YTPLAYER.volume = $("#youtube_volume").val();
+
             if (window.YTPLAYER) {
+                window.YTPLAYER.volume = $("#youtube_volume").val();
                 window.YTPLAYER.setVolume(window.YTPLAYER.volume*$("#master-volume input").val());
                 data={
                     volume: window.YTPLAYER.volume


### PR DESCRIPTION
This makes sure a default volume is set if the player joins without a DM and sends the YT volume from the mixer when a player connects.

Also beta fixes a bug I introduced in beta erroring on checking a token in ct_load. should have been data.current. 

When skipping ahead in a track don't try and set current time if we haven't loaded the audio yet / don't have a duration. Other wise duration = NaN and it errors out.