### PR TITLE
Fix - light bucket fill shouldn't extend past walls (stroke width should be 1)

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3851,7 +3851,7 @@ function particleLook(ctx, walls, lightRadius=100000, fog=false, fogStyle, fogTy
 					clearPolygon(ctx, lightPolygon, undefined, true);
 					drawPolygon(ctx, lightPolygon, fogStyle, undefined, undefined, undefined, undefined, undefined, true);
 				}
-				drawPolygon(ctx, lightPolygon, fogStyle, undefined, undefined, undefined, undefined, undefined, undefined, true);
+				drawPolygon(ctx, lightPolygon, fogStyle, undefined, 1, undefined, undefined, undefined, undefined, true);
 			}
 		}
 	}


### PR DESCRIPTION
Light bucket fill was extending past walls. This should resolve that.