### PR TITLE
Fix - issue with tokens not being draggable when slower loads occur.

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1878,7 +1878,9 @@ class Token {
 				x: 0,
 				y: 0
 			};
-
+		 	if(window.moveOffscreenCanvasMask == undefined){
+		 		window.moveOffscreenCanvasMask = document.createElement('canvas');
+		 	}
 			let canvas = window.moveOffscreenCanvasMask;
 			let ctx = canvas.getContext("2d", { willReadFrequently: true });
 


### PR DESCRIPTION
Sometimes this offscreen canvas used for detecting moveable areas for players was undefined. Causing an error before tokens we're giving the draggable function.