### PR TITLE
QoL - Adjust redraw light delay to capture holding an arrow key to move.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -48,7 +48,7 @@ const debounceLightChecks = mydebounce(() => {
 		redraw_light();
 		if(!window.DM)
 			check_token_visibility();
-}, 250);
+}, 500);
 
 
 function random_token_color() {
@@ -1942,7 +1942,7 @@ class Token {
 						if (get_avtt_setting_value("allowTokenMeasurement")){
 							WaypointManager.fadeoutMeasuring()
 						}	
-						setTimeout(debounceLightChecks, 500)
+						setTimeout(debounceLightChecks, 250)
 
 						self.update_and_sync(event, false);
 						if (self.selected ) {


### PR DESCRIPTION
While trying to replicate/figure out what was happening in #1122 I noticed that the debounce for redraw light would run before holding a movement key down triggered the next function call. 

For my setup 500ms captures the next call when holding down the key. I think this resolves some of the issue seen in the above PR as it won't stutter before letting go of the key for scenes with lots of walls or lower end pcs.

I'm going to hold off on this and the other improvements by Josh-Archer until next release since we're so close.