### PR TITLE
Fix - Token out of alignment between DM and Player

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -520,7 +520,7 @@ async function do_check_token_visibility() {
 				$(tokenSelector + "," + auraSelector).hide();
 			}
 			else if (!window.TOKEN_OBJECTS[id].options.hidden ) {
-				$(tokenSelector).css({'opacity': 1, 'display': 'block'});
+				$(tokenSelector).css({'opacity': 1, 'display': 'flex'});
 				if(!window.TOKEN_OBJECTS[id].options.hideaura || id == playerTokenId)
 					$(auraSelector).show();
 			}


### PR DESCRIPTION
Reported on discord - tokens with an aspect ratio that isn't 1:1 don't align for DM's / players.

https://discord.com/channels/815028457851191326/815028804103307354/1099637627830947850

Looks like we changed it from .show() to display block here to prevent re-rendering when it should have been flex.
