### PR TITLE
Beta Fix - use roll.action for the roll title

### DIFF
--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -268,7 +268,7 @@ class DiceRoller {
                 let roll = new rpgDiceRoller.DiceRoll(diceRoll.expression); 
                 let regExpression = new RegExp(`${diceRoll.expression.replace(/[+-]/g, '\\$&')}:\\s`);
                 let rollType = (diceRoll.rollType) ? diceRoll.rollType : 'Custom';
-                let rollTitle = (diceRoll.name) ? diceRoll.name : 'AboveVTT';
+                let rollTitle = (diceRoll.action) ? diceRoll.action : 'AboveVTT';
                 
                 let msgdata = {
                       player: window.PLAYER_NAME,


### PR DESCRIPTION
I was using roll.name instead of roll.action to get the roll title for the gamelog message.