### PR TITLE
Beta fix - display projector button if already on when loading in, reverse setting order so it makes more sense in light settings

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2833,8 +2833,8 @@ function init_zoom_buttons() {
 		});
 		projector_toggle.append(`<div class="ddbc-tab-options__header-heading ddbc-tab-options__header-heading--is-active"><span style="font-size: 20px;" class="material-symbols-outlined">cast</span></div>`);
 		zoom_section.append(projector_toggle);
-		if (!get_avtt_setting_value("projector")) {
-			projector_toggle.toggleClass('enabled', false);
+		if (get_avtt_setting_value("projector")) {
+			projector_toggle.toggleClass('enabled', true);
 		}
 
 		const cursor_ruler_toggle = $(`<div id='cursor_ruler_toggle' class='ddbc-tab-options--layout-pill hasTooltip button-icon hideable' data-name='Send Cursor/Ruler To Players'></div>`);

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -410,11 +410,6 @@ function edit_scene_vision_settings(scene_id){
    	 	let darknessFilterRangeValue = parseInt(darknessFilterRange.val());
    	 	scene.darkness_filter = darknessFilterRangeValue;
 	});
-
-	form.append(form_row('darknessFilter',
-						'Line of Sight/Darkness Opacity',
-						darknessFilterRange)
-	);
 	form.append(form_row('disableSceneVision',
 			'Disable token vision/light',
 			form_toggle("disableSceneVision",null, false,  function(event) {
@@ -422,6 +417,12 @@ function edit_scene_vision_settings(scene_id){
 			})
 		)
 	);
+
+	form.append(form_row('darknessFilter',
+						'Line of Sight/Darkness Opacity',
+						darknessFilterRange)
+	);
+
 	form.find('#darknessFilter_row').attr('title', `This will darken the map by the percentage indicated. This filter interacts with light auras. Any light aura on the map will reveal the darkness. Fully opaque white light will completely eliminate the darkness in it's area.`)
 	darknessFilterRange.after(darknessNumberInput);
 


### PR DESCRIPTION
The projector button wasn't displaying if the setting was on when loading in. This fixes that.

Swapped the settings order in the light/vision settings so that darkness filter is right above the selectable previews - since they are linked.