### PR TITLE
Hex grids draft - function for drawing only

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -647,6 +647,78 @@ function redraw_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=nul
 	}
 	gridContext.stroke();
 }
+function redraw_hex_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color=null, lineWidth=null, subdivide=null, dash=[], columns=true){
+	const gridCanvas = document.getElementById("grid_overlay");
+	const gridContext = gridCanvas.getContext("2d");
+
+	clear_grid();
+	gridContext.setLineDash(dash);
+	let startX = offsetX / window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.offsetx / window.CURRENT_SCENE_DATA.scale_factor;
+	let startY = offsetY / window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.offsety / window.CURRENT_SCENE_DATA.scale_factor;
+	startX = Math.round(startX)
+	startY = Math.round(startY) 
+	const hexSize = hpps/1.5 / window.CURRENT_SCENE_DATA.scale_factor || window.CURRENT_SCENE_DATA.hpps/1.5 / window.CURRENT_SCENE_DATA.scale_factor;
+	gridContext.lineWidth = lineWidth || window.CURRENT_SCENE_DATA.grid_line_width;
+	gridContext.strokeStyle = color || window.CURRENT_SCENE_DATA.grid_color;
+
+
+
+	let hexWidth = Math.floor(hexSize * Math.cos(Math.PI / 6));
+	let hexHeight = Math.floor(hexSize * Math.sin(Math.PI / 6));
+
+	let numRows = Math.floor(gridCanvas.height / hexHeight);
+	let numCols = Math.floor(gridCanvas.width / hexWidth);
+
+	if(columns){
+		for (let r = 0; r < numRows; r++) {
+		  for (let c = 0; c < numCols; c++) {
+			let x = c * hexSize*1.5 + startX;
+			let y = Math.floor(r * hexHeight * (Math.PI+0.5)  + (c % 2) * hexHeight*2) + startY;
+		    drawHexagon(x, y);
+		  }
+		}
+	}
+	else{
+		let hexWidth = hexSize * Math.sqrt(3) / 2;
+		let hexHeight = hexSize;
+
+		for (let r = 0; r < numRows; r++) {
+		  for (let c = 0; c < numCols; c++) {
+		   	let x = c * hexWidth + startX;
+		    let y = r * hexHeight * 3 + (c % 2) * hexHeight *1.5 + startY;
+		    drawHexagon(x, y);
+		  }
+		}
+	}
+	function drawHexagon(x, y) {
+		if(columns){
+		  gridContext.beginPath();
+		  gridContext.moveTo(x + hexSize, y);
+		  for (let i = 1; i <= 6; i++) {
+		    let angle = i * Math.PI / 3;
+		    let dx = hexSize * Math.cos(angle);
+		    let dy = hexSize * Math.sin(angle);
+		    gridContext.lineTo(x + dx, y + dy);
+		  }
+		  gridContext.closePath();
+		  gridContext.stroke();
+		}
+		else{
+		  gridContext.beginPath();
+		  gridContext.moveTo(x, y + hexSize);
+		  for (let i = 1; i <= 6; i++) {
+		    let angle = i * Math.PI / 3;
+		    let dx = hexSize * Math.sin(angle);
+		    let dy = hexSize * Math.cos(angle);
+		    gridContext.lineTo(x + dx, y + dy);
+		  }
+		  gridContext.closePath();
+		  gridContext.stroke();
+		}
+	}
+	
+	
+}
 
 function draw_wizarding_box() {
 

--- a/Fog.js
+++ b/Fog.js
@@ -672,10 +672,16 @@ function redraw_hex_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color
 	if(columns){
 		for (let r = 0; r < numRows; r++) {
 		  for (let c = 0; c < numCols; c++) {
-			let x = c * hexSize*1.5 + startX;
-			let y = Math.floor(r * hexHeight * (Math.PI+0.5)  + (c % 2) * hexHeight*2) + startY;
+			let x = c * hexSize*1.5 + startX - hexSize/1.5;
+			let y = Math.floor(r * hexHeight * (Math.PI+0.5)  + (c % 2) * hexHeight*2) + startY - hexHeight/2;
 		    drawHexagon(x, y);
 		  }
+		}
+		window.verticalHexGrid = true; //switch to current scene settings when available
+		delete window.horizontalHexGrid;
+		window.hexGridSize = {
+			width: hexSize*1.5,
+			height: hexHeight * (Math.PI+0.5)
 		}
 	}
 	else{
@@ -684,12 +690,19 @@ function redraw_hex_grid(hpps=null, vpps=null, offsetX=null, offsetY=null, color
 
 		for (let r = 0; r < numRows; r++) {
 		  for (let c = 0; c < numCols; c++) {
-		   	let x = c * hexWidth + startX;
-		    let y = r * hexHeight * 3 + (c % 2) * hexHeight *1.5 + startY;
+		   	let x = c * hexWidth + startX - hexWidth/7;
+		    let y = r * hexHeight * 3 + (c % 2) * hexHeight *1.5 + startY - hexHeight/1.4;
 		    drawHexagon(x, y);
 		  }
 		}
+		window.horizontalHexGrid = true; //switch to current scene settings when available
+		delete window.verticalHexGrid;
+		window.hexGridSize = {
+			width: hexWidth*2,
+			height: hexHeight * 1.5
+		}
 	}
+
 	function drawHexagon(x, y) {
 		if(columns){
 		  gridContext.beginPath();

--- a/Token.js
+++ b/Token.js
@@ -1854,10 +1854,14 @@ class Token {
 
 							const selectedOldTop = parseInt($(event.target).css("top"));
 							const selectedOldleft = parseInt($(event.target).css("left"));
-							
 
-							const selectedNewtop =  Math.round(Math.round( (selectedOldTop - startY) / window.CURRENT_SCENE_DATA.vpps)) * window.CURRENT_SCENE_DATA.vpps + startY;
-							const selectedNewleft = Math.round(Math.round( (selectedOldleft - startX) / window.CURRENT_SCENE_DATA.hpps)) * window.CURRENT_SCENE_DATA.hpps + startX;
+
+
+							
+							let token_position = snap_point_to_grid(selectedOldleft, selectedOldTop);
+
+							const selectedNewtop =  token_position.y;
+							const selectedNewleft = token_position.x;
 
 							console.log("Snapping from "+selectedOldleft+ " "+selectedOldTop + " -> "+selectedNewleft + " "+selectedNewtop);
 							console.log("params startX " + startX + " startY "+ startY + " vpps "+window.CURRENT_SCENE_DATA.vpps + " hpps "+window.CURRENT_SCENE_DATA.hpps);
@@ -1899,9 +1903,11 @@ class Token {
 
 									const oldtop = parseInt($(tok).css("top"));
 									const oldleft = parseInt($(tok).css("left"));
+									
+									let new_position = snap_point_to_grid(oldleft, oldtop);
 
-									const newtop = Math.round((oldtop - startY) / window.CURRENT_SCENE_DATA.vpps) * window.CURRENT_SCENE_DATA.vpps + startY;
-									const newleft = Math.round((oldleft - startX) / window.CURRENT_SCENE_DATA.hpps) * window.CURRENT_SCENE_DATA.hpps + startX;
+									const newtop = new_position.x;
+									const newleft = new_position.y;
 
 									$(tok).css("top", newtop + "px");
 									$(tok).css("left", newleft + "px");
@@ -2515,10 +2521,16 @@ function snap_point_to_grid(mapX, mapY, forceSnap = false) {
 		// adjust to the nearest square coordinate
 		const startX = window.CURRENT_SCENE_DATA.offsetx;
 		const startY = window.CURRENT_SCENE_DATA.offsety;
-		const gridWidth = window.CURRENT_SCENE_DATA.hpps;
-		const gridHeight = window.CURRENT_SCENE_DATA.vpps;
-		const currentGridX = Math.floor((mapX - startX) / gridWidth);
-		const currentGridY = Math.floor((mapY - startY) / gridHeight);
+		const gridWidth = (window.verticalHexGrid || window.horizontalHexGrid) ? window.hexGridSize.width : window.CURRENT_SCENE_DATA.hpps;
+		const gridHeight = (window.verticalHexGrid || window.horizontalHexGrid) ? window.hexGridSize.height : window.CURRENT_SCENE_DATA.vpps;
+		let currentGridX = Math.floor((mapX - startX) / gridWidth);
+		let currentGridY = Math.floor((mapY - startY) / gridHeight);
+		if(window.verticalHexGrid && currentGridX % 2 == 1){ //replace with current scene when setting exists
+			currentGridY += 0.5;
+		}
+		else if(window.horizontalHexGrid && currentGridY % 2 == 1){//replace with current scene when setting exists
+			currentGridX += 0.5;
+		}
 		return {
 			x: Math.ceil((currentGridX * gridWidth) + startX),
 			y: Math.ceil((currentGridY * gridHeight) + startY)


### PR DESCRIPTION
I've looked at this a couple times but I think the grid draw here will work well. I'd like to include this as an option when we redo scene settings / the grid wizard. This includes the 2 common grid types for hexs. Just functions for drawing them at the appropriate size to tokens/rulers for now.

We'll have to setup a way to set the size in the wizard and adjust snap to grid - this shouldn't be too difficult just set an offset depending what column/row it falls in. We may want to do some transform on the canvas when we need to stretch it a bit when maps don't have perfect hexs.

Feel free to grab this if anyone wants to continue work on it.

![hex grids](https://user-images.githubusercontent.com/65363489/232214201-b55d599f-a010-4e09-b253-2699bb21edc8.gif)


