### PR TITLE
refactor: extract get_my_known_languages()

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -745,6 +745,17 @@ async function rebuild_window_pcs() {
   });
 }
 
+/**
+ * Returns known languages of player's PC
+ * @returns {string[]}
+ */
+function get_my_known_languages() {
+  const pc = find_pc_by_player_id(my_player_id())
+  const knownLanguages = pc?.proficiencyGroups.find(g => g.group === "Languages")?.values?.trim().split(/\s*,\s*/gi) ?? [];
+  knownLanguages?.push('Telepathy');
+  return knownLanguages;
+}
+
 async function rebuild_window_users() {
   window.playerUsers = await DDBApi.fetchCampaignUserDetails(window.gameId);
   let playerUser = window.playerUsers.filter(d=> d.id == window.PLAYER_ID)[0]?.userId;

--- a/Journal.js
+++ b/Journal.js
@@ -1687,11 +1687,8 @@ class JournalManager{
             	languageText = languageText.replace(/<\/?p>/g, '');   	
 
 
-            	if (!window.DM && (language) != undefined) {
-					const pc = find_pc_by_player_id(my_player_id())
-					const knownLanguages = pc?.proficiencyGroups.find(g => g.group === "Languages")?.values?.toLowerCase().trim().split(/\s*,\s*/gi) ?? [];
-					knownLanguages.push('telepathy');
-
+            	if (!window.DM && language != undefined) {
+					const knownLanguages = get_my_known_languages().map(language => language.toLowerCase())
 					if (!knownLanguages.includes(language.toLowerCase())) {
 						const container = $("<div>").html(languageText);
 						const elements = container.find("*").add(container);

--- a/Main.js
+++ b/Main.js
@@ -2105,16 +2105,14 @@ Disadvantage: 2d20kl1 (keep lowest)&#xa;&#xa;
 	
 	const languageSelect= $(`<select id='chat-language'></select>`)
 	const ignoredLanguages = ['All'];
-	const pc = find_pc_by_player_id(my_player_id())
-			
-	const knownLanguages = pc?.proficiencyGroups.find(g => g.group === "Languages")?.values?.trim().split(/\s*,\s*/gi) ?? [];
-	knownLanguages?.push('Telepathy');
-	for(let i in window.ddbConfigJson.languages){
-		if(ignoredLanguages.includes(window.ddbConfigJson.languages[i].name))
+
+	const knownLanguages = get_my_known_languages();
+	for (const language of window.ddbConfigJson.languages) {
+		if (ignoredLanguages.includes(language.name))
 			continue;
-		if(!window.DM && !knownLanguages.includes(window.ddbConfigJson.languages[i].name))
+		if (!window.DM && !knownLanguages.includes(language.name))
 			continue;
-		const option = $(`<option value='${window.ddbConfigJson.languages[i].id}'>${window.ddbConfigJson.languages[i].name}</option>`)
+		const option = $(`<option value='${language.id}'>${language.name}</option>`)
 		languageSelect.append(option);
 	}
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1624,11 +1624,9 @@ class MessageBroker {
 
 		// hide message if PC doesn't speak this language
 		if (!window.DM && data.language != undefined) {
-			const pc = find_pc_by_player_id(my_player_id())
-			const knownLanguages = pc?.proficiencyGroups.find(g => g.group === "Languages")?.values?.trim().split(/\s*,\s*/gi) ?? [];
-			knownLanguages.push('Telepathy');
-
-			if (!knownLanguages.includes(window.ddbConfigJson.languages.find(d => d.id == data.language).name)) {
+			const knownLanguages = get_my_known_languages()
+			const messageLanguage = window.ddbConfigJson.languages.find(d => d.id == data.language)?.name;
+			if (!knownLanguages.includes(messageLanguage)) {
 				const container = $("<div>").html(data.text);
 				const elements = container.find("*").add(container);
 				const textNodes = elements.contents().not(elements);


### PR DESCRIPTION
With last `.toLowerCase()` change I've noticed that this is done 3 times in 3 different places, which triggers my internal "time to extract it" breakpoint, so I did that.

I did not add `toLowerCase()` for comparison in MessageBroker.js, though it could be added there