### PR TITLE
Fix - Ensure overlay is removed so DM doesn't get stuck on 'Start up complete'

### DIFF
--- a/Startup.js
+++ b/Startup.js
@@ -161,6 +161,7 @@ async function start_above_vtt_for_dm() {
   did_update_scenes();
 
   startup_step("Start up complete");
+  remove_loading_overlay();
 }
 
 async function start_above_vtt_for_players() {


### PR DESCRIPTION
I've seen a few people stuck on ';start up complete' when joining as the DM. This is usually due to a map image request sending an error back. Getting them to manually remove the overlay then switch scenes fixes it so I'm forcing the overlay to be removed if it reaches that message.