### PR TITLE
Fix - Only paste tokens at mouse if mouse is hovering the map

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -281,10 +281,22 @@ Mousetrap.bind('command+c', function(e) {
 
 Mousetrap.bind('ctrl+v', function(e) {
     if (window.navigator.userAgent.indexOf("Mac") != -1) return; // Mac/iOS use command
-    paste_selected_tokens(window.cursor_x, window.cursor_y);
+    if($('#temp_overlay:hover').length>0){
+        paste_selected_tokens(window.cursor_x, window.cursor_y);
+    } 
+    else {
+        let center = center_of_view();
+        paste_selected_tokens(center.x, center.y);
+    }
 });
 Mousetrap.bind('command+v', function(e) {
-    paste_selected_tokens(e.clientX - e.target.getBoundingClientRect(), e.clientY - e.target.getBoundingClientRect());
+    if($('#temp_overlay:hover').length>0){
+        paste_selected_tokens(window.cursor_x, window.cursor_y);
+    } 
+    else {
+        let center = center_of_view();
+        paste_selected_tokens(center.x, center.y);
+    }
 });
 
 document.onmousemove = function(event)


### PR DESCRIPTION
Got a couple reports of pasting sending the token to random spots/top right of map. 

I think this is due to pasting when the cursor is off the map or a bug with mac paste due to getBoundingClient not specifying what is being subtracted (it returns an object {x, y, top, bottom .... } ). This should resolve both cases.