### PR TITLE
Bloodied Health Aura Style

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -37,6 +37,7 @@ function token_setting_options() {
 			type: 'dropdown',
 			options: [
 				{ value: "aura", label: "Aura", description: "Tokens will have a colored aura" },
+				{ value: "aura-bloodied-50", label: "Bloodied 50", description: "Tokens will have a red aura when bloodied" },				
 				{ value: "bar", label: "HP Meter", description: "How this meter is displayed depends on token type. Color blind alternative to auras." },
 				{ value: "none", label: "None", description: "Tokens will not have a health visual" }
 			],

--- a/Token.js
+++ b/Token.js
@@ -815,7 +815,6 @@ class Token {
 		}
 
 		const tokenHpAuraColor = token_health_aura(this.hpPercentage, this.options.healthauratype);
-		console.log("AURCOLOR", tokenHpAuraColor);
 		let tokenWidth =  this.sizeWidth();
 		let tokenHeight = this.sizeHeight();
 		

--- a/Token.js
+++ b/Token.js
@@ -804,6 +804,9 @@ class Token {
 			} else if(this.options.healthauratype == "aura"){
 				this.options.disableaura = false;
 				this.options.enablepercenthpbar = false;
+			} else if(this.options.healthauratype.startsWith("aura-bloodied-")){
+				this.options.disableaura = false;
+				this.options.enablepercenthpbar = false;
 			}
 		}
 
@@ -811,7 +814,8 @@ class Token {
 			token.css('--hp-percentage', `${this.hpPercentage}%`);
 		}
 
-		const tokenHpAuraColor = token_health_aura(this.hpPercentage);
+		const tokenHpAuraColor = token_health_aura(this.hpPercentage, this.options.healthauratype);
+		console.log("AURCOLOR", tokenHpAuraColor);
 		let tokenWidth =  this.sizeWidth();
 		let tokenHeight = this.sizeHeight();
 		
@@ -3581,7 +3585,7 @@ function deselect_all_tokens() {
    	}
 }
 
-function token_health_aura(hpPercentage) {
+function token_health_aura(hpPercentage, auraType) {
 	//PERC TO RGB------------
 	const percentToHEX = function (percent) {
 		let HEX;
@@ -3614,7 +3618,7 @@ function token_health_aura(hpPercentage) {
 		let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
 		return result ? `rgb(${pHex(result[1])} ${pHex(result[2])} ${pHex(result[3])} / 60%)` : null;
 	}
-	return hexToRGB(percentToHEX(hpPercentage));
+	return auraType.startsWith('aura-bloodied-') ? ((hpPercentage > parseInt(auraType.split('-')[2])) ? "rgb(0 0 0 / 0%)" : "rgb(255 0 0 / 60%)") : hexToRGB(percentToHEX(hpPercentage));
 }
 
 function setTokenAudio(tokenOnMap, token){

--- a/Token.js
+++ b/Token.js
@@ -804,7 +804,7 @@ class Token {
 			} else if(this.options.healthauratype == "aura"){
 				this.options.disableaura = false;
 				this.options.enablepercenthpbar = false;
-			} else if(this.options.healthauratype.startsWith("aura-bloodied-")){
+			} else if(this.options.healthauratype && this.options.healthauratype.startsWith("aura-bloodied-")){
 				this.options.disableaura = false;
 				this.options.enablepercenthpbar = false;
 			}
@@ -3618,7 +3618,7 @@ function token_health_aura(hpPercentage, auraType) {
 		let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
 		return result ? `rgb(${pHex(result[1])} ${pHex(result[2])} ${pHex(result[3])} / 60%)` : null;
 	}
-	return auraType.startsWith('aura-bloodied-') ? ((hpPercentage > parseInt(auraType.split('-')[2])) ? "rgb(0 0 0 / 0%)" : "rgb(255 0 0 / 60%)") : hexToRGB(percentToHEX(hpPercentage));
+	return (auraType && auraType.startsWith('aura-bloodied-')) ? ((hpPercentage > parseInt(auraType.split('-')[2])) ? "rgb(0 0 0 / 0%)" : "rgb(255 0 0 / 60%)") : hexToRGB(percentToHEX(hpPercentage));
 }
 
 function setTokenAudio(tokenOnMap, token){


### PR DESCRIPTION
Add "Bloodied" option for token health aura style.
Draws the red ring only if HP < 50%
Could enable other percentages pretty easily by adding to options menu