### PR TITLE
Internal - match DDB request for config data

### DIFF
--- a/DDBApi.js
+++ b/DDBApi.js
@@ -221,7 +221,7 @@ class DDBApi {
     if(window.ddbConfigJson != undefined)
       return window.ddbConfigJson
     const url = "https://www.dndbeyond.com/api/config/json";
-    return await DDBApi.fetchJsonWithTokenOmitCred(url);
+    return await DDBApi.fetchJsonWithToken(url);
   }
 
   static async fetchActiveCharacters(campaignId) {


### PR DESCRIPTION
So it was never this request it was having dev tools open that was flagging. Changing this back to match DDB's request on the encounter builder page.