### PR TITLE
Beta Fix - issue with grid wizard controls on video maps

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1265,7 +1265,6 @@ function edit_scene_dialog(scene_id) {
 
 			$("#VTT").css("--scene-scale", 1)
 
-			$("#sources-import-main-container").remove();
 			$("#scene_selector").removeAttr("disabled");
 			$("#scene_selector_toggle").click();
 			$("#scene_selector_toggle").hide();


### PR DESCRIPTION
Some maps take longer to load, it's already replacing the data we don't need to remove the container.