### PR TITLE
Fix - AoE tokens should be able to be locked, player restricted and reveal in fog

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -30,9 +30,11 @@ const TOKEN_COLORS = ["1A6AFF", "FF7433", "1E50DC", "FFD433", "884DFF", "5F0404"
 
 const availableToAoe = [
 	"hidden",
-	"locked",  // not sure why you'd want this, but it doesn't hurt to support it
+	"locked", 
 	"restrictPlayerMove",
-	"revealname"
+	"revealname",
+	"revealInFog",
+	"lockRestrictDrop"
 ];
 
 


### PR DESCRIPTION
I never added this settings to the list when they probably should have been.