### PR TITLE
Beta Fix - Non-ddb dice open5e monster rolls, dice buttons under chat, hover should always show full result

### DIFF
--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -43,7 +43,7 @@ class DiceRoll {
         }
         try {
             let alteredRollType = newRollType.trim().toLowerCase().replace("-", " ");
-            const validRollTypes = ["to hit", "damage", "save", "check", "heal", "reroll", "initiative"];
+            const validRollTypes = ["to hit", "damage", "save", "check", "heal", "reroll", "initiative", "attack", "roll"];
             if (validRollTypes.includes(alteredRollType)) {
                 this.#diceRollType = alteredRollType;
             } else {

--- a/Main.js
+++ b/Main.js
@@ -2241,7 +2241,7 @@ Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 	`));
 
 	$(".dice-roller > div img").on("click", function(e) {
-		if ($(".dice-toolbar__dropdown").length > 0) {
+		if ($(".dice-toolbar__dropdown").length > 0 && !window.EXPERIMENTAL_SETTINGS['rpgRoller']) {
 			// DDB dice are on the screen so let's use those. Ours will synchronize when these change.
 			if (!$(".dice-toolbar__dropdown").hasClass("dice-toolbar__dropdown-selected")) {
 				// make sure it's open
@@ -2270,34 +2270,37 @@ Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 
 	$(".dice-toolbar__dropdown").on("DOMSubtreeModified", function() {
 		// Any time the DDB dice buttons change state, we want to synchronize our dice buttons to match theirs.
-		$(".dice-die-button").each(function() {
-			let dieSize = $(this).attr("data-dice");
-			let ourDiceElement = $(`.dice-roller > div img[alt='${dieSize}']`);
-			let diceCountElement = $(this).find(".dice-die-button__count");
-			ourDiceElement.parent().find("span").remove();
-			if (diceCountElement.length == 0) {
-				ourDiceElement.removeAttr("data-count");
-			} else {
-				let diceCount = parseInt(diceCountElement.text());
-				ourDiceElement.attr("data-count", diceCount);
-				ourDiceElement.parent().append(`<span class="dice-badge">${diceCount}</span>`);
-			}
-		})
+		if (!window.EXPERIMENTAL_SETTINGS['rpgRoller']) {
+			$(".dice-die-button").each(function() {
+				let dieSize = $(this).attr("data-dice");
+				let ourDiceElement = $(`.dice-roller > div img[alt='${dieSize}']`);
+				let diceCountElement = $(this).find(".dice-die-button__count");
+				ourDiceElement.parent().find("span").remove();
+				if (diceCountElement.length == 0) {
+					ourDiceElement.removeAttr("data-count");
+				} else {
+					let diceCount = parseInt(diceCountElement.text());
+					ourDiceElement.attr("data-count", diceCount);
+					ourDiceElement.parent().append(`<span class="dice-badge">${diceCount}</span>`);
+				}
+			})
 
-		// make sure our roll button is shown/hidden after all animations have completed
-		setTimeout(function() {
-			if ($(".dice-toolbar").hasClass("rollable")) {
-				$(".roll-button").addClass("show");
-			} else {
-				$(".roll-button").removeClass("show");
-			}
-		}, 0);
+
+			// make sure our roll button is shown/hidden after all animations have completed
+			setTimeout(function() {
+				if ($(".dice-toolbar").hasClass("rollable")) {
+					$(".roll-button").addClass("show");
+				} else {
+					$(".roll-button").removeClass("show");
+				}
+			}, 0);
+		}
 	});
 
 	$(".dice-roller > div img").on("contextmenu", function(e) {
 		e.preventDefault();
 
-		if ($(".dice-toolbar__dropdown").length > 0) {
+		if ($(".dice-toolbar__dropdown").length > 0 && !window.EXPERIMENTAL_SETTINGS['rpgRoller']) {
 			// There are DDB dice on the screen so update those buttons. Ours will synchronize when these change.
 			// the only way I could get this to work was with pure javascript. Everything that I tried with jQuery did nothing
 			let dieSize = $(this).attr("alt");
@@ -2327,12 +2330,12 @@ Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 		}
 	});
 
-	if ($(".roll-button").length == 0) {
+	if ($(".roll-button").length == 0 || window.EXPERIMENTAL_SETTINGS['rpgRoller']) {
 		const rollButton = $(`<button class="roll-button">Roll</button>`);
 		$("body").append(rollButton);
 		rollButton.on("click", function (e) {
 
-			if ($(".dice-toolbar").hasClass("rollable")) {
+			if ($(".dice-toolbar").hasClass("rollable") && !window.EXPERIMENTAL_SETTINGS['rpgRoller']) {
 				let theirRollButton = $(".dice-toolbar__target").children().first();
 				if (theirRollButton.length > 0) {
 					// we found a DDB dice roll button. Click it and move on
@@ -2350,6 +2353,7 @@ Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 			let sentAsDDB = send_rpg_dice_to_ddb(rollExpression.join("+"), sendToDM);
 			if (!sentAsDDB) {
 				const roll = new rpgDiceRoller.DiceRoll(rollExpression.join("+"));
+				
 				const text = roll.output;
 				const uuid = new Date().getTime();
 				const data = {
@@ -2368,6 +2372,7 @@ Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;<br/>
 						$(this).remove();
 					});
 				}
+						
 			}
 
 			$(".roll-button").removeClass("show");

--- a/MonsterDice.js
+++ b/MonsterDice.js
@@ -343,15 +343,20 @@ function roll_button_clicked(clickEvent, displayName, imgUrl, entityType = undef
 	let pressedButton = $(clickEvent.currentTarget).clone();
 	const expression = pressedButton.attr('data-exp');
 	const modifier = pressedButton.attr('data-mod')?.replaceAll("(", "")?.replaceAll(")", "");
-	const rollType = pressedButton.attr('data-rolltype');
+	let rollType = pressedButton.attr('data-rolltype');
 	const action = pressedButton.attr('data-actiontype');
 
-	if(window.EXPERIMENTAL_SETTINGS['rpgRoller']){      
-	    let roll = new rpgDiceRoller.DiceRoll(`${expression}${modifier}`); 
+
+	if(window.EXPERIMENTAL_SETTINGS['rpgRoller']){     
+	    let fullExpression = `${expression}${modifier}`.replace(/\s/g, '')
+	    let regExpression = new RegExp(`${fullExpression.replace(/[+-]/g, '\\$&')}:\\s`);
+	    let roll = new rpgDiceRoller.DiceRoll(fullExpression); 
+	    if(rollType == 'undefined')
+	    	rollType = 'AboveVTT'
 	    let msgdata = {
 	        player: window.PLAYER_NAME,
 	        img: window.PLAYER_IMG,
-	        text: `<div class="tss-24rg5g-DiceResultContainer-Flex" title='${expression}${modifier}'><div class="tss-kucurx-Result"><div class="tss-3-Other-ref tss-1o65fpw-Line-Title-Other"><span class='aboveDiceOutput'>${action}: <span class='abovevtt-roll-${rollType}'>${rollType}</span></span></div></div><svg width="1" height="32" class="tss-10y9gcy-Divider"><path fill="currentColor" d="M0 0h1v32H0z"></path></svg><div class="tss-1jo3bnd-TotalContainer-Flex"><div class="tss-3-Other-ref tss-3-Collapsed-ref tss-3-Pending-ref tss-jpjmd5-Total-Other-Collapsed-Pending-Flex"><span class='aboveDiceTotal'>${roll.total}</span></div></div></div>`,
+	        text: `<div class="tss-24rg5g-DiceResultContainer-Flex" title='${roll.output.replace(regExpression, '')}'><div class="tss-kucurx-Result"><div class="tss-3-Other-ref tss-1o65fpw-Line-Title-Other"><span class='aboveDiceOutput'>${rollType}: <span class='abovevtt-roll-${action}'>${action}</span></span></div></div><svg width="1" height="32" class="tss-10y9gcy-Divider"><path fill="currentColor" d="M0 0h1v32H0z"></path></svg><div class="tss-1jo3bnd-TotalContainer-Flex"><div class="tss-3-Other-ref tss-3-Collapsed-ref tss-3-Pending-ref tss-jpjmd5-Total-Other-Collapsed-Pending-Flex"><span class='aboveDiceTotal'>${roll.total}</span></div></div></div>`,
 	        whisper: (gamelog_send_to_text() != "Everyone") ? window.PLAYER_NAME : ``
 	    };
 	    window.MB.inject_chat(msgdata);       

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4622,7 +4622,8 @@ div#selectedTokensBorderRotationGrabberConnector,
     color: rgb(27, 154, 240);
 }
 .abovevtt-roll-custom,
-.abovevtt-roll-initiative{
+.abovevtt-roll-initiative,
+.abovevtt-roll-roll{
     color: rgb(245, 166, 35);
 }
 


### PR DESCRIPTION
When using non-ddb dice the dice under chat should no longer used ddb dice.

Open5e monsters some buttons weren't working with non-ddb dice. 

Hovering a roll in the gamelog for monsters wasn't showing the full dice results just the expression.