### PR TITLE
Fix - when creating a scene from dndbeyond it should no longer throw an error when compendium is in the url.

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -1229,7 +1229,7 @@ function init_journal(gameid){
 }
 
 function render_source_chapter_in_iframe(url) {
-	if (typeof url !== "string" || (!url.startsWith('https://www.dndbeyond.com/sources/') && !url.startsWith('/sources/'))) {
+	if (typeof url !== "string" || (!url.startsWith('https://www.dndbeyond.com/sources/') && !url.startsWith('/sources/') && !url.startsWith('https://www.dndbeyond.com/compendium/') && !url.startsWith('/compendium/'))) {
 		console.error(`render_source_chapter_in_iframe was given an invalid url`, url);
 		showError(new Error(`Unable to render a DDB chapter. This url does not appear to be a valid DDB chapter ${url}`));
 	}


### PR DESCRIPTION
Fixes #1258

So it seems sometimes dndbeyond has compendium instead of sources in the url. I'm not sure if this is due to purchasing just the compendium product vs full product or if they've made a change somehow. I'm not getting compendium in my urls but the url does direct to the book if I go their manually.