### PR TITLE
Fix - add 1 second delay before loading scripts to avoid being flagged as bot when refreshing.

### DIFF
--- a/DDBApi.js
+++ b/DDBApi.js
@@ -260,18 +260,17 @@ class DDBApi {
       characterIds = window.playerUsers.map(c => c.id);
     } catch (error) {
       console.warn("fetchCampaignCharacterIds caught an error trying to collect ids from fetchActiveCharacters", error);
-      try {
-        window.playerUsers = await DDBApi.fetchCampaignCharacters(campaignId);
-        window.playerUsers.forEach(c => {
-          if (!characterIds.includes(c.id)) {
-            characterIds.push(c.id);
-          }
-        });
-      } catch (error) {
-        console.warn("fetchCampaignCharacterIds caught an error trying to collect ids from fetchActiveCharacters", error);
-      }
     }
-
+    try {
+      window.playerUsers = await DDBApi.fetchCampaignCharacters(campaignId);
+      window.playerUsers.forEach(c => {
+        if (!characterIds.includes(c.id)) {
+          characterIds.push(c.id);
+        }
+      });
+    } catch (error) {
+      console.warn("fetchCampaignCharacterIds caught an error trying to collect ids from fetchActiveCharacters", error);
+    }
     let playerUser = window.playerUsers.filter(d=> d.id == window.PLAYER_ID)[0]?.userId;
     window.myUser = playerUser ? playerUser : 'THE_DM'; 
     return characterIds;

--- a/Load.js
+++ b/Load.js
@@ -145,4 +145,5 @@ function injectScript() {
 	(document.head || document.documentElement).appendChild(s);
 }
 
-injectScript();
+setTimeout(injectScript, 1000) // this timeout prevents DDB from thinking we are browsing as a bot by giving it enough time to run it's own loading before sending more requests.
+

--- a/LoadCharacterPage.js
+++ b/LoadCharacterPage.js
@@ -63,5 +63,5 @@ if (!isVttGamePage) {
         (document.head || document.documentElement).appendChild(s);
     }
 
-    injectScript();
+    setTimeout(injectScript, 1000) // this timeout prevents DDB from thinking we are browsing as a bot by giving it enough time to run it's own loading before sending more requests.
 }


### PR DESCRIPTION
I've been getting flagged as 'we think your using automated tools to browse' when refreshing while working on abovevtt recently. This seems to resolve the issue - I think it's due to DDB making their own api requests on load and us making them too quickly afterwards.