### PR TITLE
Beta - Reduce the amount hexes get skewed per 'tick' of the slider to allow for more fine tune control

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -460,8 +460,8 @@ function open_grid_wizard_controls(scene_id, aligner1, aligner2, regrid=function
 		}
 		else{			
 			window.CURRENT_SCENE_DATA.scaleAdjustment = {
-				x: 1 + ($('#horizontalMinorAdjustmentInput').val()-50)/100,
-				y: 1 + ($('#verticalMinorAdjustmentInput').val()-50)/100
+				x: 1 + ($('#horizontalMinorAdjustmentInput').val()-50)/500,
+				y: 1 + ($('#verticalMinorAdjustmentInput').val()-50)/500
 			}	
 		}
 		moveAligners();
@@ -476,8 +476,8 @@ function open_grid_wizard_controls(scene_id, aligner1, aligner2, regrid=function
 		}
 		else{			
 			window.CURRENT_SCENE_DATA.scaleAdjustment = {
-				x: 1 + ($('#horizontalMinorAdjustmentInput').val()-50)/100,
-				y: 1 + ($('#verticalMinorAdjustmentInput').val()-50)/100
+				x: 1 + ($('#horizontalMinorAdjustmentInput').val()-50)/500,
+				y: 1 + ($('#verticalMinorAdjustmentInput').val()-50)/500
 			}	
 		}
 		moveAligners();


### PR DESCRIPTION
The skewing of hexgrids was a little too much per tick to get a good alignment when close. I think this brings it more inline with the square minor adjustments.