### PR TITLE
Open5e monster folder will now have CR and type monster filters applied to them; previewing of monsters on click in the sidebar; and a load more button

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -54,7 +54,7 @@ $(function() {
         }
 
       }
-      else{
+      else if(event.data.msgType == 'CharacterData'){
         update_pc_with_data(event.data.characterId, event.data.pcData);
       }
     })

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1450,6 +1450,10 @@ function did_click_row(clickEvent) {
         window.open(clickedItem.monsterData.url, '_blank');
       }
       break;
+    case ItemType.Open5e: 
+        console.log(`Opening open5e monster with id ${clickedItem.monsterData.slug}`);
+        open_monster_item(clickedItem, true);
+      break;
     case ItemType.BuiltinToken:
       // display_builtin_token_details_modal(clickedItem);
       break;


### PR DESCRIPTION
Open5e monsters will have CR and type monster filters applied.
Preview of monsters in the sidebar.
Load more button.

This fixes 1 error as well with the tab message broker when a DM gets a message that's not character data.