### PR TITLE
Feat - Quick add PC npc links to a custom stat block so their sheet is opened. (Rolls still won't show up in game log unless they are in the campaign)

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -1138,6 +1138,7 @@ class JournalManager{
 			      { title: 'Average HP', inline: 'b',classes: 'custom-avghp custom-stat' },
 			      { title: 'HP Roll', inline: 'b', classes: 'custom-hp-roll custom-stat' },
 			      { title: 'Initiative', inline: 'b', classes: 'custom-initiative custom-stat' },
+			      { title: 'Custom PC Sheet Link', inline: 'b', classes: 'custom-pc-sheet custom-stat' }
 			   	]},
 			   	{ title: 'Statblock Seperator', block: 'div', wrapper: false, classes:'abovevtt-mon-stat-block__separator'}
 			],
@@ -1659,6 +1660,10 @@ class JournalManager{
 			      
 			      .custom-initiative.custom-stat{
 			      	color: #007900;
+			      }
+
+			      .custom-pc-sheet.custom-stat{
+			      	color: #08a1e3;
 			      }
 				  
 			      .custom-ac.custom-stat{

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -141,7 +141,14 @@ function token_context_menu_expanded(tokenIds, e) {
 			
 			button.click(function(){
 				let customStatBlock = window.JOURNAL.notes[token.options.statBlock].text;
-				load_monster_stat(undefined, token.options.id, customStatBlock)
+				let pcURL = $(customStatBlock).find('.custom-pc-sheet.custom-stat').text();
+				if(pcURL){
+					open_player_sheet(pcURL);
+				}else{
+					load_monster_stat(undefined, token.options.id, customStatBlock)
+				}
+
+				
 				close_token_context_menu();
 			});
 			if(token.options.player_owned || window.DM){

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3858,6 +3858,13 @@ div#importer_area>div>div:first-of-type {
     overflow-y: auto;
     flex: auto;
 }
+#token-configuration-modal .sidebar-panel-body{
+    min-height:300px;
+}
+#token-configuration-modal{
+    height: unset;
+}
+
 .tokens-panel-back-button {
     background-image: url(https://media-waterdeep.cursecdn.com/file-attachments/0/737/chevron-left-green.svg);
     background-repeat: no-repeat;


### PR DESCRIPTION
Add an option to quick add a pc sheet that's not in the campaign as a custom stat block.