### PR TITLE
QoL - Display first custom image in listing when set; Fix - Deleting custom images from open5e monsters with context menu;

### DIFF
--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -1105,7 +1105,9 @@ function build_sidebar_list_row(listItem) {
   let imgHolder = $(`<div class="sidebar-list-item-row-img"></div>`);
   rowItem.append(imgHolder);
   if (listItem.type !== "aoe"){
-    let img = $(`<img src="${parse_img(listItem.image)}" alt="${listItem.name} image" class="token-image" />`);
+    let tokenCustomizations = find_token_customization(listItem.type, listItem.id);
+    let listingImage = (tokenCustomizations?.tokenOptions?.alternativeImages && tokenCustomizations.tokenOptions?.alternativeImages[0] != undefined) ? tokenCustomizations.tokenOptions?.alternativeImages[0] : listItem.image; 
+    let img = $(`<img src="${parse_img(listingImage)}" alt="${listItem.name} image" class="token-image" />`);
     imgHolder.append(img);
   }
   else{

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1685,6 +1685,8 @@ function display_token_configuration_modal(listItem, placedToken = undefined) {
         persist_token_customization(customization);
         if (redraw) {
             redraw_token_images_in_modal(sidebarPanel, listItem, placedToken);
+            let listingImage = (customization.tokenOptions?.alternativeImages && customization.tokenOptions?.alternativeImages[0] != undefined) ? customization.tokenOptions?.alternativeImages[0] : listItem.image;     
+            $(`#${listItem.id}.sidebar-list-item-row .token-image`).attr('src', listingImage);
         } else {
             sidebarPanel.body.append(build_token_div_for_sidebar_modal(newImageUrl, listItem, placedToken));
         }
@@ -2752,7 +2754,7 @@ function register_custom_token_image_context_menu() {
                             placedToken.place_sync_persist();
                         }
 
-                        if (listItem?.isTypeMyToken() || listItem?.isTypeMonster() || listItem?.isTypePC()) {
+                        if (listItem?.isTypeMyToken() || listItem?.isTypeMonster() || listItem?.isTypePC() || listItem?.isTypeOpen5eMonster()) {
                             let customization = find_token_customization(listItem.type, listItem.id);
                             if (!customization) {
                                 showError("register_custom_token_image_context_menu Remove failed to find a token customization object matching listItem: ", listItem);
@@ -2760,6 +2762,8 @@ function register_custom_token_image_context_menu() {
                             }
                             customization.removeAlternativeImage(imgSrc);
                             persist_token_customization(customization);
+                            let listingImage = (customization.tokenOptions?.alternativeImages && customization.tokenOptions?.alternativeImages[0] != undefined) ? customization.tokenOptions?.alternativeImages[0] : listItem.image;     
+                            $(`#${listItem.id}.sidebar-list-item-row .token-image`).attr('src', listingImage);
                             redraw_token_images_in_modal(window.current_sidebar_modal, listItem, placedToken);
                         } else {
                             showError("register_custom_token_image_context_menu Remove attempted to remove a custom image with an invalid type. listItem:", listItem);
@@ -2767,7 +2771,7 @@ function register_custom_token_image_context_menu() {
                         }
                         selectedItem.remove();
                     }
-                };
+                };  
             }
             return { items: items };
         }


### PR DESCRIPTION
When a custom image is set lets show it in the token panel. 

Also fixes an error on trying to delete a single token image if it's a open5e monster.