### PR TITLE
refactor: provide bg color for splash screen so it's never transparent

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1368,8 +1368,6 @@ function init_splash() {
 	localStorage.setItem("AboveVttLastUsedVersion", window.AVTT_VERSION);
 
 	let cont = $("<div id='splash'></div>");
-	cont.css('background', "url('/content/1-0-1487-0/skins/waterdeep/images/mon-summary/paper-texture.png')");
-
 	cont.append(`<h1 style='margin-top:0px; padding-bottom:2px;margin-bottom:2px; text-align:center'><img width='250px' src='${window.EXTENSION_PATH}assets/logo.png'><div style='margin-left:20px; display:inline;vertical-align:bottom;'>${window.AVTT_VERSION}${AVTT_ENVIRONMENT.versionSuffix}</div></h1>`);
 	cont.append("<div style='font-style: italic;padding-left:80px;font-size:20px;margin-bottom:2px;margin-top:2px; margin-left:50px;'>Fine.. We'll do it ourselves..</div>");
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -988,6 +988,10 @@ div.top_menu.visible,
     text-overflow: ellipsis;
 }
 
+#splash {
+    background: #f8f2d4 url(https://www.dndbeyond.com/content/1-0-1487-0/skins/waterdeep/images/mon-summary/paper-texture.png);
+}
+
 div#scene_selector,
 #text_controller_inside,
 #combat_tracker_inside,


### PR DESCRIPTION
I've reinstalled os and was reminded that splashscreen is transparent on initially before image is fetched for the first time becuase there is no background color.

Maybe this could be classified as a fix tho