### PR TITLE
fix: remember labelX and labelY to avoid label jump on mouse up

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -251,15 +251,13 @@ class WaypointManagerClass {
 	}
 
 	/**
-	* Draw the waypoints, note that we sum up the cumulative distance, midlineLabels is true for token drag
-	* as otherwise the token sits on the measurement label
-	* @param midlineLabels {boolean} always false
+	* Draw the waypoints, note that we sum up the cumulative distance
 	* @param labelX {number | undefined} if provided, move last text of last waypoint there
 	* @param labelY {number | undefined} if provided, move last text of last waypoint there
 	* @param alpha {number | undefined} set alpha of drawings to this, 1 if unset
 	* @param playerId {string | false | undefined} `window.PLAYER_ID` if unset
 	*/
-	draw(midlineLabels, labelX, labelY, alpha = 1, playerId=window.PLAYER_ID) {
+	draw(labelX = undefined, labelY = undefined, alpha = 1, playerId=window.PLAYER_ID) {
 		const rulerContainer = this.getOrCreateDrawingContainer(playerId);
 
 		// update alpha for the entire container
@@ -275,9 +273,9 @@ class WaypointManagerClass {
 			// drawn over the labels...
 			this.ctx.beginPath();
 			if (i < this.coords.length - 1) {
-				elementsToDraw += this.makeWaypointSegment(this.coords[i], cumulativeDistance, midlineLabels, undefined, undefined, sceneMapSize);
+				elementsToDraw += this.makeWaypointSegment(this.coords[i], cumulativeDistance, undefined, undefined, sceneMapSize);
 			} else {
-				elementsToDraw += this.makeWaypointSegment(this.coords[i], cumulativeDistance, midlineLabels, labelX, labelY, sceneMapSize);
+				elementsToDraw += this.makeWaypointSegment(this.coords[i], cumulativeDistance, labelX, labelY, sceneMapSize);
 			}
 			cumulativeDistance += this.coords[i].distance
 		}
@@ -289,13 +287,12 @@ class WaypointManagerClass {
 	* Make a waypoint segment SVGs with all the lines and labels etc.
 	* @param coord {{startX: number, startY: number, endX: number, endY: number, distance: number}}
 	* @param cumulativeDistance {number}
-	* @param midlineLabels {boolean}
 	* @param labelX {number}
 	* @param labelY {number}
 	* @param sceneMapSize {{sceneHeight: number, sceneWidth: number}}
 	* @returns {string} SVG elements for waypoint line and label
 	*/
-	makeWaypointSegment(coord, cumulativeDistance, midlineLabels, labelX, labelY, sceneMapSize) {
+	makeWaypointSegment(coord, cumulativeDistance, labelX, labelY, sceneMapSize) {
 		// Snap to centre of current grid square
 		let gridSize =  window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
 		let snapPointXStart = coord.startX;
@@ -361,30 +358,10 @@ class WaypointManagerClass {
 		let text = `${totalDistance}${unitSymbol}`
 		let textMetrics = this.ctx.measureText(text);
 
-		// Calculate our positions and dmensions based on if we are measuring (midlineLabels == false) or
-		// token dragging (midlineLabels == true)
 		let contrastRect = { x: 0, y: 0, width: 0, height: 0 }
 		let textRect = { x: 0, y: 0, width: 0, height: 0 }
 
-		if (midlineLabels === true) {
-
-			// Calculate our coords and dimensions
-			textX = (snapPointXStart + snapPointXEnd) / 2;
-			textY = (snapPointYStart + snapPointYEnd) / 2;
-
-			contrastRect.x = textX - margin;
-			contrastRect.y = textY - margin;
-			contrastRect.width = textMetrics.width + (margin * 4);
-			contrastRect.height = heightOffset + (margin * 3);
-
-			textRect.x = textX;
-			textRect.y = textY;
-			textRect.width = textMetrics.width + (margin * 3);
-			textRect.height = heightOffset + margin;
-
-			// Knock the text down slightly
-			textY += (margin * 2);
-		} else if (labelX !== undefined && labelY !== undefined) {
+		if (labelX !== undefined && labelY !== undefined) {
 
 			// Calculate our coords and dimensions
 			contrastRect.x = labelX - margin + slopeModifier;
@@ -501,7 +478,7 @@ class WaypointManagerClass {
 
 			self.ctx.clearRect(0,0, self.canvas.width, self.canvas.height);
 			self.ctx.globalAlpha = alpha;
-			self.draw(false, undefined, undefined, alpha, window.PLAYER_ID)
+			self.draw(undefined, undefined, alpha, window.PLAYER_ID)
 			alpha = alpha - (0.08 * deltaTime / 100); // 0.08 per 100 ms
 			if (alpha <= 0.0) {
 				self.clearWaypoints();
@@ -2475,7 +2452,7 @@ function drawing_mousemove(e) {
 					WaypointManager.cancelFadeout()
 					WaypointManager.registerMouseMove(mouseX, mouseY);
 					WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX/window.CURRENT_SCENE_DATA.scale_factor, window.BEGIN_MOUSEY/window.CURRENT_SCENE_DATA.scale_factor, mouseX/window.CURRENT_SCENE_DATA.scale_factor, mouseY/window.CURRENT_SCENE_DATA.scale_factor);
-					WaypointManager.draw(false);
+					WaypointManager.draw();
 					window.temp_context.fillStyle = '#f50';
 					sendRulerPositionToPeers();
 				}

--- a/Fog.js
+++ b/Fog.js
@@ -155,8 +155,13 @@ class WaypointManagerClass {
 		}
 	}
 
-	// Draw a nice circle
-	drawBobble(x, y, radius, playerId) {
+	/**
+	* Draw a nice circle
+	* @param x {number}
+	* @param y {number}
+	* @returns {string} <circle> tag
+	*/
+	makeBobble(x, y) {
 		/*
 		this.ctx.beginPath();
 		this.ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
@@ -166,10 +171,7 @@ class WaypointManagerClass {
 		this.ctx.fillStyle =  this.drawStyle.color
 		this.ctx.fill();
 		*/
-		let existingBobbles = $(`.ruler-svg-bobbles[data-player-id='${playerId}']`).html();
-	    let newBobble = `<circle cx='${x}' cy='${y}' fill='${this.drawStyle.color}' stroke='${this.drawStyle.outlineColor}'>`;
-	    $(`.ruler-svg-bobbles[data-player-id='${playerId}']`).html(existingBobbles + newBobble);
-
+	    return `<circle cx='${x}px' cy='${y}px' fill='${this.drawStyle.color}' stroke='${this.drawStyle.outlineColor}'></circle>`;
 	}
 
 	// Increment the current index into the array of waypoints, and draw a small indicator
@@ -396,39 +398,53 @@ class WaypointManagerClass {
 		this.ctx.fillStyle = this.drawStyle.textColor
 		this.ctx.textBaseline = 'top';
 		this.ctx.fillText(text, textX, textY);*/
-		let sceneWidth = Math.floor($('#scene_map').width());
-		let sceneHeight = Math.floor($('#scene_map').height());
+		
+		const sceneMap = $('#scene_map');
+		const sceneWidth = Math.floor(sceneMap.width());
+		const sceneHeight = Math.floor(sceneMap.height());
 
+		const vtt = $('#VTT');
 
+		// add ruler line and text
 		let rulerLineSVG = $(`
 			<svg data-player-id='${playerId}' viewbox='0 0 ${sceneWidth} ${sceneHeight}' width='${sceneWidth}' height='${sceneHeight}' class='ruler-svg-line' style='top:0px; left:0px;'>
-			<line x1='${snapPointXStart}' y1='${snapPointYStart}' x2='${snapPointXEnd}' y2='${snapPointYEnd}' stroke="${this.drawStyle.outlineColor}"/>
-			<line x1='${snapPointXStart}' y1='${snapPointYStart}' x2='${snapPointXEnd}' y2='${snapPointYEnd}' stroke="${this.drawStyle.color}"/>
-
+				<line x1='${snapPointXStart}' y1='${snapPointYStart}' x2='${snapPointXEnd}' y2='${snapPointYEnd}' stroke="${this.drawStyle.outlineColor}"/>
+				<line x1='${snapPointXStart}' y1='${snapPointYStart}' x2='${snapPointXEnd}' y2='${snapPointYEnd}' stroke="${this.drawStyle.color}"/>
 			</svg>
-		`)
-
-		let rulerBobbleSVG = $(`
-			<svg data-player-id='${playerId}' viewbox='0 0 ${sceneWidth} ${sceneHeight}' width='${sceneWidth}' height='${sceneHeight}' class='ruler-svg-bobbles' style='top:0px; left:0px;'>
-			</svg>
-		`)
-
-
+		`);
 		let textSVG = $(`
 			<svg data-player-id='${playerId}' class='ruler-svg-text' style='top:${textY*window.CURRENT_SCENE_DATA.scale_factor}px; left:${textX*window.CURRENT_SCENE_DATA.scale_factor}px; width:${textRect.width}px;'>
 				<text x="1" y="11">
 					${text}
 				</text>
-			</svg>`)
-		$('#VTT').append(rulerLineSVG)	
-		$('#VTT').append(textSVG)
+			</svg>`
+		);
+		vtt.append(
+			rulerLineSVG,
+			textSVG
+		)	
 
-		if($(`.ruler-svg-bobbles[data-player-id='${playerId}]'`).length == 0){
-			$('#VTT').append(rulerBobbleSVG)
+		// add player bobble container if there isn't one
+		let playerBobbleContainer = $(`.ruler-svg-bobbles[data-player-id='${playerId}']`)
+		if (playerBobbleContainer.length === 0) {
+			let rulerBobbleContainerSvg = $(`
+				<svg data-player-id='${playerId}' viewbox='0 0 ${sceneWidth} ${sceneHeight}' width='${sceneWidth}' height='${sceneHeight}' class='ruler-svg-bobbles' style='top:0px; left:0px;'>
+				</svg>
+			`)
+			vtt.append(rulerBobbleContainerSvg)
+			
+			// re-query the container now that it has been added
+            playerBobbleContainer = $(`.ruler-svg-bobbles[data-player-id='${playerId}']`)
 		}
+		
+		// add bobbles to the container
+		playerBobbleContainer.append(
+			this.makeBobble(snapPointXStart, snapPointYStart),
+			this.makeBobble(snapPointXEnd, snapPointYEnd)
+		);
+
+		// update alpha of all added svgs 
 		$(`svg[data-player-id='${playerId}']`).css('--svg-text-alpha', alpha);
-		this.drawBobble(snapPointXStart, snapPointYStart, undefined, playerId);
-		this.drawBobble(snapPointXEnd, snapPointYEnd, undefined, playerId);
 	}
 
 	/**

--- a/Fog.js
+++ b/Fog.js
@@ -155,25 +155,6 @@ class WaypointManagerClass {
 		}
 	}
 
-	/**
-	* Draw a nice circle
-	* @param x {number}
-	* @param y {number}
-	* @returns {string} <circle> tag
-	*/
-	makeBobble(x, y) {
-		/*
-		this.ctx.beginPath();
-		this.ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
-		this.ctx.lineWidth = radius
-		this.ctx.strokeStyle = this.drawStyle.outlineColor
-		this.ctx.stroke();
-		this.ctx.fillStyle =  this.drawStyle.color
-		this.ctx.fill();
-		*/
-	    return `<circle cx='${x}px' cy='${y}px' fill='${this.drawStyle.color}' stroke='${this.drawStyle.outlineColor}'></circle>`;
-	}
-
 	// Increment the current index into the array of waypoints, and draw a small indicator
 	checkNewWaypoint(mousex, mousey) {
 			//console.log("Incrementing waypoint");
@@ -229,7 +210,7 @@ class WaypointManagerClass {
 	// Draw the waypoints, note that we sum up the cumulative distance, midlineLabels is true for token drag
 	// as otherwise the token sits on the measurement label
 	draw(midlineLabels, labelX, labelY, alpha = 1, playerId=window.PLAYER_ID) {
-		$(`.ruler-svg-text[data-player-id='${playerId}'], .ruler-svg-line[data-player-id='${playerId}'], .ruler-svg-bobbles[data-player-id='${playerId}']`).remove();
+		$(`.ruler-svg-text[data-player-id='${playerId}'], .ruler-svg-line[data-player-id='${playerId}']`).remove();
 		
 		let cumulativeDistance = 0;
 		this.numberOfDiagonals = 0;
@@ -423,25 +404,6 @@ class WaypointManagerClass {
 			rulerLineSVG,
 			textSVG
 		)	
-
-		// add player bobble container if there isn't one
-		let playerBobbleContainer = $(`.ruler-svg-bobbles[data-player-id='${playerId}']`)
-		if (playerBobbleContainer.length === 0) {
-			let rulerBobbleContainerSvg = $(`
-				<svg data-player-id='${playerId}' viewbox='0 0 ${sceneWidth} ${sceneHeight}' width='${sceneWidth}' height='${sceneHeight}' class='ruler-svg-bobbles' style='top:0px; left:0px;'>
-				</svg>
-			`)
-			vtt.append(rulerBobbleContainerSvg)
-			
-			// re-query the container now that it has been added
-            playerBobbleContainer = $(`.ruler-svg-bobbles[data-player-id='${playerId}']`)
-		}
-		
-		// add bobbles to the container
-		playerBobbleContainer.append(
-			this.makeBobble(snapPointXStart, snapPointYStart),
-			this.makeBobble(snapPointXEnd, snapPointYEnd)
-		);
 
 		// update alpha of all added svgs 
 		$(`svg[data-player-id='${playerId}']`).css('--svg-text-alpha', alpha);
@@ -3928,7 +3890,7 @@ function calculateFourthPoint(point1, point2, point3) {
 }
 function clear_temp_canvas(playerId=window.PLAYER_ID){
 	window.temp_context.clearRect(0, 0, window.temp_canvas.width, window.temp_canvas.height); 
-	$(`.ruler-svg-text[data-player-id='${playerId}'], .ruler-svg-line[data-player-id='${playerId}'], .ruler-svg-bobbles[data-player-id='${playerId}']`).remove();
+	$(`.ruler-svg-text[data-player-id='${playerId}'], .ruler-svg-line[data-player-id='${playerId}']`).remove();
 }
 
 function bucketFill(ctx, mouseX, mouseY, fogStyle = 'rgba(0,0,0,0)', fogType=0, islight=false, distance1=10000, distance2){

--- a/Fog.js
+++ b/Fog.js
@@ -96,6 +96,10 @@ class WaypointManagerClass {
 		this.canvas=undefined;
 		this.ctx=undefined;
 		this.numWaypoints = 0;
+		
+		/**
+		* @type {{startX: number, startY: number, endX: number, endY: number, distance: number, labelX: number | undefined, labelY: number | undefined}[]}
+		*/
 		this.coords = [];
 		this.currentWaypointIndex = 0;
 		this.mouseDownCoords = { mousex: undefined, mousey: undefined };
@@ -269,15 +273,27 @@ class WaypointManagerClass {
 		this.numberOfDiagonals = 0;
 		let elementsToDraw = "";
 		for (let i = 0; i < this.coords.length; i++) {
+			const waypointCoordinates = this.coords[i];
+
+			// remember labelX and labelY to recall it when redrawing while fading away
+			// if labelX and labelY are undefined, we are redrawing and should not do this
+			if (labelX != null && labelY != null) {
+				const lastWaypoint = i === this.coords.length - 1
+				if (lastWaypoint) {
+					waypointCoordinates.labelX = labelX;
+					waypointCoordinates.labelY = labelY;
+				}
+			}
+			
 			// We do the beginPath here because otherwise the lines on subsequent waypoints get
 			// drawn over the labels...
 			this.ctx.beginPath();
 			if (i < this.coords.length - 1) {
-				elementsToDraw += this.makeWaypointSegment(this.coords[i], cumulativeDistance, undefined, undefined, sceneMapSize);
+				elementsToDraw += this.makeWaypointSegment(waypointCoordinates, cumulativeDistance, sceneMapSize);
 			} else {
-				elementsToDraw += this.makeWaypointSegment(this.coords[i], cumulativeDistance, labelX, labelY, sceneMapSize);
+				elementsToDraw += this.makeWaypointSegment(waypointCoordinates, cumulativeDistance, sceneMapSize);
 			}
-			cumulativeDistance += this.coords[i].distance
+			cumulativeDistance += waypointCoordinates.distance
 		}
 
 		rulerContainer.innerHTML = elementsToDraw;
@@ -285,14 +301,12 @@ class WaypointManagerClass {
 
 	/**
 	* Make a waypoint segment SVGs with all the lines and labels etc.
-	* @param coord {{startX: number, startY: number, endX: number, endY: number, distance: number}}
+	* @param coord {{startX: number, startY: number, endX: number, endY: number, distance: number, labelX: number | undefined, labelY: number | undefined}}
 	* @param cumulativeDistance {number}
-	* @param labelX {number}
-	* @param labelY {number}
 	* @param sceneMapSize {{sceneHeight: number, sceneWidth: number}}
 	* @returns {string} SVG elements for waypoint line and label
 	*/
-	makeWaypointSegment(coord, cumulativeDistance, labelX, labelY, sceneMapSize) {
+	makeWaypointSegment(coord, cumulativeDistance, sceneMapSize) {
 		// Snap to centre of current grid square
 		let gridSize =  window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor;
 		let snapPointXStart = coord.startX;
@@ -361,8 +375,8 @@ class WaypointManagerClass {
 		let contrastRect = { x: 0, y: 0, width: 0, height: 0 }
 		let textRect = { x: 0, y: 0, width: 0, height: 0 }
 
+		const { labelX, labelY} = coord;
 		if (labelX !== undefined && labelY !== undefined) {
-
 			// Calculate our coords and dimensions
 			contrastRect.x = labelX - margin + slopeModifier;
 			contrastRect.y = labelY - margin + slopeModifier;

--- a/PeerCommunication.js
+++ b/PeerCommunication.js
@@ -704,7 +704,7 @@ function clear_peer_canvas(playerId) {
   const context = canvas.getContext("2d");
   context.clearRect(0, 0, canvas.width, canvas.height);
 
-  $(`.ruler-svg-line[data-player-id='${playerId}'], .ruler-svg-bobbles[data-player-id='${playerId}'], .ruler-svg-text[data-player-id='${playerId}']`).remove();
+  $(`.ruler-svg-line[data-player-id='${playerId}'], .ruler-svg-text[data-player-id='${playerId}']`).remove();
 }
 
 /** iterates over window.PEER_RULERS and draws any rulers that need to be drawn */

--- a/PeerCommunication.js
+++ b/PeerCommunication.js
@@ -711,7 +711,7 @@ function clear_peer_canvas(playerId) {
 function redraw_peer_rulers(playerId) {
   //clear_peer_canvas(playerId); // make sure we clear the canvas first. Otherwise, we'll see every previous position of every ruler
   const waypointManager = window.PEER_RULERS[playerId];
-  waypointManager.draw(false, undefined, undefined, undefined, playerId);
+  waypointManager.draw(undefined, undefined, undefined, playerId);
   
 }
 

--- a/PeerCommunication.js
+++ b/PeerCommunication.js
@@ -704,7 +704,7 @@ function clear_peer_canvas(playerId) {
   const context = canvas.getContext("2d");
   context.clearRect(0, 0, canvas.width, canvas.height);
 
-  $(`.ruler-svg-line[data-player-id='${playerId}'], .ruler-svg-text[data-player-id='${playerId}']`).remove();
+  WaypointManager.clearWaypointDrawings(playerId)
 }
 
 /** iterates over window.PEER_RULERS and draws any rulers that need to be drawn */

--- a/Token.js
+++ b/Token.js
@@ -2815,7 +2815,7 @@ class Token {
 
 							clear_temp_canvas();
 							WaypointManager.storeWaypoint(WaypointManager.currentWaypointIndex, window.BEGIN_MOUSEX/window.CURRENT_SCENE_DATA.scale_factor, window.BEGIN_MOUSEY/window.CURRENT_SCENE_DATA.scale_factor, tokenMidX/window.CURRENT_SCENE_DATA.scale_factor, tokenMidY/window.CURRENT_SCENE_DATA.scale_factor);
-							WaypointManager.draw(false, Math.round(tokenPosition.x + (self.sizeWidth() / 2))/window.CURRENT_SCENE_DATA.scale_factor, Math.round(tokenPosition.y + self.sizeHeight() + 10)/window.CURRENT_SCENE_DATA.scale_factor);
+							WaypointManager.draw(Math.round(tokenPosition.x + (self.sizeWidth() / 2))/window.CURRENT_SCENE_DATA.scale_factor, Math.round(tokenPosition.y + self.sizeHeight() + 10)/window.CURRENT_SCENE_DATA.scale_factor);
 						}
 						if (!self.options.hidden) {
 							sendTokenPositionToPeers(tokenPosition.x, tokenPosition.y, self.options.id, allowTokenMeasurement);

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2999,8 +2999,7 @@ button.roll-button-mod.minus {
 }
 
 
-.ruler-svg-line,
-.ruler-svg-bobbles{
+.ruler-svg-line {
     border-radius:2px;
     position:absolute;
     z-index:80;
@@ -3010,9 +3009,6 @@ button.roll-button-mod.minus {
     pointer-events:none;
 }
 
-.ruler-svg-bobbles{
-     z-index:85;
-}
 .ruler-svg-line line:first-of-type{
     stroke-width: calc(2 / var(--window-zoom));
 }
@@ -3020,10 +3016,7 @@ button.roll-button-mod.minus {
 .ruler-svg-line line:nth-of-type(2){
     stroke-width: calc(1 / var(--window-zoom));
 }
-.ruler-svg-bobbles circle{
-    stroke-width: calc(0.5 / var(--window-zoom));
-    r: calc(1 / var(--window-zoom));
-}
+
 #raycastingCanvas,
 #light_overlay,
 .aura-element-container-clip:not([data-animation])>.islight,


### PR DESCRIPTION
* refactor: optimize jquery calls in drawWaypointSegment
* refactor: remove ruler-svg-bobbles
* refactor: optimize draw loop by moving all dom operations out
* refactor: remove midlineLabels as unused

I've realized it would take ages merging these one by one.

You can review each commit one by one, each is self contained.

