### PR TITLE
Fix - projector mode zoom should only send from the DM window, should prevent odd behaviour when multiple pc views are open

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -149,7 +149,7 @@ function change_zoom(newZoom, x, y) {
 	$(window).scrollTop(pageY);
 	$("body").css("--window-zoom", window.ZOOM)
 	$(".peerCursorPosition").css("transform", "scale(" + 1/window.ZOOM + ")");
-	if(window.EXPERIMENTAL_SETTINGS.projector == true){
+	if(window.EXPERIMENTAL_SETTINGS.projector == true && window.DM){
 		tabCommunicationChannel.postMessage({
    			msgType: 'projectionZoom',
    			newZoom: newZoom,


### PR DESCRIPTION
I missed window.DM on the zoom part of the projector setting.