### PR TITLE
QoL - players should be able to see their own stats in the right click no matter the settings hiding hp/ac

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -974,7 +974,7 @@ function build_menu_stat_inputs(tokenIds) {
 	let ac = '';
 	let elev = '';
 
-	if(tokens.length == 1 && ((tokens[0].options.player_owned && !tokens[0].options.disablestat) || (!tokens[0].options.hidestat && tokens[0].isPlayer() && !tokens[0].options.disablestat) || window.DM)){
+	if(tokens.length == 1 && ((tokens[0].options.player_owned && !tokens[0].options.disablestat) || (!tokens[0].options.hidestat && tokens[0].isPlayer() && !tokens[0].options.disablestat) || tokens[0].options.id.includes(window.PLAYER_ID) || window.window.DM)){
 		hp = tokens[0].hp;
 		max_hp = tokens[0].maxHp;
 		ac = tokens[0].ac;


### PR DESCRIPTION
Currently when hp/ac is disabled players don't get their own hp/ac in the token menu. This only allows it to show for their own token - still giving the option for people to hide other pcs for more gritty games where that isn't known.