### PR TITLE
Fix - Only play audio when fully loaded

### DIFF
--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -192,7 +192,12 @@ class Mixer extends EventTarget {
             if (state.paused || channel.paused) {
                 player.pause();
             } else if (play) {
-                player.play();
+                player.addEventListener("canplaythrough", (event) => {
+                  /* the audio is now playable; play it if permissions allow */
+                    if(!(state.paused || channel.paused))
+                        player.play();
+                }, { once: true });
+                
             }
         });
 


### PR DESCRIPTION
There's a report in discord about audio playing a short bit then stopping. I think what's happening is the file is 'ready to play' but not fully loaded so there are interruptions. This makes sure the file is fully loaded before playing.