### PR TITLE
Fix - DDB monster list not loading and stat blocks getting stuck on one monster

### DIFF
--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -34,12 +34,13 @@ function build_and_display_stat_block_with_data(monsterData, container, tokenId,
         // is not as good as the data we get from fetching the monster directly so
         // build with what the listItem has on it, then fetch more details, then re-render it with the updated details
         display_stat_block_in_container(new MonsterStatBlock(monsterData), container, tokenId);
-        fetch_and_cache_monsters([monsterData.stat], function (open5e = false) {
+        let monsterId = (monsterData.slug) ? monsterData.slug : monsterData.id
+        fetch_and_cache_monsters([monsterId], function (open5e = false) {
           if(!open5e){
-            display_stat_block_in_container(new MonsterStatBlock(cached_monster_items[monsterData.id].monsterData), container, tokenId);
+            display_stat_block_in_container(new MonsterStatBlock(cached_monster_items[monsterId].monsterData), container, tokenId);
           }
           else{
-            display_stat_block_in_container(new MonsterStatBlock(cached_open5e_items[monsterData.stat].monsterData), container, tokenId);}
+            display_stat_block_in_container(new MonsterStatBlock(cached_open5e_items[monsterId].monsterData), container, tokenId);}
         }, open5e);
     }
 }

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -2259,7 +2259,7 @@ function open_monster_item(listItem, open5e=false) {
     let sidebarModal = new SidebarPanel("monster-stat-block", true);
     display_sidebar_modal(sidebarModal);
     try {
-        build_and_display_stat_block_with_data(listItem.monsterData, sidebarModal.body, undefined);
+        build_and_display_stat_block_with_data(listItem.monsterData, sidebarModal.body, undefined, open5e);
     } catch (error) {
         console.error("open_monster_item failed to build a stat block locally. Attempting to open an iFrame instead", error);
         close_sidebar_modal();


### PR DESCRIPTION
A fix for ddb monster list not loading and stat blocks getting stuck.

This was happening due to undefined id's being requested from ddb's server.