### PR TITLE
fix: don't throw if loading youtube script fails

### DIFF
--- a/Startup.js
+++ b/Startup.js
@@ -358,11 +358,13 @@ function load_external_script(scriptUrl) {
   return new Promise(function (resolve, reject) {
     let script = document.createElement('script');
     script.src = scriptUrl;
-    script.addEventListener('error', function () {
-      reject(console.warn(`Failed to load external script ${scriptUrl}`));
+    script.addEventListener('error', err => {
+      reject(err);
     });
     script.addEventListener('load', resolve);
     document.head.appendChild(script);
+  }).catch((err) => {
+    console.error(`Failed to load external script`, scriptUrl, err);
   })
 }
 


### PR DESCRIPTION
Not all campaigns use and require youtube to operate. If youtube is blocked in your country, this will fail to load, killing the startup.

To avoid that, we just console error the failure instead.

This should probably resolve all those failed to load youtube duplicates.

Refs: #2637 (and others)