### PR TITLE
QoL - default letter and number tokens to default have vision/light off

### DIFF
--- a/built-in-tokens.js
+++ b/built-in-tokens.js
@@ -1091,7 +1091,8 @@ const builtInTokens = [
         "name": letter,
         "folderPath": "/Letters",
         "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/${letter}.png`,
-        "disableborder": true
+        "disableborder": true,
+        "auraislight": false
       })
     });
 [...Array(99).keys()]
@@ -1101,18 +1102,21 @@ const builtInTokens = [
         "name": `${number}`.padStart(2, "0"),
         "folderPath": "/Numbers",
         "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/numbers/${number}.png`,
-        "disableborder": true
+        "disableborder": true,
+        "auraislight": false
       })
     });
 builtInTokens.push({
   "name": `! - Exclamation Mark`,
   "folderPath": "/Letters",
   "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/EXCLAMATION.png`,
-  "disableborder": true
+  "disableborder": true,
+  "auraislight": false
 })
 builtInTokens.push({
   "name": `? - Question Mark`,
   "folderPath": "/Letters",
   "image": `https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/QUESTION.png`,
-  "disableborder": true
+  "disableborder": true,
+  "auraislight": false
 })


### PR DESCRIPTION
Have vision/light default to off on letter and number tokens. I think primarily these tokens don't have vision and it would be more common to use them as hidden tokens for the dm to mark things. 