### PR TITLE
Fix - issue with token reveal being checked before new LoS is drawn

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3765,6 +3765,8 @@ async function redraw_light(){
 	}
 	await Promise.all(promises);
 	context.drawImage(offscreenCanvasMask, 0, 0); // draw to visible canvas only once so we render this once
+	if(!window.DM)
+		check_token_visibility();
 }
 
 

--- a/Token.js
+++ b/Token.js
@@ -39,18 +39,15 @@ const availableToAoe = [
 
 
 
-const debounceLightChecks = mydebounce(async () => {		
+const debounceLightChecks = mydebounce(() => {		
 		if(window.DRAGGING)
 			return;
 		if(window.walls?.length < 5){
 			redraw_light_walls();	
 		}
 		//let promise = [new Promise (_ => setTimeout(redraw_light(), 1000))];
-		let promise = [redraw_light()];
-		if(!window.DM)
-			promise.push(check_token_visibility());
-		
-		await Promise.all(promise);
+		redraw_light();
+
 }, 500);
 
 


### PR DESCRIPTION
reported on discord that sometimes tokens aren't revealed until next move/reveal check.