### PR TITLE
Beta Fix - issue with custom stat blocks in the combat tracker

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -661,7 +661,7 @@ function ct_add_token(token,persist=true,disablerolling=false){
 		stat.click(function(){			
 			if(token.options.statBlock){
 				let customStatBlock = window.JOURNAL.notes[token.options.statBlock].text;
-				load_monster_stat(undefined, undefined, customStatBlock);
+				load_monster_stat(undefined, token.options.id, customStatBlock);
 				return;
 			}
 			load_monster_stat(token.options.monster, token.options.id);

--- a/StatHandler.js
+++ b/StatHandler.js
@@ -56,7 +56,7 @@ class StatHandler {
 		}
 		else if(monsterid =='customStat'){
 			let modifier = parseInt(window.TOKEN_OBJECTS[tokenId].options.customInit);
-			let expression = "1d20+" + modifier;
+			let expression = (!isNaN(modifier)) ? "1d20+" + modifier : '0';
 			let roll = new rpgDiceRoller.DiceRoll(expression);
 			console.log(expression + "->" + roll.total);
 			callback(roll.total);


### PR DESCRIPTION
Fixes an issue with the sheet when opened from the combat tracker not having the spellslot trackers since token id wasn't provided.

Fixes an issue where a token with a  custom stat block without initiative set couldn't be added to the combat tracker.