### PR TITLE
Fix - Tiny token AC blocking movement

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -995,7 +995,8 @@ class Token {
 	}
 
 	build_ac() {
-		let bar_height = Math.max(16, Math.floor(this.sizeHeight() * 0.2)); // no less than 16px
+		let bar_height = this.sizeHeight() * 0.2;
+		bar_height = Math.ceil(bar_height);
 		let acValue = (this.options.armorClass != undefined) ? this.options.armorClass : this.options.ac
 		let ac = $("<div class='ac'/>");
 		ac.css("position", "absolute");

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1655,6 +1655,10 @@ div#combat_button{
     position: absolute;
 }
 
+.token>.ac{
+    pointer-events: none;
+}
+
 .color-reminder {
     display: inline-block;
     width:85%;


### PR DESCRIPTION
Fixes #1193

This removes tiny token ac pointer events and scales them the same on all maps regardless of grid size.

