### PR TITLE
Beta Fix - have locked coniditons per campaign, fix top right button order

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1155,7 +1155,7 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 		if (conditionName.startsWith("#")) {
 			let lockedConditions = {
 				[conditionName] : '',
-				...JSON.parse(localStorage.getItem("lockedConditions"))
+				...JSON.parse(localStorage.getItem(`lockedConditions.${window.gameId}`))
 			}
 			let colorItem = $(`<input type='text' placeholder='custom condition'></input>`);
 			tokens.every(token => {
@@ -1232,7 +1232,7 @@ function build_conditions_and_markers_flyout_menu(tokenIds) {
 				}
 
 
-				localStorage.setItem("lockedConditions", JSON.stringify(lockedConditions));
+				localStorage.setItem(`lockedConditions.${window.gameId}`, JSON.stringify(lockedConditions));
 			})
 
 			conditionItem.append(conditionLock);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1123,7 +1123,6 @@ div#scene_properties form > div {
     z-index: 57000;
     display: flex;
     flex-direction: row;
-    direction: rtl;
 }
 
 .condition-lock.material-symbols-outlined {


### PR DESCRIPTION
I accidently left in a rtl for the buttons and this adds a game id for lock conditions