### PR TITLE
Auto center on Next token in Combat

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -261,6 +261,9 @@ function init_combat_tracker(){
 				$("[data-current] button.openSheetCombatButton").click();
 			}
 			let newTarget=$("#combat_area tr[data-current=1]").attr('data-target');
+			window.TOKEN_OBJECTS[newTarget].highlight(!get_avtt_setting_value("highlightScrolling"));
+			window.MB.sendMessage("custom/myVTT/highlight", {id: newTarget});
+			
 			if(window.TOKEN_OBJECTS[currentTarget] != undefined){
 				delete window.TOKEN_OBJECTS[currentTarget].options.current;
 				delete window.TOKEN_OBJECTS[currentTarget].options.round;
@@ -451,9 +454,9 @@ function ct_add_token(token,persist=true,disablerolling=false){
 	if(token.options.stat)
 		entry.attr('data-stat', token.options.stat)
 
-
+	
 	let video = false;
-
+	
 	if(['.mp4', '.webm','.m4v'].some(d => token.options.imgsrc.includes(d))){
 		img = $("<video disableRemotePlayback muted width=35 height=35 class='Avatar_AvatarPortrait__2dP8u'>");
 		video = true;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -595,7 +595,7 @@ class MessageBroker {
 			}
 			if (msg.eventType == "custom/myVTT/highlight") {
 				if (msg.data.id in window.TOKEN_OBJECTS) {
-					window.TOKEN_OBJECTS[msg.data.id].highlight(true);
+					window.TOKEN_OBJECTS[msg.data.id].highlight(!get_avtt_setting_value("highlightScrolling"));
 				}
 			}
 			if (msg.eventType == "custom/myVTT/pointer") {
@@ -1227,7 +1227,7 @@ class MessageBroker {
 		//Security logic to prevent content being sent which can execute JavaScript.
 		data.player = DOMPurify.sanitize( data.player,{ALLOWED_TAGS: []});
 		data.img = DOMPurify.sanitize( data.img,{ALLOWED_TAGS: []});
-		data.text = DOMPurify.sanitize( data.text,{ALLOWED_TAGS: ['video','img','div','p', 'b', 'button', 'span', 'style', 'path', 'svg', 'a'], ADD_ATTR: ['target']}); //This array needs to include all HTML elements the extension sends via chat.
+		data.text = DOMPurify.sanitize( data.text,{ALLOWED_TAGS: ['img','div','p', 'b', 'button', 'span', 'style', 'path', 'svg', 'a'], ADD_ATTR: ['target']}); //This array needs to include all HTML elements the extension sends via chat.
 
 		if(data.dmonly && !(window.DM) && !local) // /dmroll only for DM of or the user who initiated it
 			return $("<div/>");
@@ -1842,47 +1842,26 @@ class MessageBroker {
 
 	reconnectDisconnectedAboveWs(){
 		if (this.abovews.readyState != this.abovews.OPEN && !this.loadingAboveWS){
-			if(window.reconnectAttemptAbovews == undefined){
-				window.reconnectAttemptAbovews = 0;
-			}
-
-		
-			window.reconnectAttemptAbovews++;
-			if(window.reconnectAttemptAbovews > 5)
-				return;
-
-			if(window.reconnectAttemptAbovews < 5){
-				let msgdata = {
+			let msgdata = {
 					player: window.PLAYER_NAME,
 					img: window.PLAYER_IMG,
 					text: "You have disconnected from the AboveVTT websocket. Attempting to reconnect!",
 					whisper: window.PLAYER_NAME
-				};
-				this.inject_chat(msgdata);	
-				this.loadAboveWS(function(){ 
-					setTimeout(
-						function(){
-							let msgdata = {
-									player: window.PLAYER_NAME,
-									img: window.PLAYER_IMG,
-									text: `${window.PLAYER_NAME} has reconnected.`
-							};
+			};
+			this.inject_chat(msgdata);	
+			this.loadAboveWS(function(){ 
+				setTimeout(
+					function(){
+						let msgdata = {
+								player: window.PLAYER_NAME,
+								img: window.PLAYER_IMG,
+								text: `${window.PLAYER_NAME} has reconnected.`
+						};
 
-							window.MB.inject_chat(msgdata);
-						}, 4000)
-					}
-				);
-			}
-			else {
-				let msgdata = {
-					player: window.PLAYER_NAME,
-					img: window.PLAYER_IMG,
-					text: `<span><p>You have disconnected from the AboveVTT websocket 5 times. It is likely you are experiencing connection issues. </p><p>Reconnect messages/forced reconnect will be disabled until refresh.</p><p>This could be caused by a VPN, anti-tracker, adblocker, firewall, school/work network settings, or other extention/program.</p></span>`,
-					whisper: window.PLAYER_NAME
-				};
-				this.inject_chat(msgdata);
-			}
-					
+						window.MB.inject_chat(msgdata);
+					}, 4000)
+				}
+			);		
 		}
 	}
 }

--- a/Settings.js
+++ b/Settings.js
@@ -306,6 +306,17 @@ function avtt_settings() {
 			],
 			defaultValue: false
 		}
+		,
+		{
+			name: "highlightScrolling",
+			label: "Allow Scrolling to Highlighted Token",
+			type: "toggle",
+			options: [
+				{ value: true, label: "Allow", description: `When a token is highlighted, it center the screen on that token` },
+				{ value: false, label: "Never", description: `When a token is highlighted, it will keep your screen settings as is` }
+			],
+			defaultValue: true
+		}
 	];
 
 	if (window.DM) {


### PR DESCRIPTION
this pull request is for https://github.com/cyruzzo/AboveVTT/issues/1141
This also enables a setting for the user to want to have the scene move to different tokens on highlight, as well as adding that setting to the highlight message, and sending that message to the players once the DM hits the next button on the combat tracker

the only changes i made are: 
combat tracker, lines 264, 265, 266
message Broker, lines 598
Settings: 309 - 319