### PR TITLE
Feat: Option to use rpg dice roller instead of ddb dice.

### DIFF
--- a/ChatObserver.js
+++ b/ChatObserver.js
@@ -61,13 +61,27 @@ class ChatObserver {
 
     #parseSlashCommand(text) {
         let diceRoll = DiceRoll.fromSlashCommand(text);
-        let didSend = window.diceRoller.roll(diceRoll); // TODO: update this with more details?
-        if (didSend === false) {
-            // it was too complex so try to send it through rpgDiceRoller
+        if(window.AboveDice){
             let expression = text.replace(diceRollCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
-            didSend = send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
+            let roll = new rpgDiceRoller.DiceRoll(expression); 
+            let msgdata = {
+                player: window.PLAYER_NAME,
+                img: window.PLAYER_IMG,
+                text: `<div><span class='aboveDiceTotal'>${roll.total}</span><span class='aboveDiceOutput'>${roll.output}</span></div>`,
+                whisper: (gamelog_send_to_text() != "Everyone") ? window.PLAYER_NAME : ``
+            };
+            window.MB.inject_chat(msgdata);       
         }
-        return didSend;
+        else{
+            let didSend = window.diceRoller.roll(diceRoll); // TODO: update this with more details?
+            if (didSend === false) {
+                // it was too complex so try to send it through rpgDiceRoller
+                let expression = text.replace(diceRollCommandRegex, "").match(allowedExpressionCharactersRegex)?.[0];
+                didSend = send_rpg_dice_to_ddb(expression, window.pc.name, window.pc.image, rollType, undefined, action);
+            }
+            return didSend;
+        }
+
     }
 
     #sendChatMessage(text) {

--- a/DiceContextMenu/DiceContextMenu.js
+++ b/DiceContextMenu/DiceContextMenu.js
@@ -48,7 +48,20 @@ function standard_dice_context_menu(expression, modifierString = "", action = un
         diceRoll.entityId = entityId;
         diceRoll.sendToOverride = dcm.checkedRow(0)?.title?.replace(/\s+/g, "");
 
-        window.diceRoller.roll(diceRoll);
+
+        if(window.AboveDice){      
+            let roll = new rpgDiceRoller.DiceRoll(diceRoll.expression); 
+            let msgdata = {
+                player: window.PLAYER_NAME,
+                img: window.PLAYER_IMG,
+                text: `<div><span class='aboveDiceTotal'>${roll.total}</span><span class='aboveDiceOutput'>${roll.output}</span></div>`,
+                whisper: `${(diceRoll.sendToOverride != 'Everyone') ? window.PLAYER_NAME : ``}`
+            };
+            window.MB.inject_chat(msgdata);       
+        }
+        else{
+            window.diceRoller.roll(diceRoll);
+        }
     });
 
     return menu;
@@ -90,7 +103,19 @@ function damage_dice_context_menu(diceExpression, modifierString = "", action = 
             diceRoll.entityType = entityType;
             diceRoll.entityId = entityId;
 
-            window.diceRoller.roll(diceRoll);
+            
+            if(window.AboveDice){      
+                let roll = new rpgDiceRoller.DiceRoll(diceRoll.expression); 
+                let msgdata = {
+                    player: window.PLAYER_NAME,
+                    img: window.PLAYER_IMG,
+                    text: `<div><span class='aboveDiceTotal'>${roll.total}</span><span class='aboveDiceOutput'>${roll.output}</span></div>`,
+                };
+                window.MB.inject_chat(msgdata);       
+            }
+            else{
+                window.diceRoller.roll(diceRoll);
+            }
         });
 }
 

--- a/MonsterDice.js
+++ b/MonsterDice.js
@@ -346,15 +346,27 @@ function roll_button_clicked(clickEvent, displayName, imgUrl, entityType = undef
 	const rollType = pressedButton.attr('data-rolltype');
 	const action = pressedButton.attr('data-actiontype');
 
-	window.diceRoller.roll(new DiceRoll(
-		`${expression}${modifier}`,
-		action,
-		rollType,
-		displayName,
-		imgUrl,
-		entityType,
-		entityId
-	));
+	if(window.AboveDice){      
+	    let roll = new rpgDiceRoller.DiceRoll(`${expression}${modifier}`); 
+	    let msgdata = {
+	        player: window.PLAYER_NAME,
+	        img: window.PLAYER_IMG,
+	        text: `<div><span class='aboveDiceTotal'>${roll.total}</span><span class='aboveDiceOutput'>${roll.output}</span></div>`,
+	        whisper: (gamelog_send_to_text() != "Everyone") ? window.PLAYER_NAME : ``
+	    };
+	    window.MB.inject_chat(msgdata);       
+	}
+	else{
+		window.diceRoller.roll(new DiceRoll(
+			`${expression}${modifier}`,
+			action,
+			rollType,
+			displayName,
+			imgUrl,
+			entityType,
+			entityId
+		));
+	}
 	pressedButton = null
 }
 

--- a/MonsterDice.js
+++ b/MonsterDice.js
@@ -346,7 +346,7 @@ function roll_button_clicked(clickEvent, displayName, imgUrl, entityType = undef
 	const rollType = pressedButton.attr('data-rolltype');
 	const action = pressedButton.attr('data-actiontype');
 
-	if(window.AboveDice){      
+	if(window.EXPERIMENTAL_SETTINGS['rpgRoller']){      
 	    let roll = new rpgDiceRoller.DiceRoll(`${expression}${modifier}`); 
 	    let msgdata = {
 	        player: window.PLAYER_NAME,

--- a/Settings.js
+++ b/Settings.js
@@ -321,6 +321,17 @@ function avtt_settings() {
 			}
 		);
 	}
+	settings.push(
+	{
+		name: "rpgRoller",
+		label: "Disable DDB dice where possible",
+		type: "toggle",
+		options: [
+			{ value: true, label: "Allow", description: `Disables DDB dice and uses a random number generator` },
+			{ value: false, label: "Never", description: `Defaults to DDB dice` }
+		],
+		defaultValue: false
+	})
 
 	if (AVTT_ENVIRONMENT.versionSuffix) {
 		// This is either a local or a beta build, so allow this helpful debugging tool

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4588,7 +4588,17 @@ div#selectedTokensBorderRotationGrabberConnector,
     width: 245px;
     max-height: 100%;
 }
-
+.aboveDiceTotal{
+    width: 100%;
+    display: block;
+    text-align: center;
+    font-weight: 700;
+    font-size: 23px;
+    font-family: Roboto,Open Sans,Helvetica,sans-serif;
+}
+.aboveDiceOutput{
+    width:100%;
+}
 #tokenOptionsContainer{
     overflow: hidden auto;
     padding: 5px;


### PR DESCRIPTION
There has been a few request to have an option to not use ddb dice. This would be an option in experimental settings. Feel free to grab this and add to it/finish it up.

To Do:

- [x] Character Sheets
- [ ] Formatting to look like DDB rolls in chat (maybe - can come after first merge)
- [x] Monster Sheets
- [x] Chat line


This is currently using `window.AboveDice = true` in the console to enable this.
(this will be replaced by the option.)

Monster example:
https://cdn.discordapp.com/attachments/1118492516510072882/1118562776995074178/dice_example.gif