### PR TITLE
Beta - issue with clunky token reveal

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -4073,7 +4073,7 @@ async function redraw_light(){
 	context.drawImage(offscreenCanvasMask, 0, 0); // draw to visible canvas only once so we render this once
 	
 	if(!window.DM)
-		check_token_visibility();
+		do_check_token_visibility();
 }
 
 


### PR DESCRIPTION
Token reveal during light should always be checked. We should debounce light checks more if necessary instead.