### PR TITLE
Fix - Undoing a token delete should update the player view and sync to server

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -978,7 +978,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 			}, 500);
 		}
 
-		window.TOKEN_OBJECTS[id].place();
+		window.TOKEN_OBJECTS[id].place_sync_persist();
 		this.scene.hasTokens = true;
 	}
 


### PR DESCRIPTION
Currently undoing a token delete just places the token and doesn't update for players or on the server. This fixes that.