### PR TITLE
Beta - pull non-campaign pc rolls into abovevtt and gamelog

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -36,9 +36,32 @@ $(function() {
       if(event.data.msgType == 'CharacterData' && !find_pc_by_player_id(event.data.characterId, false))
         return;
       if(event.data.msgType == 'roll'){
-        window.MB.inject_chat(event.data.msg);
+        if(window.EXPERIMENTAL_SETTINGS['rpgRoller']){
+           window.MB.inject_chat(event.data.msg);
+        }
+        else{
+          if(event.data.msg.sendTo == window.PLAYER_ID){
+            window.diceRoller.roll(new DiceRoll(
+              `${event.data.msg.rollData.expression}${event.data.msg.rollData.modifier}`,
+              event.data.msg.rollData.rollTitle,
+              event.data.msg.rollData.rollType,
+              event.data.msg.player,
+              event.data.msg.img,
+              "character",
+              event.data.msg.playerId
+            ));
+          }
+        }       
         return;
       }
+      if(event.data.msgType=='isAboveOpen'){
+        tabCommunicationChannel.postMessage({
+          msgType: 'setupObserver',
+          tab: window.PLAYER_ID
+        })
+        return;
+      }
+
       if(!window.DM){
         if(event.data.msgType == 'CharacterData'){
           window.MB.sendMessage("custom/myVTT/character-update", {
@@ -58,6 +81,17 @@ $(function() {
       else if(event.data.msgType == 'CharacterData'){
         update_pc_with_data(event.data.characterId, event.data.pcData);
       }
+    })
+  }
+  if(is_abovevtt_page()){
+    tabCommunicationChannel.postMessage({
+      msgType: 'setupObserver',
+      tab: window.PLAYER_ID
+    })
+  }
+  else{
+    tabCommunicationChannel.postMessage({
+      msgType: 'isAboveOpen'
     })
   }
 });

--- a/Main.js
+++ b/Main.js
@@ -8,6 +8,9 @@ window.onbeforeunload = function(event)
 		console.log("refreshing page, storing zoom first");
 		add_zoom_to_storage();
 		window.PeerManager.send(PeerEvent.goodbye());
+		tabCommunicationChannel.postMessage({
+      		msgType: 'removeObserver'
+    	})
 	}
 };
 
@@ -1701,7 +1704,7 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 	iframe.off("load").on("load", function(event) {
 		console.log("fixing up the character sheet");
 
-		observe_character_sheet_changes($(event.target).contents());
+	
 
 
 		let scripts = [
@@ -1738,6 +1741,8 @@ function open_player_sheet(sheet_url, closeIfOpen = true) {
 		    ($(event.target)[0].contentDocument.head || $(event.target)[0].contentDocument.documentElement).appendChild(s);
 		}
 		injectScript();
+
+		observe_character_sheet_changes($(event.target).contents());
 
 		$(event.target).contents().find("head").append(`
 			<style>


### PR DESCRIPTION
Example:
https://youtu.be/gG2SbYWOyWE

Prioritizes the DM view to roll in, when the vtt window is closed checks if another abovevtt window is still open, if not it should roll on the sheet normally again. 