### PR TITLE
Fix - Player token customizations should properly override token settings.

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -772,7 +772,13 @@ function observe_character_theme_change() {
               update_window_color(newColor);
               if(window.PeerManager != undefined)
                 window.PeerManager.send(PeerEvent.preferencesChange());
-              character_sheet_changed({color: newColor});
+              character_sheet_changed({
+                decorations: {
+                  characterTheme:{ 
+                    themeColor: newColor
+                  }
+                }
+              });
             }
           }
         });

--- a/Token.js
+++ b/Token.js
@@ -2633,11 +2633,16 @@ function place_token_at_map_point(tokenObject, x, y) {
 	let options = {
 		...default_options(),
 		...window.TOKEN_SETTINGS,
-		...tokenObject,
 		...pc,
+		...tokenObject,
 		id: tokenObject.id // pc.id uses the DDB characterId, but we want to use the pc.sheet for player ids. So just use whatever we were given with tokenObject.id
 	};
-
+	if(window.all_token_objects[options.id] !== undefined){
+		options = {
+			...options,
+			...window.all_token_objects[options.id].options
+		};
+	}
 	// aoe tokens have classes instead of images
 	if (typeof options.imgsrc === "string" && !options.imgsrc.startsWith("class")) {
 		options.imgsrc = parse_img(options.imgsrc);
@@ -2667,14 +2672,7 @@ function place_token_at_map_point(tokenObject, x, y) {
 		}
 	}
 
-	if(window.all_token_objects[options.id] !== undefined){
-		if(window.all_token_objects[options.id].options.ct_show !== undefined){
-			options = window.all_token_objects[options.id].options;
-		  	$(`#combat_area tr[data-target='${options.id}'] .findSVG`).remove();
-	       	let findSVG=$('<svg class="findSVG" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 11c1.33 0 4 .67 4 2v.16c-.97 1.12-2.4 1.84-4 1.84s-3.03-.72-4-1.84V13c0-1.33 2.67-2 4-2zm0-1c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm6 .2C18 6.57 15.35 4 12 4s-6 2.57-6 6.2c0 2.34 1.95 5.44 6 9.14 4.05-3.7 6-6.8 6-9.14zM12 2c4.2 0 8 3.22 8 8.2 0 3.32-2.67 7.25-8 11.8-5.33-4.55-8-8.48-8-11.8C4 5.22 7.8 2 12 2z"/></svg>');	
-	        $(`#combat_area tr[data-target='${options.id}'] .findTokenCombatButton`).append(findSVG);
-		}
-	}
+
 	
 	options.left = `${x - options.size/2}px`;
 	options.top = `${y - options.size/2}px`;

--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -640,12 +640,23 @@ function persist_token_customization(customization, callback) {
             callback(false, "Invalid Customization");
             return;
         }
-
+        customization.tokenOptions = Object.fromEntries(Object.entries(customization.tokenOptions).filter(([key, value]) => value != 'undefined'))
         let existingIndex = window.TOKEN_CUSTOMIZATIONS.findIndex(c => c.tokenType === customization.tokenType && c.id === customization.id);
         if (existingIndex >= 0) {
             window.TOKEN_CUSTOMIZATIONS[existingIndex] = customization;
         } else {
             window.TOKEN_CUSTOMIZATIONS.push(customization);
+        } 
+
+
+        if(customization.tokenType == 'pc'){
+            if(window.all_token_objects[customization.id])
+                window.all_token_objects[customization.id].options = {
+                    ...window.all_token_objects[customization.id].options,
+                    ...customization.tokenOptions,
+                    size: customization.tokenOptions.tokenSize * window.CURRENT_SCENE_DATA.hpps,
+                    gridSquares: customization.tokenOptions.tokenSize
+                }
         }
 
         // TODO: call the API with a single object instead of persisting everything

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -977,7 +977,7 @@ function create_and_place_token(listItem, hidden = undefined, specificImage= und
                 temp: 0
             };
             options.armorClass = pc.armorClass;
-            options.color = color_from_pc_object(pc);
+            options = {...options, ...find_token_options_for_list_item(listItem)}
             break;
         case ItemType.Monster:
             switch (options['defaultmaxhptype']) {
@@ -1652,6 +1652,9 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
     inputWrapper.append(imageScaleWrapper);
 
     // border color
+    if(listItem.isTypePC()){
+        customization.tokenOptions.color = color_from_pc_object(find_pc_by_player_id(listItem.id));
+    }
     const color = customization.tokenOptions.color || random_token_color();
     const borderColorWrapper = build_token_border_color_input(color, function (newColor, eventType) {
         customization.setTokenOption("color", newColor);
@@ -1669,7 +1672,10 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
         ],
         defaultValue: false
     };
+
+
     const specificBorderColorValue = (typeof customization.tokenOptions.color === "string" && customization.tokenOptions.color.length > 0);
+
     const borderColorToggle = build_toggle_input(specificBorderColorSetting, specificBorderColorValue, function (useSpecificColorKey, useSpecificColorValue) {
         if (useSpecificColorValue === true) {
             customization.setTokenOption("color", color);


### PR DESCRIPTION
Currently some customizations on player tokens don't set properly and are overridden by the syncing of player tokens. This should resolve that issue - the custom border should also update to the theme when a player changes their theme.