### PR TITLE
Fix - The audio loop button was causing the tracks to have the wrong pause setting

### DIFF
--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -211,7 +211,7 @@ class Mixer extends EventTarget {
      * @param {MixerState} state
      */
     _write(state, setPlaylist = false) {
-        if(!setPlaylist){
+        if(!setPlaylist && window.DM){
             let selectedPlaylistID = this.selectedPlaylist();
             if(selectedPlaylistID != undefined){
                 state.playlists[selectedPlaylistID].channels = state.channels;

--- a/audio/ui.js
+++ b/audio/ui.js
@@ -151,6 +151,7 @@ function init_mixer() {
                 loop.toggleClass('pressed', false);
             }
             loop.on('click', function(){
+                const channel = window.MIXER.state().channels[id]
                 if(channel.loop) {
                     loop.toggleClass('pressed', false);
                     channel.loop = false;


### PR DESCRIPTION
This fixes a bug with the loop button that would cause mixer tracks to pause when they shouldn't. Possibly also messing up loop. It was looking at a channel variable from outside the click function which has the wrong data - it should be pulling looking at the current state on click.

This also fixes and player side error that wasn't really having any effect since players didn't need the info. Just window.DM