### PR TITLE
fix - 0 max hp when reducing health using the heal/damage input rather than the health input

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -417,8 +417,8 @@ function observe_character_sheet_changes(documentToObserve) {
             break;
           case "childList":
             const firstRemoved = $(mutation.removedNodes[0]);
-            if(firstRemoved.hasClass('ct-health-summary__hp-item-content') && firstRemoved.children('input').length){ // this is to catch if the player just died look at the removed node to get value - to prevent 0/0 hp
-              let maxhp = parseInt(firstRemoved.find(`input`).attr('max'));
+            if(firstRemoved.hasClass('ct-health-summary__hp-item') && firstRemoved.children('#ct-health-summary-max-label').length){ // this is to catch if the player just died look at the removed node to get value - to prevent 0/0 hp
+              let maxhp = parseInt(firstRemoved.find(`.ct-health-summary__hp-number`).text());
               send_character_hp(maxhp);
             }else if (
               ($(mutation.addedNodes[0]).hasClass('ct-health-summary__hp-number')) ||


### PR DESCRIPTION
I chose the wrong mutation to capture both of these. The original one only captures the hp input change. This should capture both that and the heal/dmg input buttons.