### PR TITLE
Beta Fix - load() audio if it isn't already loaded (load events relying on play only don't seem to work as well)

### DIFF
--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -182,13 +182,15 @@ class Mixer extends EventTarget {
                 console.log("parse dropbox audio is converting", url, "to", parsed);
                 player.src = parsed;
             }
+            if(player.readyState != 4){
+                player.load();  
+            }
             // sync player
             player.volume = state.volume * channel.volume;
             player.loop = channel.loop;
             if(channel.currentTime != undefined){
                 player.currentTime = channel.currentTime;
             }
-            
             if (state.paused || channel.paused) {
                 player.pause();
             } else if (play) {


### PR DESCRIPTION
Relying on play to load each audio track doesn't seem to load all tracks after awhile. This seems to work better.