### PR TITLE
QoL - chat rolls allow d6, d8 etc. Add invalid roll msg.

### DIFF
--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5663,6 +5663,12 @@ input.max_hp[disabled]{
    content: "\e413"; 
 }
 
+.invalidExpression:before{
+    content: attr(data-content);
+    display: block;
+    position: relative;
+    top: 0;
+}
 
 #conditions-flyout li{
     font-size: 14px;


### PR DESCRIPTION
Allows d6 d8 etc in roll formulas. Automatically add 1's in front. 

Adds a message letting users know the roll was invalid and to hover for roll formats.