### PR TITLE
Fix - some player data sync issues, debounce token updates in update_pc_with_data

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -18,13 +18,13 @@ const sendCharacterUpdateEvent = mydebounce(() => {
       characterId: window.PLAYER_ID,
       pcData: pcData
     });
+    update_pc_with_data(window.PLAYER_ID, pcData);
   } else {
     tabCommunicationChannel.postMessage({
       characterId: window.location.href.split('/').slice(-1)[0],
       pcData: pcData
     });
   }
-  update_pc_with_data(window.PLAYER_ID, pcData);
 }, 1500);
 
 /** @param changes {object} the changes that were observed. EX: {hp: 20} */

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -530,9 +530,6 @@ function update_pc_with_data(playerId, data) {
     lastSynchronized: Date.now()
   }
   if (window.DM) {
-    if (!window.PC_TOKENS_NEEDING_UPDATES) {
-      window.PC_TOKENS_NEEDING_UPDATES = [];
-    }
     if (!window.PC_TOKENS_NEEDING_UPDATES.includes(playerId)) {
       window.PC_TOKENS_NEEDING_UPDATES.push(playerId);
     }
@@ -567,9 +564,6 @@ function update_pc_with_api_call(playerId) {
   if (window.PC_TOKENS_NEEDING_UPDATES.includes(playerId)) {
     console.log(`update_pc_with_api_call isn't adding ${playerId} because we're already waiting for debounce_pc_token_update to handle it`);
     return;
-  }
-  if (!window.PC_NEEDS_API_CALL) {
-    window.PC_NEEDS_API_CALL = {};
   }
   if (Object.keys(window.PC_NEEDS_API_CALL).includes(playerId)) {
     console.log(`update_pc_with_api_call is already waiting planning to call the API to fetch ${playerId}. Nothing to do right now.`);

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -506,8 +506,9 @@ async function rebuild_window_pcs() {
     return {
       ...characterData,
       image: characterData.decorations?.avatar?.avatarUrl || characterData.avatarUrl || defaultAvatarUrl,
-      sheet: `/profile/${characterData.userId}/characters/${characterData.characterId}`
-    }
+      sheet: `/profile/${characterData.userId}/characters/${characterData.characterId}`,
+      lastSynchronized: Date.now()
+    };
   });
 }
 
@@ -523,7 +524,11 @@ function update_pc_with_data(playerId, data) {
   }
   console.debug(`update_pc_with_data is updating ${playerId} with`, data);
   const pc = window.pcs[index];
-  window.pcs[index] = {...pc, ...data}
+  window.pcs[index] = {
+    ...pc,
+    ...data,
+    lastSynchronized: Date.now()
+  }
   if (window.DM) {
     if (!window.PC_TOKENS_NEEDING_UPDATES) {
       window.PC_TOKENS_NEEDING_UPDATES = [];
@@ -552,6 +557,45 @@ const debounce_pc_token_update = mydebounce(() => {
     });
     window.PC_TOKENS_NEEDING_UPDATES = [];
   }
+});
+
+function update_pc_with_api_call(playerId) {
+  if (!playerId) {
+    console.log('update_pc_with_api_call was called without a playerId');
+    return;
+  }
+  if (window.PC_TOKENS_NEEDING_UPDATES.includes(playerId)) {
+    console.log(`update_pc_with_api_call isn't adding ${playerId} because we're already waiting for debounce_pc_token_update to handle it`);
+    return;
+  }
+  if (!window.PC_NEEDS_API_CALL) {
+    window.PC_NEEDS_API_CALL = {};
+  }
+  if (Object.keys(window.PC_NEEDS_API_CALL).includes(playerId)) {
+    console.log(`update_pc_with_api_call is already waiting planning to call the API to fetch ${playerId}. Nothing to do right now.`);
+    return;
+  }
+  window.PC_NEEDS_API_CALL[playerId] = Date.now();
+  debounce_fetch_character_from_api();
+}
+
+const debounce_fetch_character_from_api = mydebounce(() => {
+  const idsAndDates = { ...window.PC_NEEDS_API_CALL }; // make a copy so we can refer to it later
+  window.PC_NEEDS_API_CALL = {}; // clear it out in case we get new updates while the API call is active
+  const characterIds = Object.keys(idsAndDates);
+  console.log('debounce_fetch_character_from_api is about to call DDBApi before update_pc_with_data for ', characterIds);
+  DDBApi.fetchCharacterDetails(characterIds).then((characterDataCollection) => {
+    characterDataCollection.forEach((characterData) => {
+      // check if we've synchronized this player data while the API call was active because we don't want to update the PC with stale data
+      const lastSynchronized = find_pc_by_player_id(characterData.characterId, false)?.lastSynchronized;
+      if (!lastSynchronized || lastSynchronized < idsAndDates[characterData.characterId]) {
+        console.log('debounce_fetch_character_from_api is about to call update_pc_with_data with', characterData.characterId, characterData);
+        update_pc_with_data(characterData.characterId, characterData);
+      } else {
+        console.log(`debounce_fetch_character_from_api is not calling update_pc_with_data for ${characterData.characterId} because ${lastSynchronized} < ${idsAndDates[characterData.characterId]}`);
+      }
+    });
+  });
 });
 
 async function harvest_game_id() {

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -554,10 +554,6 @@ const debounce_pc_token_update = mydebounce(() => {
   }
 });
 
