### PR TITLE
QoL Adjust vision/light default values for better visibility for DMs with new layering

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1580,13 +1580,13 @@ class Token {
 			if(this.options.light2 == undefined){
 				this.options.light2 = {
 					feet: 0,
-					color: 'rgba(255, 255, 255, 0.5)'
+					color: 'rgba(142, 142, 142, 1)'
 				}
 			}
 			if(this.options.vision == undefined){
 				this.options.vision = {
 					feet: 60,
-					color: 'rgba(255, 255, 255, 0.5)'
+					color: 'rgba(142, 142, 142, 1)'
 				}
 			}
 			if((!window.DM && this.options.restrictPlayerMove && this.options.name != window.PLAYER_NAME) || this.options.locked){
@@ -1640,7 +1640,7 @@ class Token {
 			if(this.options.light2 == undefined){
 				this.options.light2 = {
 					feet: 0,
-					color: 'rgba(255, 255, 255, 0.5)'
+					color: 'rgba(142, 142, 142, 1)'
 				}
 			}
 			if(this.options.vision == undefined){
@@ -1657,7 +1657,7 @@ class Token {
 			        }
 		            this.options.vision = {
 		                feet: darkvision.toString(),
-		                color: 'rgba(255, 255, 255, 0.5)'
+		                color: 'rgba(142, 142, 142, 1)'
 		            }
 		        }
 		        else if(this.isMonster()){
@@ -1686,13 +1686,13 @@ class Token {
 		       		} 
 		            this.options.vision = {
 		                feet: darkvision.toString(),
-		                color: 'rgba(255, 255, 255, 0.5)'
+		                color: 'rgba(142, 142, 142, 1)'
 		            }
 		        }
 				else{
 					this.options.vision = {
 						feet: 60,
-						color: 'rgba(255, 255, 255, 0.5)'
+						color: 'rgba(142, 142, 142, 1)'
 					}
 				
 				}

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -924,8 +924,8 @@ function build_token_light_inputs(tokenIds) {
 		wrapper.find("input[name='light1']").val(feet1);
 		wrapper.find("input[name='light2']").val(feet2);
 
-		let color1 = "rgba(255, 255, 255, 0.8)";
-		let color2 = "rgba(255, 255, 255, 0.4)";
+		let color1 = "rgba(255, 255, 255, 1)";
+		let color2 = "rgba(142, 142, 142, 1)";
 		wrapper.find("input[name='light1Color']").spectrum("set", color1);
 		wrapper.find("input[name='light2Color']").spectrum("set", color2);
 

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1548,7 +1548,7 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
             }
             customization.tokenOptions.vision = {
                 feet: darkvision.toString(),
-                color: 'rgba(255, 255, 255, 0.5)'
+                color: 'rgba(142, 142, 142, 1)'
             }
         }
         else if(listItem.isTypeMonster()){
@@ -1565,26 +1565,26 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
 
             customization.tokenOptions.vision = {
                 feet: darkvision.toString(),
-                color: 'rgba(255, 255, 255, 0.5)'
+                color: 'rgba(142, 142, 142, 1)'
             }
         }
         else{
             customization.tokenOptions.vision = {
                 feet: '60',
-                color: 'rgba(255, 255, 255, 0.5)'
+                color: 'rgba(142, 142, 142, 1)'
             }
         }
     }
     if(customization.tokenOptions.light1 == undefined){
         customization.tokenOptions.light1 = {
             feet: '0',
-            color: 'rgba(255, 255, 255, 0.8)'
+            color: 'rgba(255, 255, 255, 1)'
         }
     }
     if(customization.tokenOptions.light2 == undefined){
         customization.tokenOptions.light2 = {
             feet: '0',
-            color: 'rgba(255, 255, 255, 0.5)'
+            color: 'rgba(142, 142, 142, 1)'
         }
     }
 


### PR DESCRIPTION
After changing the layering for performance the darkvision/dim light is too dark for DM's on some maps. It's come up a couple times in discord as well. 

I also think using fully opaque colors might be better for defaults here. It gives the DM a view that's more comparable to players and might help people figure out light overriding a bit better ... maybe lol. 

