### PR TITLE
internal - Extend api debounce timeout

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -568,8 +568,14 @@ function update_pc_with_api_call(playerId) {
   } else if (Object.keys(window.PC_NEEDS_API_CALL).includes(playerId)) {
     console.log(`update_pc_with_api_call is already waiting planning to call the API to fetch ${playerId}. Nothing to do right now.`);
   } else {
-    console.log(`update_pc_with_api_call is adding ${playerId} to window.PC_NEEDS_API_CALL`);
-    window.PC_NEEDS_API_CALL[playerId] = Date.now();
+    const pc = find_pc_by_player_id(playerId, false);
+    const twoSecondsAgo = new Date(Date.now() - 2000).getTime();
+    if (pc && pc.lastSynchronized && pc.lastSynchronized > twoSecondsAgo) {
+      console.log(`update_pc_with_api_call is not adding ${playerId} to window.PC_NEEDS_API_CALL because it has been updated within the last 2 seconds`);
+    } else {
+      console.log(`update_pc_with_api_call is adding ${playerId} to window.PC_NEEDS_API_CALL`);
+      window.PC_NEEDS_API_CALL[playerId] = Date.now();
+    }
   }
   debounce_fetch_character_from_api();
 }


### PR DESCRIPTION
This extends the window in which we fetch character data from the API. It used to be 0.7 seconds, which caused our sync event and the DDB sync event to both be handled when there was any amount of network latency. This extends the window to 2 seconds before the DDB sync event, and 5 seconds after the DDB sync event. So if we get our sync event anywhere in that window, we will not call the API.