### PR TITLE
Internal - remove timeout as it doesn't appear to be the cause, just happened in incognito window no extensions

### DIFF
--- a/Load.js
+++ b/Load.js
@@ -145,5 +145,5 @@ function injectScript() {
 	(document.head || document.documentElement).appendChild(s);
 }
 
-setTimeout(injectScript, 2000) // this timeout prevents DDB from thinking we are browsing as a bot by giving it enough time to run it's own loading before sending more requests.
+injectScript();
 

--- a/LoadCharacterPage.js
+++ b/LoadCharacterPage.js
@@ -63,5 +63,5 @@ if (!isVttGamePage) {
         (document.head || document.documentElement).appendChild(s);
     }
 
-    setTimeout(injectScript, 2000) // this timeout prevents DDB from thinking we are browsing as a bot by giving it enough time to run it's own loading before sending more requests.
+    injectScript();
 }


### PR DESCRIPTION
I was wrong in my assumption just looks like it was coincidence. It's happening in a incognito window, no extensions loaded, on the campaign page at minimum.