### PR TITLE
Fix - right click rolls when capturing from other tabs

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -320,7 +320,7 @@ function init_characters_pages(container = $(document)) {
     tabCommunicationChannel.postMessage({
       msgType: 'isAboveOpen'
     })
-  
+    window.diceRoller = new DiceRoller(); 
   }
 }
 


### PR DESCRIPTION
Right click isn't captured due to not having a window.diceRoller - this resolves that.