### PR TITLE
Fix - issue with google drive images failing to load.

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -758,8 +758,8 @@ async function normalize_scene_urls(scenes) {
   return scenesArray;
 }
 
-const throttleGoogleApi = throttledQueue(5, 10000);
-const throttleImage = throttledQueue(10, 10000);
+const throttleGoogleApi = throttledQueue(2, 6000, true);
+const throttleImage = throttledQueue(10, 1000, true);
 
 function throttledQueue(
   maxRequestsPerInterval,

--- a/Main.js
+++ b/Main.js
@@ -32,9 +32,9 @@ async function parse_img(url) {
 			const parsed = 'https://drive.google.com/uc?id=' + retval.split('/')[5];
 			console.log("parse_img is converting", url, "to", parsed);
 			retval = parsed;
-			return await throttleImage(() => {
-				return Promise.resolve(retval);
-			})
+			retval = await getGoogleDriveAPILink(retval)	
+			return Promise.resolve(retval);
+			
 		} 
 		else if(retval.includes("dropbox.com")){
 			const splitUrl = url.split('dropbox.com');


### PR DESCRIPTION
Move all google images to the google drive api - as the images using it appear to be loading properly. Throttle may need to be adjusted to prevent rate limit issues.