### PR TITLE
Fix - Adjust light blur based on scene scale, this was revealing too much past walls on high scale maps.

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5856,7 +5856,7 @@ div.ddbc-tab-options--layout-pill>button{
     background: #000;
     z-index: 10;
     opacity: 1;
-    filter:blur(10px);
+    filter:blur(calc(10px / var(--scene-scale)));
 }
 
 #text_div{


### PR DESCRIPTION
The map scale was compounding the blur due to scaling - causing light near walls to blur too far past them. This compensates for that.