### PR TITLE
Fix - Import should no longer error and appear to hang

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -977,7 +977,7 @@ function import_readfile() {
 
 
 		if(DataFile.mixerstate != undefined){
-			window.MIXER._write(DataFile.mixerstate);
+			window.MIXER._write(DataFile.mixerstate, true);
 		}
 		if(DataFile.tracklibrary != undefined){
 			let trackMap = new Map(DataFile.tracklibrary);


### PR DESCRIPTION
This should fix the import error. This was happening due to not setting true on writing to the mixer on import here. This is usually false when adding/adjusting tracks in the mixer. It needs to be true when switching playlists and in this case importing audio - to prevent the current playlist from updating before switching or attempting to update a playlist that may not exist in this case and causing an error.