### PR TITLE
Beta fix - prevent infinite loop on jounal folder parent.

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -392,7 +392,11 @@ class JournalManager{
 					chapter_list.append(section_chapter);
 				}
 				else{		
-				let parentFolder = chapter_list.find(`.folder[data-id='${self.chapters[i].parentID}']`);
+					let parentFolder = chapter_list.find(`.folder[data-id='${self.chapters[i].parentID}']`);
+					let parentID = self.chapters[i]?.parentID
+					if(self.chapters[i].id == self.chapters.filter(d => d.id == parentID)[0].parentID){
+						delete self.chapters[i].parentID
+					}
 					if(parentFolder.length == 0){
 						self.chapters.splice(self.chapters.length-1, 0, self.chapters.splice(i, 1)[0]);
 						i -= 1; 


### PR DESCRIPTION
If quickly changing the folder structure somehow folders end up inside their parent each other causing an infinite loop looking for the parent folder. This prevents that - I'll look more into how it happens but this is a quick fix.