### PR TITLE
Fix - Combat tracker and cross scene hp sync

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -573,7 +573,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 			var old = $("#tokens").find(selector);
 
 			if (maxhp_input.val().trim().startsWith("+") || maxhp_input.val().trim().startsWith("-")) {
-				maxhp_input.val(Math.max(0, token.hp + parseInt(maxhp_input.val())));
+				maxhp_input.val(Math.max(0, token.maxHp + parseInt(maxhp_input.val())));
 			}
 
 			old.find(".max_hp").val(maxhp_input.val().trim());
@@ -823,8 +823,9 @@ function ct_load(data=null){
 
 					ct_add_token(window.all_token_objects[data[i]['data-target']],false,true);
 					if([data[i]['data-target']] in window.TOKEN_OBJECTS){
-						window.TOKEN_OBJECTS[data[i]['data-target']].hp = window.all_token_objects[data[i]['data-target']].hp;
+						window.TOKEN_OBJECTS[data[i]['data-target']].hp = window.all_token_objects[data[i]['data-target']].baseHp;
 						window.TOKEN_OBJECTS[data[i]['data-target']].maxHp = window.all_token_objects[data[i]['data-target']].maxHp;
+						window.TOKEN_OBJECTS[data[i]['data-target']].tempHp = window.all_token_objects[data[i]['data-target']].tempHp;
 					}
 				}
 

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -552,6 +552,14 @@ const debounce_pc_token_update = mydebounce(() => {
         };
         token.place_sync_persist(); // not sure if this is overkill
       }
+      token = window.all_token_objects[pc?.sheet] //for the combat tracker and cross scene syncing/tokens - we want to update this even if the token isn't on the current map
+      if(token){
+        token.options = {
+          ...token.options,
+          ...pc,
+          id: pc.sheet // pc.id is DDB characterId, but we use the sheet as an id for tokens
+        };
+      }
       update_pc_token_rows();
     });
     window.PC_TOKENS_NEEDING_UPDATES = [];


### PR DESCRIPTION
We also need to update `window.all_token_objects` when we update player data. Otherwise the combat tracker and cross scene syncing sets hp to the `all_token_objects` data which will be old data. 

Also fixes a bug where changing the max hp in the combat tracker with +/- was adding/subtracting it from the hp to get the total instead of maxHp.