### PR TITLE
QoL - make token ac bold for readability

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -1682,6 +1682,7 @@ div#combat_button{
 
 .token>.ac{
     pointer-events: none;
+    font-weight: 900;
 }
 
 .color-reminder {


### PR DESCRIPTION
Just makes the ac bold for readability.


![image](https://github.com/cyruzzo/AboveVTT/assets/65363489/f021cc39-79f2-4f89-bd39-61966cef4af0)
vs

![image](https://github.com/cyruzzo/AboveVTT/assets/65363489/a57c6eef-1b8e-43af-8a59-35f2cc4f4ea2)

