### PR TITLE
QoL - loading indicator for UVTT maps; Beta Fix - prevent double load of grid wizard on uvtt maps.

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1350,6 +1350,7 @@ class MessageBroker {
 
 		let old_src = $("#scene_map").attr('src');
 		if(data.UVTTFile == 1){
+			build_import_loading_indicator("Loading UVTT Map");
 			data.map = await get_map_from_uvtt_file(data.player_map);
 		}
 
@@ -1472,7 +1473,7 @@ class MessageBroker {
 				update_pc_token_rows();
 				console.groupEnd()
 			});
-				
+			$('.import-loading-indicator').remove();
 			remove_loading_overlay();
 		}
 		// console.groupEnd()

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -1359,7 +1359,9 @@ function edit_scene_dialog(scene_id) {
 				drawings:[],
 				tokens: {}
 			}
-
+			if(sceneData.UVTTFile==1){
+				container.append(build_combat_tracker_loading_indicator('One moment while we load the UVTT File'));
+			}
 			window.ScenesHandler.scenes[scene_id] = sceneData;
 
 


### PR DESCRIPTION
UVTT maps can take awhile to load and sometimes look like the extensions has crashed. This gives an indicator that it's still loading. 

Also add a loading indicator to uvtt grid wizard as it doesn't look like it's loading when first pressing the button. Clicking it again breaks the wizard - this prevents the 2nd click and lets the user know it's working.