### PR TITLE
better error handling and logging of MessageBroker events

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -160,8 +160,13 @@ class MessageBroker {
 
 		this.loadingAboveWS=true;
 		
-		this.abovews.onerror = function() {
+		this.abovews.onerror = function(errorEvent) {
 			self.loadingAboveWS = false;
+			try {
+				console.error("MB.onerror", errorEvent);
+			} catch (err) { // this is probably overkill, but just in case
+				console.error("MB.onerror failed to log event", err);
+			}
 		};
 
 		this.abovews.onmessage=this.onmessage;
@@ -366,7 +371,13 @@ class MessageBroker {
 			if (event.data == "ping")
 				return;
 
-			var msg = $.parseJSON(event.data);
+			var msg = {};
+			try {
+				msg = JSON.parse(event.data);
+			} catch (parsingError) {
+				console.error("MB.onmessage failed to handle", event, parsingError);
+				return;
+			}
 			if (window.location.search.includes("popoutgamelog=true") && msg.eventType != "dice/roll/pending")
 				return;
 			console.log(msg.eventType);


### PR DESCRIPTION
I wasn't sure if we wanted to call `showError` for any of these because it could be a lot. For now I'm just logging the errors.

This relates to #357 which I hadn't seen in a long time, but was recently found again in Discord.

I'm unable to reproduce what the discord user is seeing, but rolling from the Bigby's Living Hand stat block will cause errors that this will log out. There's probably a real fix for that stat block, but this PR is just trying to not break the MessageBroker websocket.