### PR TITLE
Fix - issue with roll context menu being stuck open unless rolled for players

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -4232,9 +4232,6 @@ div#selectedTokensBorderRotationGrabberConnector,
     height: 100%;
 }
 
-.MuiModal-root{
-    pointer-events: none;
-}
 
 #VTT{
 	z-index:2;


### PR DESCRIPTION
Reported on discord players context roll menu gets stuck open unless you complete the roll.

https://discord.com/channels/815028457851191326/815028457851191329/1133253659845726362

I think awhile back ddb changed this to cover the sheet and it stopped us from clicking on anything. Seems to no longer behave that way and this solves the issue.