### PR TITLE
QoL - Projector mode will now scroll to center of view instead of edge

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -47,7 +47,8 @@ $(function() {
           });
         }
         else if(event.data.msgType == 'projectionScroll' && event.data.sceneId == window.CURRENT_SCENE_DATA.id){
-          window.scroll(event.data.x, event.data.y);
+          let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
+          window.scroll(event.data.x - window.innerWidth/2 + sidebarSize/2, event.data.y - window.innerHeight/2);
         }
         else if(event.data.msgType == 'projectionZoom' && event.data.sceneId == window.CURRENT_SCENE_DATA.id){
           change_zoom(event.data.newZoom, event.data.x, event.data.y);

--- a/Startup.js
+++ b/Startup.js
@@ -13,11 +13,12 @@ $(function() {
     window.addEventListener("scroll", function(event) { // ddb has an scroll event listener on the character sheet where they add/remove classes and throttle the sheet scroll causing right click drag of the map to not be smooth
       event.stopImmediatePropagation();
       if($('#projector_toggle.enabled > [class*="is-active"]').length>0){
+            let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
             tabCommunicationChannel.postMessage({
               msgType: 'projectionScroll',
-              x: window.pageXOffset,
-              y: window.pageYOffset,
-              sceneId: window.CURRENT_SCENE_DATA.id
+              x: window.pageXOffset + window.innerWidth/2 - sidebarSize/2,
+              y: window.pageYOffset + window.innerHeight/2,
+              sceneId: window.CURRENT_SCENE_DATA.id,
             });
       }
     }, true);


### PR DESCRIPTION
when using projector mode on different resolution windows it would scroll to same scroll coordinates not the center. This adjusts it to scroll to the center of view no matter the resolution.