### PR TITLE
Fix - Issue of a previously paused track playing when another is paused in the mixer in some circumstances

### DIFF
--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -187,12 +187,11 @@ class Mixer extends EventTarget {
                 player.preload = "metadata";
                 this._players[id] = player;
             }
-            if(player.paused)
-                player.load();
+
             if (state.paused || channel.paused) {
                 player.pause();
             } else if (play) {        
-
+                player.load();
                 player.addEventListener("canplaythrough", (event) => {
                   /* the audio is now playable; play it if permissions allow */
                     // sync player


### PR DESCRIPTION
Steps to reproduce issue:

Play 1 track, play another simultaneously. Pause the first track. Pause the second track and the first track will start playing. 

Move the audio load to fix this.