### PR TITLE
Fix - undefined audio channel src causing type error on `startsWith` when loading into abovevtt

### DIFF
--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -163,6 +163,10 @@ class Mixer extends EventTarget {
         const state = this.state();
  
         Object.entries(state.channels).forEach(([id, channel]) => {
+            if(!channel?.src){
+                delete this._players[id];
+                return;
+            }
             let player = this._players[id]
 
             // create new player if needed

--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -186,18 +186,20 @@ class Mixer extends EventTarget {
                 player.preload = "metadata";
                 this._players[id] = player;
             }
-
-            // sync player
-            player.volume = state.volume * channel.volume;
-            player.loop = channel.loop;
-            if(channel.currentTime != undefined){
-                player.currentTime = channel.currentTime;
-            }
+            if(player.paused)
+                player.load();
             if (state.paused || channel.paused) {
                 player.pause();
-            } else if (play) {
+            } else if (play) {        
+
                 player.addEventListener("canplaythrough", (event) => {
                   /* the audio is now playable; play it if permissions allow */
+                    // sync player
+                    player.volume = state.volume * channel.volume;
+                    player.loop = channel.loop;
+                    if(channel.currentTime != undefined){
+                        player.currentTime = channel.currentTime;
+                    }
                    if(this._players[id] && !(state.paused || channel.paused))
                         player.play();
                 }, { once: true });

--- a/audio/ui.js
+++ b/audio/ui.js
@@ -81,6 +81,9 @@ function init_mixer() {
         channelNameDiv.find(".channelName").css("--name-width-overflow", (100 - nameWidth < 0) ? 90 - nameWidth+'px' : 0);
         /** @type {Object.<string, Channel>} */
         Object.entries(channels).forEach(([id, channel]) => {
+            if(!channel?.src){
+                return;
+            }
             const item = document.createElement("li");
             item.className = "audio-row";
             let channelNameDiv = $(`<div class='channelNameOverflow'><div class='channelName'>${channel.name}</div></div>`)


### PR DESCRIPTION
This moves onto the next channel if a src is undefined and removes it from the mixer.