### PR TITLE
Beta Fixes - Token movement with arrow keys, Token vision shouldn't always be shared, Allow `/sources/` urls for dndbeyond sources

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3221,11 +3221,16 @@ async function redraw_light(){
 			if(selectedIds.length == 0 || found || !window.SelectedTokenVision){	
 				let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
 				
-				if(!(playerTokenId == undefined && window.TOKEN_OBJECTS[auraId].options.share_vision != true && !window.DM && window.TOKEN_OBJECTS[auraId].options.itemType != 'pc')
-					&& !(!auraId.includes(window.PLAYER_ID) && !window.DM && window.TOKEN_OBJECTS[auraId].options.share_vision != true && playerTokenId != undefined))
+				let hideVisionWhenNoPlayerToken = (playerTokenId == undefined && window.TOKEN_OBJECTS[auraId].options.share_vision != true && !window.DM && window.TOKEN_OBJECTS[auraId].options.itemType != 'pc')
+				if(hideVisionWhenNoPlayerToken) //when player token does not exist show vision for all pc tokens and shared vision for other tokens. Mostly used by DM's, streams and tabletop tv games.
+					return; //we don't want to draw this tokens vision no need for further checks - go next token.
+				
+				let hideVisionWhenPlayerTokenExists = (!auraId.includes(window.PLAYER_ID) && !window.DM && window.TOKEN_OBJECTS[auraId].options.share_vision != true && playerTokenId != undefined)
+				if(hideVisionWhenPlayerTokenExists)	//when player token does exist show your own vision and shared vision.
+					return; //we don't want to draw this tokens vision - go next token.
 
-					$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).css('visibility', 'visible'); 		
-					drawPolygon(offscreenContext, lightPolygon, 'rgba(255, 255, 255, 1)', true); //draw to offscreen canvas so we don't have to render every draw and use this for a mask
+				$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).css('visibility', 'visible'); 		
+				drawPolygon(offscreenContext, lightPolygon, 'rgba(255, 255, 255, 1)', true); //draw to offscreen canvas so we don't have to render every draw and use this for a mask
 			}
 		})); 	
 	}

--- a/Journal.js
+++ b/Journal.js
@@ -1229,7 +1229,7 @@ function init_journal(gameid){
 }
 
 function render_source_chapter_in_iframe(url) {
-	if (typeof url !== "string" || !url.startsWith('https://www.dndbeyond.com/sources/')) {
+	if (typeof url !== "string" || (!url.startsWith('https://www.dndbeyond.com/sources/') && !url.startsWith('/sources/'))) {
 		console.error(`render_source_chapter_in_iframe was given an invalid url`, url);
 		showError(new Error(`Unable to render a DDB chapter. This url does not appear to be a valid DDB chapter ${url}`));
 	}

--- a/Token.js
+++ b/Token.js
@@ -526,8 +526,8 @@ class Token {
 
 		this.options.top = top + 'px';
 		this.options.left = left + 'px';
-		await new Promise(() => this.place(100));
-		await new Promise(() => this.update_and_sync());
+		await this.place(100)
+		this.update_and_sync();
 	}
 
 	snap_to_closest_square() {
@@ -2757,6 +2757,7 @@ function deselect_all_tokens() {
 		}
 	}
 	remove_selected_token_bounding_box();
+	window.CURRENTLY_SELECTED_TOKENS = [];
 	let darknessFilter = (window.CURRENT_SCENE_DATA.darkness_filter != undefined) ? window.CURRENT_SCENE_DATA.darkness_filter : 0;
 	let darknessPercent = 100 - parseInt(darknessFilter); 	
 	if(window.DM && darknessPercent < 40){
@@ -3154,7 +3155,7 @@ async function draw_selected_token_bounding_box(){
 	}
 	else {
 		window.NEXT_DRAWBOX=Date.now()+300;
-		await do_draw_selected_token_bounding_box;
+		await do_draw_selected_token_bounding_box();
 		return;
 	}
 }


### PR DESCRIPTION
This fixes a few beta bugs.

 It fixes 2 or 3 bugs with movement keys not working as expect. One example below. 
 https://youtu.be/Niwka87m34g
 
 Allows `/sources/` urls for sources window. Some of the source links we get from ddb gives us these links. It still opens but an error was popping up. Hides the marketplace and adds a message about content not being owned. Also adds a background to resize_drag_window so that pages that would bewithout a background when in smaller windows still get one. #Closes 1147
 Fix
![image](https://user-images.githubusercontent.com/65363489/232724749-25035091-84a0-45d6-aeeb-cb8417d6cac4.png)
Bug
![image](https://user-images.githubusercontent.com/65363489/232725879-ad6fa676-1c76-4d66-ac2e-07fb6ae4b14a.png)
Fix
![image](https://user-images.githubusercontent.com/65363489/232725944-6de1d2e8-f8bb-495b-ab14-9af016d0b890.png)

 Fixes token vision being always shared.
 
 
 
 