### PR TITLE
Beta Fix - Improve large UVTT map performance and fix light color/range

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5737,7 +5737,7 @@ input.max_hp[disabled]{
 .token img[src*='/assets/lightbulb.png'] {
     background:#ffffff80;
     border-radius:20px !important;
-    border:5px solid #000 !important;
+    border: var(--token-border-width) solid #000 !important;
     opacity:0.5;
 }
 .body-rpgcampaign .ddb-campaigns-invite-primary {


### PR DESCRIPTION
By manually setting the grid size 50 this ensures we don't run into issues with exports that have large grid squares. For example if a UVTT file had 200px as the grid and a 40x50 grid we'd get a 8000x10000px map image - which often causes performance issues due to large canvas'.  With 50px grid we cut that down to 2000x2500px - still a good size to play on but reduces performance issues. 

I added a comment about future changes we can make to improve even larger maps as well taking advantage of scaling.

This also includes some fixes for light in the imports.