### PR TITLE
Fix - remove sourcebook journal background so it can be minimized properly

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4313,6 +4313,14 @@ div#selectedTokensBorderRotationGrabberConnector,
 #combat_area tr{
     position: relative;
 }
+.resize_drag_window{
+    pointer-events:none;
+    background:none;
+}
+.resize_drag_window > *{
+    pointer-events:all;
+}
+
 
 #text_controller_title_bar,
 .text-input-title-bar,


### PR DESCRIPTION
Makes the background none and removes pointer events on the main window but adds them to the content.