-const test_debounce = mydebounce((someVar) => {
-  console.log('someVar', someVar);
-})
-
 async function harvest_game_id() {
   if (is_campaign_page()) {
     const fromPath = window.location.pathname.split("/").pop();

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -528,7 +528,9 @@ function update_pc_with_data(playerId, data) {
     if (!window.PC_TOKENS_NEEDING_UPDATES) {
       window.PC_TOKENS_NEEDING_UPDATES = [];
     }
-    window.PC_TOKENS_NEEDING_UPDATES.push(playerId);
+    if (!window.PC_TOKENS_NEEDING_UPDATES.includes(playerId)) {
+      window.PC_TOKENS_NEEDING_UPDATES.push(playerId);
+    }
     debounce_pc_token_update();
   }
 }
@@ -536,10 +538,9 @@ function update_pc_with_data(playerId, data) {
 const debounce_pc_token_update = mydebounce(() => {
   if (window.DM) {
     window.PC_TOKENS_NEEDING_UPDATES.forEach((playerId) => {
-     
       const pc = find_pc_by_player_id(playerId, false);
-      let token = window.TOKEN_OBJECTS[pc.sheet];
-      if (token && pc) {
+      let token = window.TOKEN_OBJECTS[pc?.sheet];
+      if (token) {
         token.options = {
           ...token.options,
           ...pc,
@@ -552,6 +553,10 @@ const debounce_pc_token_update = mydebounce(() => {
     window.PC_TOKENS_NEEDING_UPDATES = [];
   }
 });
+
+const test_debounce = mydebounce((someVar) => {
+  console.log('someVar', someVar);
+})
 
 async function harvest_game_id() {
   if (is_campaign_page()) {

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -536,8 +536,9 @@ function update_pc_with_data(playerId, data) {
 const debounce_pc_token_update = mydebounce(() => {
   if (window.DM) {
     window.PC_TOKENS_NEEDING_UPDATES.forEach((playerId) => {
-      let token = window.TOKEN_OBJECTS[playerId];
+     
       const pc = find_pc_by_player_id(playerId, false);
+      let token = window.TOKEN_OBJECTS[pc.sheet];
       if (token && pc) {
         token.options = {
           ...token.options,
@@ -548,6 +549,7 @@ const debounce_pc_token_update = mydebounce(() => {
       }
       update_pc_token_rows();
     });
+    window.PC_TOKENS_NEEDING_UPDATES = [];
   }
 });
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -484,7 +484,7 @@ class MessageBroker {
 			if (msg.eventType == "custom/myVTT/audioPlayingSyncMe") {
 				self.handleAudioPlayingSync(msg);
 			}
-			if(msg.eventType == ('custom/myVTT/character-update')){
+			if (msg.eventType.includes('character-update')) {
 					update_pc_with_data(msg.data.characterId, msg.data.pcData);
 			}
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -484,8 +484,12 @@ class MessageBroker {
 			if (msg.eventType == "custom/myVTT/audioPlayingSyncMe") {
 				self.handleAudioPlayingSync(msg);
 			}
-			if (msg.eventType.includes('character-update')) {
-					update_pc_with_data(msg.data.characterId, msg.data.pcData);
+			if(msg.eventType == ('custom/myVTT/character-update')){
+				update_pc_with_data(msg.data.characterId, msg.data.pcData);
+			}
+			if(msg.eventType == ('character-sheet/character-update/fulfilled')) {
+				console.log('update_pc character-sheet/character-update/fulfilled', msg);
+				update_pc_with_api_call(msg.data?.characterId);
 			}
 
 			if (msg.eventType == "custom/myVTT/reveal") {

--- a/Startup.js
+++ b/Startup.js
@@ -79,6 +79,8 @@ async function start_above_vtt_common() {
   window.TOKEN_SETTINGS = $.parseJSON(localStorage.getItem(`TokenSettings${window.gameId}`)) || {};
   window.all_token_objects = {};
   window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId);
+  window.PC_TOKENS_NEEDING_UPDATES = [];
+  window.PC_NEEDS_API_CALL = {};
 
   await load_external_script("https://www.youtube.com/iframe_api");
   $("#site").append("<div id='windowContainment'></div>");


### PR DESCRIPTION
This does 2 things:
1. MessageBroker is now listening to the DDB `character-update` event again. It was removed by mistake in 0.90
    * ~~I think this actually needs to be updated to fetch from the API because we expect the change to be included in the event which DDB doesn't send.~~ This has been done
2. `window.pcs` continues to update whenever we get any character-update event, but token updates are debounced. I did it this way because you can't pass variables into a debounced function.
    * ~~As I write this, I realize, I need to clear `window.PC_TOKENS_NEEDING_UPDATES` after updating the token~~ this has been done
