### PR TITLE
QoL - AoE will be revealed in fog so it's not lost to players; When there are no walls or darkness reveal tokens to players even if there isn't a PC token on the map

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -454,7 +454,7 @@ function check_single_token_visibility(id){
 	let auraSelector = ".aura-element[id='aura_" + auraSelectorId + "']";
 	let selector = "div.token[data-id='" + id + "']";
 	let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-	let playerTokenHasVision = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+	let playerTokenHasVision = (playerTokenId == undefined) ? ((window.walls.length > 4 || window.CURRENT_SCENE_DATA.darkness_filter > 0) ? true : false) : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
 	const hideThisTokenInFogOrDarkness = (!window.TOKEN_OBJECTS[id].options.revealInFog); //we want to hide this token in fog or darkness
 	
 	const inFog = is_token_under_fog(id); // this token is in fog
@@ -517,7 +517,7 @@ async function do_check_token_visibility() {
 
 
 			let playerTokenId = $(`.token[data-id*='${window.PLAYER_ID}']`).attr("data-id");
-			let playerTokenHasVision = (playerTokenId == undefined) ? true : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
+			let playerTokenHasVision = (playerTokenId == undefined) ? ((window.walls.length > 4 || window.CURRENT_SCENE_DATA.darkness_filter > 0) ? true : false) : window.TOKEN_OBJECTS[playerTokenId].options.auraislight;
 
 			//Combining some and filter cut down about 140ms for average sized picture
 			let someFilter = function(ctx) {

--- a/Token.js
+++ b/Token.js
@@ -210,6 +210,7 @@ class Token {
 			this.options.hidestat = true
 			this.options.disableborder = true
 			this.options.disableaura = true
+			this.options.revealInFog = true
 		}
 	}
 


### PR DESCRIPTION
Some token visibility QoL improvements.

AoE should always be visible when placed for players - unless hidden manually. 

Tokens should show up for players when no PC token is on the map if there are no walls (except the map edges) and 0 darkness. Useful for puzzle maps etc.