### PR TITLE
QoL - Projector mode for local player view, this will make any local player tabs follow the DMs scroll and zoom. Useful for in person or streaming play.

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -21,6 +21,7 @@ const sendCharacterUpdateEvent = mydebounce(() => {
     update_pc_with_data(window.PLAYER_ID, pcData);
   } else {
     tabCommunicationChannel.postMessage({
+      msgType: 'CharacterData',
       characterId: window.location.href.split('/').slice(-1)[0],
       pcData: pcData
     });

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -33,13 +33,22 @@ $(function() {
   window.diceRoller = new DiceRoller();
   if (is_abovevtt_page()) {
     tabCommunicationChannel.addEventListener ('message', (event) => {
-      if(!find_pc_by_player_id(event.data.characterId, false))
+      if(event.data.msgType == 'CharacterData' && !find_pc_by_player_id(event.data.characterId, false))
         return;
       if(!window.DM){
-         window.MB.sendMessage("custom/myVTT/character-update", {
-          characterId: event.data.characterId,
-          pcData: event.data.pcData
-        });
+        if(event.data.msgType == 'CharacterData'){
+          window.MB.sendMessage("custom/myVTT/character-update", {
+            characterId: event.data.characterId,
+            pcData: event.data.pcData
+          });
+        }
+        else if(event.data.msgType == 'projectionScroll'){
+          window.scroll(event.data.x, event.data.y);
+        }
+        else if(event.data.msgType == 'projectionZoom'){
+          change_zoom(event.data.newZoom, event.data.x, event.data.y);
+        }
+
       }
       else{
         update_pc_with_data(event.data.characterId, event.data.pcData);

--- a/Main.js
+++ b/Main.js
@@ -149,6 +149,14 @@ function change_zoom(newZoom, x, y) {
 	$(window).scrollTop(pageY);
 	$("body").css("--window-zoom", window.ZOOM)
 	$(".peerCursorPosition").css("transform", "scale(" + 1/window.ZOOM + ")");
+	if(window.EXPERIMENTAL_SETTINGS.projector == true){
+		tabCommunicationChannel.postMessage({
+   			msgType: 'projectionZoom',
+   			newZoom: newZoom,
+   			x: x,
+   			y: y
+   		})
+	}
 	console.groupEnd()
 }
 

--- a/Settings.js
+++ b/Settings.js
@@ -291,6 +291,16 @@ function avtt_settings() {
 					{ value: "combatTurn", label: "Current Combat Turn", description: `You will only see players' token measurement and ruler measurement during their turn in combat. You will not see rulers of any player that disables cursor/ruler streaming.` }
 				],
 				defaultValue: "all"
+			},
+			{
+				name: "projector",
+				label: "Streaming/TV Table Projector Mode",
+				type: "toggle",
+				options: [
+					{ value: true, label: "Enable", description: `If you have another tab with the player view open it will receive your scroll and zoom events.` },
+					{ value: false, label: "Disable", description: `If you have another tab with the player view open it will not receive your scroll and zoom events.` }
+				],
+				defaultValue: false
 			}
 		);
 	} else {

--- a/Startup.js
+++ b/Startup.js
@@ -12,6 +12,13 @@ $(function() {
     init_loading_overlay_beholder();
     window.addEventListener("scroll", function(event) { // ddb has an scroll event listener on the character sheet where they add/remove classes and throttle the sheet scroll causing right click drag of the map to not be smooth
       event.stopImmediatePropagation();
+      if(window.EXPERIMENTAL_SETTINGS.projector == true && window.DM){
+            tabCommunicationChannel.postMessage({
+              msgType: 'projectionScroll',
+              x: window.pageXOffset,
+              y: window.pageYOffset
+            });
+      }
     }, true);
     startup_step("Gathering basic campaign info");
     harvest_game_id()                 // find our campaign id


### PR DESCRIPTION
With this setting enabled it will make the player view in a 2nd tab follow the scroll and zoom of the DM view. This can be useful for TV/projector play or streaming. It eliminates having to control multiple views for position of the map.