### PR TITLE
Fix - issue with new dropbox urls for those that have had it rolled onto their account

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -26,8 +26,10 @@ function parse_img(url) {
 		const parsed = 'https://drive.google.com/uc?id=' + retval.split('/')[5];
 		console.log("parse_img is converting", url, "to", parsed);
 		retval = parsed;
-	} else if (retval.includes("dropbox.com") && retval.includes("?dl=")) {
-		const parsed = retval.split("?dl=")[0] + "?raw=1";
+	} 
+	else if(retval.includes("dropbox.com")){
+		const splitUrl = url.split('dropbox.com');
+		const parsed = `https://dl.dropboxusercontent.com${splitUrl[splitUrl.length-1]}`
 		console.log("parse_img is converting", url, "to", parsed);
 		retval = parsed;
 	}


### PR DESCRIPTION
This should resolve the issue with the new dropbox url architecture. 



> Dropbox is moving to a new link architecture which centralizes links on content rather than on users. We'll refer to these "/scl" links as "new links" and the previous "/s" architecture as "legacy links".  Part of the new link architecture is the addition of an rlkey parameter.  It is this parameter which grants access to the content.  That is why removing that parameter results in visitors having to sign in and request access. 
> 


> We’ve paused our rollout to better understand this issue.  Since the issue appears to be with how the new link format is interacting with 3rd party applications, we need to understand these use cases more deeply. 

