### PR TITLE
Beta Fix - Remove black overlay on top of video and remove stage name

### DIFF
--- a/jitsifix.css
+++ b/jitsifix.css
@@ -49,6 +49,12 @@ body.desktop-browser>div>div {
 	left: unset !important;
 	top: unset !important;
 }
+.jss27{
+    background: none !important;
+}
+.stage-participant-label{
+    display:none !important;
+}
 #layout_wrapper .filmstrip__videos.remote-videos>div{
     position: relative;
 }


### PR DESCRIPTION
Removes a 80% opacity black overlay from the top of video. Also removes the stage name we don't want in our layout.