### PR TITLE
Fix - make sure playerid doesn't ever include url query string.

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -337,7 +337,7 @@ function convertToRPGRoller(){
    
     let urlSplit = window.location.href.split("/");
     if(urlSplit.length > 0) {
-      window.PLAYER_ID = urlSplit[urlSplit.length - 1];
+      window.PLAYER_ID = urlSplit[urlSplit.length - 1].split('?')[0];
     }
     $(`.integrated-dice__container:not('.above-aoe')`).off('contextmenu.rpg-roller').on('contextmenu.rpg-roller', function(e){
           e.stopPropagation();

--- a/Main.js
+++ b/Main.js
@@ -315,7 +315,7 @@ function getPlayerIDFromSheet(sheet_url) {
 	if(sheet_url) {
 		let urlSplit = sheet_url.split("/");
 		if(urlSplit.length > 0) {
-			playerID = urlSplit[urlSplit.length - 1];
+			playerID = urlSplit[urlSplit.length - 1].split('?')[0];
 		}
 	}
 	return playerID;


### PR DESCRIPTION
player id sometimes was getting ?abovevtt=true as part of it on refresh. This breaks at least the peer sharing of rulers/cursor.