### PR TITLE
QoL - ability to set unwanted player tokens or token folders as hidden.

### DIFF
--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1094,7 +1094,10 @@ function build_sidebar_list_row(listItem) {
 
   let row = $(`<div id="${listItem.id}" class="sidebar-list-item-row" title="${listItem.name}"></div>`);
   set_list_item_identifier(row, listItem);
-
+  
+  if (window.hiddenFolderItems.indexOf(listItem.id) > -1) {
+    row.toggleClass('hidden-sidebar-item', true);
+  }
   let rowItem = $(`<div class="sidebar-list-item-row-item"></div>`);
   row.append(rowItem);
   rowItem.on("click", did_click_row);
@@ -1902,7 +1905,9 @@ function disable_draggable_change_folder() {
       tokensPanel.body.removeClass("folder");
       tokensPanel.header.find("input[name='token-search']").show();
       tokensPanel.updateHeader("Tokens");
-      add_expand_collapse_buttons_to_header(tokensPanel);
+      
+      add_expand_collapse_buttons_to_header(tokensPanel, true);
+
       try {
         tokensPanel.body.find(".sidebar-list-item-row").draggable("destroy");
       } catch (e) {} // don't care if it fails, just try
@@ -1932,7 +1937,8 @@ function disable_draggable_change_folder() {
   }
 }
 
-function add_expand_collapse_buttons_to_header(sidebarPanel) {
+function add_expand_collapse_buttons_to_header(sidebarPanel, addHideButton=false) {
+
   let expandAll = $(`<button class="token-row-button expand-collapse-button" title="Expand All Folders" style=""><span class="material-icons">expand</span></button>`);
   expandAll.on("click", function (clickEvent) {
     $(clickEvent.target).closest(".sidebar-panel-content").find(".sidebar-panel-body .folder:not(.not-collapsible)").removeClass("collapsed");
@@ -1943,6 +1949,17 @@ function add_expand_collapse_buttons_to_header(sidebarPanel) {
   });
   let buttonWrapper = $("<div class='expand-collapse-wrapper'></div>");
   sidebarPanel.header.find(".sidebar-panel-header-title").append(buttonWrapper);
+  if(addHideButton){
+    let hideButton = $(`<button class="token-row-button reveal-hidden-button" title="Reveal hidden folders/tokens" style=""><span class="material-icons">disabled_visible</span></button>`);
+    hideButton.on("click", function (clickEvent) {
+      $(clickEvent.target).closest(".sidebar-panel-content").find(".sidebar-panel-body .hidden-sidebar-item").toggleClass("temporary-visible");
+      $(this).toggleClass('clicked');
+    });
+    if($('.temporary-visible').length>0){
+      $(hideButton).toggleClass('clicked', true);
+    }
+    buttonWrapper.append(hideButton);
+  }
   buttonWrapper.append(expandAll);
   buttonWrapper.append(collapseAll);
 }

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -491,6 +491,7 @@ async function init_tokens_panel() {
         SidebarListItem.Aoe("cone", 1, "acid"),
         SidebarListItem.Aoe("line", 1, "acid")
     ]
+    hiddenFolderItems = (JSON.parse(localStorage.getItem(`${window.gameId}.hiddenFolderItems`)) != null) ? JSON.parse(localStorage.getItem(`${window.gameId}.hiddenFolderItems`)) : [];
 
 
     if(localStorage.getItem('MyTokens') != null){
@@ -512,7 +513,8 @@ async function init_tokens_panel() {
     let header = tokensPanel.header;
     // TODO: remove this warning once tokens are saved in the cloud
     tokensPanel.updateHeader("Tokens");
-    add_expand_collapse_buttons_to_header(tokensPanel);
+    add_expand_collapse_buttons_to_header(tokensPanel, true);
+
     header.append("<div class='panel-warning'>WARNING/WORKINPROGRESS. THIS TOKEN LIBRARY IS CURRENTLY STORED IN YOUR BROWSER STORAGE. IF YOU DELETE YOUR HISTORY YOU LOSE YOUR LIBRARY</div>");
 
     let searchInput = $(`<input name="token-search" type="text" style="width:96%;margin:2%" placeholder="search tokens">`);
@@ -1295,6 +1297,7 @@ function register_token_row_context_menu() {
                 }
             };
 
+
             if (!rowItem.isTypeFolder() && !rowItem.isTypeEncounter()) {
                 // copy url doesn't make sense for folders
                 menuItems["copyUrl"] = {
@@ -1325,9 +1328,36 @@ function register_token_row_context_menu() {
                 };
             }
 
+            if(rowItem.isTypeFolder() || rowItem.isTypePC()){
+                menuItems["border"] = "---";
+
+                menuItems['Hide/Reveal'] = {
+                    name: (window.hiddenFolderItems.indexOf(rowItem.id) > -1) ? "Reveal in menu" : "Hide in menu",
+                    callback: function(itemKey, opt, originalEvent) {
+                        let itemToHide = find_sidebar_list_item(opt.$trigger);
+                    
+                        const index = window.hiddenFolderItems.indexOf(itemToHide.id);
+                        if (index > -1) { 
+                            window.hiddenFolderItems.splice(index, 1); 
+                        }
+                        else{
+                            window.hiddenFolderItems.push(itemToHide.id);
+                        }
+                           
+                        localStorage.setItem(`${window.gameId}.hiddenFolderItems`, JSON.stringify(window.hiddenFolderItems));
+                        let buttonClicked = $('.temporary-visible').length>0;
+                        redraw_token_list($('[name="token-search"]').val());
+                        if(buttonClicked){
+                            $('.sidebar-panel-body .hidden-sidebar-item').toggleClass('temporary-visible', true);
+                        }
+                    }
+                }
+            }
+
             if (rowItem.canDelete()) {
 
-                menuItems["border"] = "---";
+                if(!rowItem.isTypeFolder() && !rowItem.isTypeEncounter() && !rowItem.isTypePC())
+                    menuItems["border"] = "---";
 
                 // not a built in folder or token, add an option to delete
                 menuItems["delete"] = {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5858,6 +5858,18 @@ body.body-rpgcharacter-sheet #combat_area tr.CTToken:before{
     width: calc(100% - 80px);
 }
 
+.hidden-sidebar-item{
+    display: none !important;
+}
+
+.hidden-sidebar-item.temporary-visible{
+    display: block !important;
+}
+
+.reveal-hidden-button.clicked{
+    background: #F66;
+}
+
 .text-option{
     width:20px;
     height:20px;


### PR DESCRIPTION
Adds the ability to hide/reveal player tokens and token folder in the token panel. Adds the hide/reveal to the context menu and a button to temporarily reveal hidden ones at the top of the token panel.

I've been wanting to be able to hide player tokens for awhile since I run multiple groups in 1 game - this way I can hide all the other groups for that game.

It was also requested to be able to hide unused folders - like open5e etc.