### PR TITLE
Remove one drive button from audio tab - due to issues with one drive rolling everyone onto sharepoint servers.

### DIFF
--- a/audio/ui.js
+++ b/audio/ui.js
@@ -596,7 +596,7 @@ function init_trackLibrary() {
     });
     trackLibrary.dispatchEvent(new Event('onchange'));
 
-    $("#sounds-panel .sidebar-panel-body").append(header, searchTrackLibary, dropBoxbutton, oneDriveButton, importCSV, addTrack, importTrackFields, trackList);
+    $("#sounds-panel .sidebar-panel-body").append(header, searchTrackLibary, dropBoxbutton, importCSV, addTrack, importTrackFields, trackList);
 }
 
 function init() {


### PR DESCRIPTION
I just removed the button for now, hopefully they will make it possible to use this again for audio.