### PR TITLE
Audio Quality of Life updates

### DIFF
--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -649,14 +649,29 @@ class Mixer extends EventTarget {
                 $(`.audio-row[data-id='${id}'] .channel-play-pause-button.playing`).click();
                 $(progress).css('width', '');
 
-                if($(`.sequential-button`).hasClass('pressed')){
-                    let currentTrack = $(`.audio-row[data-id="${id}"]:not(.tokenTrack)`)
-                    let nextTrack = $(currentTrack).nextAll('.audio-row[data-id]:not(.tokenTrack):first');
-                    if(nextTrack.length == 0){
-                        nextTrack = $(`#mixer-channels .audio-row[data-id]:not(.tokenTrack)`).first();
+                if ($(`.sequential-button`).hasClass('pressed')) {
+                    let nextTrack;
+                    let currentTrack = $(`.audio-row[data-id="${id}"]:not(.tokenTrack)`);
+                
+                    if ($(`.sequential-button`).hasClass('shuffle')) {
+                        // Shuffle Mode: Pick a random track
+                        let tracks = $(`#mixer-channels .audio-row[data-id]:not(.tokenTrack)`).toArray();
+                        let randomIndex;
+                        do {
+                            randomIndex = Math.floor(Math.random() * tracks.length);
+                        } while ($(tracks[randomIndex]).attr("data-id") === id); // Prevent immediate repeat
+                
+                        nextTrack = $(tracks[randomIndex]);
+                    } else {
+                        // Default: Play next track in sequence
+                        nextTrack = $(currentTrack).nextAll('.audio-row[data-id]:not(.tokenTrack):first');
+                        if (nextTrack.length == 0) {
+                            nextTrack = $(`#mixer-channels .audio-row[data-id]:not(.tokenTrack)`).first();
+                        }
                     }
+                
                     nextTrack.find('.channel-play-pause-button').click();
-                }
+                }                
             }
         }
 

--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -641,26 +641,29 @@ class Mixer extends EventTarget {
         }
         player.ontimeupdate = (e) => {
             progress.style.width = e.target.currentTime / e.target.duration * 100 + "%";
-           
-        
-            if(e.target.currentTime == e.target.duration && e.target.loop == false && $(`.audio-row[data-id='${id}'] .channel-play-pause-button.playing`).length>0){
-                const id = progress.getAttribute('data-id')
+
+            if (e.target.currentTime == e.target.duration && e.target.loop == false && $(`.audio-row[data-id='${id}'] .channel-play-pause-button.playing`).length > 0) {
+                const id = progress.getAttribute('data-id');
                 e.target.currentTime = 0;
                 $(`.audio-row[data-id='${id}'] .channel-play-pause-button.playing`).click();
                 $(progress).css('width', '');
-
+            
                 if ($(`.sequential-button`).hasClass('pressed')) {
                     let nextTrack;
                     let currentTrack = $(`.audio-row[data-id="${id}"]:not(.tokenTrack)`);
-                
+            
                     if ($(`.sequential-button`).hasClass('shuffle')) {
-                        // Shuffle Mode: Pick a random track
+                        // Shuffle Mode: Pick a random track with time-seeded randomness
+                        const seed = new Date().getTime(); // Get current timestamp
+                        function seededRandom(seed) {
+                            return Math.abs(Math.sin(seed) * 10000) % 1; // Generates a stable random value
+                        }
                         let tracks = $(`#mixer-channels .audio-row[data-id]:not(.tokenTrack)`).toArray();
                         let randomIndex;
                         do {
-                            randomIndex = Math.floor(Math.random() * tracks.length);
+                            randomIndex = Math.floor(seededRandom(seed + Math.random()) * tracks.length);
                         } while ($(tracks[randomIndex]).attr("data-id") === id); // Prevent immediate repeat
-                
+            
                         nextTrack = $(tracks[randomIndex]);
                     } else {
                         // Default: Play next track in sequence
@@ -669,9 +672,9 @@ class Mixer extends EventTarget {
                             nextTrack = $(`#mixer-channels .audio-row[data-id]:not(.tokenTrack)`).first();
                         }
                     }
-                
+            
                     nextTrack.find('.channel-play-pause-button').click();
-                }                
+                }
             }
         }
 

--- a/audio/track.js
+++ b/audio/track.js
@@ -99,26 +99,21 @@ class TrackLibrary extends Library {
                 let exactSearch = search.slice(1, -1).trim(); // Remove quotes
     
                 let filterArray = Array.from(tracks); // Convert jQuery object to array
-    
                 filterArray.forEach(item => {
                     let trackText = item?.textContent?.toLowerCase() || "";
                     let trackDataSrc = item?.dataset?.src || "";
-                
-                    let foundTrack = libraryTracks.find(([_, track]) =>
-                        track.name?.toLowerCase() === trackText || track.src === trackDataSrc
-                    );
-                
-                    let trackTags = foundTrack?.[1]?.tags || "";
+                    let trackTags = item?.dataset?.tags || ""; 
                 
                     if (trackText === exactSearch) {
                         $(item).toggleClass('hidden-track', false);
                     } else if (typeof trackTags === "string") {
-                        let tagArray = trackTags.split(", ").map(tag => tag.trim().toLowerCase()); // ✅ Correct split
+                        let tagArray = trackTags.split(", ").map(tag => tag.trim().toLowerCase()); 
                         if (tagArray.includes(exactSearch)) {
                             $(item).toggleClass('hidden-track', false);
                         }
                     }
                 });
+                
             } else {
                 // **DEFAULT MODE (OR logic, same as original behavior)**
                 let filterArray = search.split(" ");

--- a/audio/track.js
+++ b/audio/track.js
@@ -102,17 +102,26 @@ class TrackLibrary extends Library {
                 filterArray.forEach(item => {
                     let trackText = item?.textContent?.toLowerCase() || "";
                     let trackDataSrc = item?.dataset?.src || "";
-                    let trackTags = item?.dataset?.tags || ""; 
+                
+                    let foundTrack = libraryTracks.find(([_, track]) =>
+                        track.name === item.textContent || track.src === item.dataset.src
+                    );
+                
+                    let trackTags = foundTrack?.[1]?.tags || []; 
+                
+                    console.log("Track Text:", trackText);
+                    console.log("Track Tags:", trackTags);
+                    console.log("Exact Search:", exactSearch);
                 
                     if (trackText === exactSearch) {
                         $(item).toggleClass('hidden-track', false);
-                    } else if (typeof trackTags === "string") {
-                        let tagArray = trackTags.split(", ").map(tag => tag.trim().toLowerCase()); 
-                        if (tagArray.includes(exactSearch)) {
+                    } else if (Array.isArray(trackTags)) { 
+                        if (trackTags.map(tag => tag.toLowerCase()).includes(exactSearch)) {
                             $(item).toggleClass('hidden-track', false);
                         }
                     }
                 });
+                
                 
             } else {
                 // **DEFAULT MODE (OR logic, same as original behavior)**

--- a/audio/track.js
+++ b/audio/track.js
@@ -85,24 +85,57 @@ class TrackLibrary extends Library {
         }
     }
 
-    filterTrackLibrary(searchFilter = ''){
+    filterTrackLibrary(searchFilter = '') {
         let tracks = $('#track-list .audio-row');
-      
-                 
-        if(searchFilter != ''){
-            tracks.toggleClass('hidden-track', true);  
-            let filterArray = searchFilter.split(" ");
-            let regex = new RegExp( filterArray.join( "|" ), "i");
-            let libraryTracks = [...this.map()]; // do this here instead of using `this.find` to speed up the find below
-            tracks.filter(item => regex.test(tracks[item].textContent) || 
-                regex.test(libraryTracks.find(([_, track]) => track.name === tracks[item].textContent || track.src === tracks[item].dataset.src)[1].tags)
-            ).toggleClass('hidden-track', false);   
-        }
-        else{
+    
+        if (searchFilter.trim() !== '') {
+            tracks.toggleClass('hidden-track', true);
+    
+            let search = searchFilter.trim().toLowerCase();
+            let libraryTracks = [...this.map()]; // Cache library tracks
+    
+            if (search.startsWith('"') && search.endsWith('"')) {
+                // **EXACT MATCH MODE (search wrapped in quotes)**
+                let exactSearch = search.slice(1, -1).trim(); // Remove quotes
+    
+                let filterArray = Array.from(tracks); // Convert jQuery object to array
+    
+                filterArray.forEach(item => {
+                    let trackText = item?.textContent?.toLowerCase() || "";
+                    let trackDataSrc = item?.dataset?.src || "";
+                
+                    let foundTrack = libraryTracks.find(([_, track]) =>
+                        track.name?.toLowerCase() === trackText || track.src === trackDataSrc
+                    );
+                
+                    let trackTags = foundTrack?.[1]?.tags || "";
+                
+                    if (trackText === exactSearch) {
+                        $(item).toggleClass('hidden-track', false);
+                    } else if (typeof trackTags === "string") {
+                        let tagArray = trackTags.split(", ").map(tag => tag.trim().toLowerCase()); // ✅ Correct split
+                        if (tagArray.includes(exactSearch)) {
+                            $(item).toggleClass('hidden-track', false);
+                        }
+                    }
+                });
+            } else {
+                // **DEFAULT MODE (OR logic, same as original behavior)**
+                let filterArray = search.split(" ");
+                let regex = new RegExp(filterArray.join("|"), "i"); // OR logic (matches any word)
+    
+                tracks.filter(item =>
+                    regex.test(tracks[item].textContent) ||
+                    regex.test(libraryTracks.find(([_, track]) =>
+                        track.name === tracks[item].textContent || track.src === tracks[item].dataset.src
+                    )?.[1]?.tags || "")
+                ).toggleClass('hidden-track', false);
+            }
+        } else {
             tracks.toggleClass('hidden-track', false);
         }
-
     }
+
     /**
      *
      * @param {string} name
@@ -116,7 +149,7 @@ class TrackLibrary extends Library {
         this.delete(id);
     }
     addTrack(name, src, tags=[]){
-        const track = new Track(name, src);  
+        const track = new Track(name, src);
         track.tags = tags;
         this.create(track);
     }

--- a/audio/ui.js
+++ b/audio/ui.js
@@ -381,6 +381,13 @@ function addTracks(filteredTracks, shuffle = false) {
         filteredTracks = shuffleArray(filteredTracks); // Random shuffle
     }
 
+    // Show confirmation if adding more than 50 tracks
+    if (filteredTracks.length > 50) {
+        if (!confirm(`You're about to add ${filteredTracks.length} tracks to the mixer. This may cause lag. Continue?`)) {
+            return;
+        }
+    }
+
     filteredTracks.forEach(track => {
         const channel = new Channel(track.name, track.src);
         channel.paused = true; // Add but don't auto-play

--- a/audio/ui.js
+++ b/audio/ui.js
@@ -350,6 +350,26 @@ function init_mixer() {
     $('#master-volume').append(clear, sequentialPlay, playPause);
 }
 
+// Function to add filtered tracks to the Mixer
+function addTracks(filteredTracks, shuffle = false) {
+    if (filteredTracks.length === 0) {
+        alert("No tracks found in the current filter.");
+        return;
+    }
+
+    if (shuffle) {
+        filteredTracks = filteredTracks.sort(() => Math.random() - 0.5); // Random shuffle
+    }
+
+    filteredTracks.forEach(track => {
+        const channel = new Channel(track.name, track.src);
+        channel.paused = true; // Add but don't auto-play
+        window.MIXER.addChannel(channel);
+    });
+
+    console.log(`Added ${filteredTracks.length} ${shuffle ? "shuffled " : ""}tracks to the Mixer.`);
+}
+
 function init_trackLibrary() {
     // header
     const header = document.createElement("h3");
@@ -396,6 +416,33 @@ function init_trackLibrary() {
     const trackSrc = $(`<input class='trackSrc trackInput' placeholder='https://.../example.mp3'/>`)
     const okButton = $('<button class="add-track-ok-button">OK</button>');  
     const cancelButton = $('<button class="add-track-cancel-button">X</button>');  
+
+    // Mixer/ Track List QOL updates
+    const addTracksToMixer = $(`<button id='addTrack'>Add Tracks to Mixer</button>`);
+    const addShuffledToMixer = $('<button id="addShuffledToMixer">Add Shuffled</button>');
+
+    // Click handlers
+    addTracksToMixer.on("click", function() {
+        const filteredTracks = [...document.querySelectorAll("#track-list .audio-row")]
+            .filter(track => track.offsetParent !== null)
+            .map(track => ({
+                name: track.getAttribute("data-name"),
+                src: track.getAttribute("data-src"),
+            }));
+        addTracks(filteredTracks);
+    });
+
+    addShuffledToMixer.on("click", function() {
+        const filteredTracks = [...document.querySelectorAll("#track-list .audio-row")]
+            .filter(track => track.offsetParent !== null)
+            .map(track => ({
+                name: track.getAttribute("data-name"),
+                src: track.getAttribute("data-src"),
+            }));
+        addTracks(filteredTracks, true); // Enable shuffle
+    });
+    
+
     addTrack.off().on("click", function(){
         importTrackFields.css("height", "25px");
     });
@@ -603,7 +650,7 @@ function init_trackLibrary() {
     });
     trackLibrary.dispatchEvent(new Event('onchange'));
 
-    $("#sounds-panel .sidebar-panel-body").append(header, searchTrackLibary, dropBoxbutton, importCSV, addTrack, importTrackFields, trackList);
+    $("#sounds-panel .sidebar-panel-body").append(header, searchTrackLibary, "<br>", addTracksToMixer, addShuffledToMixer, "<br><b>Import</b>:  ", addTrack, dropBoxbutton, importCSV, importTrackFields, trackList);
 }
 
 function init() {

--- a/audio/ui.js
+++ b/audio/ui.js
@@ -275,18 +275,25 @@ function init_mixer() {
     let sequentialPlay = $('<button class="sequential-button"></button>');
     let sequential_svg = $(`<span class="material-symbols-outlined">format_list_numbered_rtl</span>`)
     sequentialPlay.append(sequential_svg);
-    sequentialPlay.on('click', function(){
-        if(sequentialPlay.hasClass('pressed')){
-            sequentialPlay.toggleClass('pressed', false)
+    sequentialPlay.off().on("click", function() {
+        const icon = sequentialPlay.find(".material-symbols-outlined"); // Find the icon span
+    
+        // Cycle through: Off → Continuous → Shuffle → Off
+        if (!sequentialPlay.hasClass("pressed")) {
+            sequentialPlay.addClass("pressed");
+            sequentialPlay.attr("title", "Continuous Play");
+            // icon.text("repeat"); // Continuous Play icon
+        } else if (!sequentialPlay.hasClass("shuffle")) {
+            sequentialPlay.addClass("shuffle");
+            sequentialPlay.attr("title", "Shuffle Play");
+            icon.text("shuffle"); // Shuffle Play icon
+        } else {
+            sequentialPlay.removeClass("shuffle pressed");
+            sequentialPlay.attr("title", "Loop Off");
+            icon.text("format_list_numbered_rtl"); // Default icon
         }
-        else{
-
-            sequentialPlay.toggleClass('pressed', true)
-            let currentlyPlaying = $(`.audio-row[data-id]:not(.tokenTrack) .channel-play-pause-button.playing:not(:first)`)
-            if(currentlyPlaying.length>0){
-                currentlyPlaying.click();
-            }
-        }     
+    
+        console.log("Playback Mode:", sequentialPlay.attr("title"));
     });
 
     // play/pause button
@@ -350,6 +357,19 @@ function init_mixer() {
     $('#master-volume').append(clear, sequentialPlay, playPause);
 }
 
+function shuffleArray(array) {
+    const seed = new Date().getTime(); // Get the current timestamp at shuffle time
+
+    function seededRandom(seed) {
+        return Math.sin(seed) * 10000 % 1; // Simple deterministic function
+    }
+
+    return array
+        .map(track => ({ track, sort: seededRandom(seed + Math.random()) })) // Use dynamic seed
+        .sort((a, b) => a.sort - b.sort) // Sort based on seeded value
+        .map(obj => obj.track); // Return only tracks
+}
+
 // Function to add filtered tracks to the Mixer
 function addTracks(filteredTracks, shuffle = false) {
     if (filteredTracks.length === 0) {
@@ -358,7 +378,7 @@ function addTracks(filteredTracks, shuffle = false) {
     }
 
     if (shuffle) {
-        filteredTracks = filteredTracks.sort(() => Math.random() - 0.5); // Random shuffle
+        filteredTracks = shuffleArray(filteredTracks); // Random shuffle
     }
 
     filteredTracks.forEach(track => {


### PR DESCRIPTION
## Mixer
Added a "Shuffle Play" to the continuous button. When depressed, after a track has finished, the next track is randomly selected from the current playlist. 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/4be878bc-a49d-4efa-885a-157868b74674" />


## Track Library
<img width="248" alt="image" src="https://github.com/user-attachments/assets/8bc80231-8dd2-4ba6-b918-e7a53eb4c259" />

Added two new buttons. 
- Add Tracks to Mixer
  - Adds tracks from the current view to the mixer. Warns if more than 50 are requested. 
- Add Shuffled
  - Same as above, only the list is shuffled first. 
  
Random is seeded using the timestamp to prevent repeatable random outcomes. 

## Search Filter
- Existing behavior works as before (OR filtering). 
- Added quoted strings, that require an exact match and work for name and tags. 
  - For example, 
    - `A Clash of Fang and Flame` matches 448 tracks
    - `"A Clash of Fang and Flame"` matches 1 track name
    - `Modern-Warfare` matches 53 tracks (from the tag)
    - `"Modern-Warfare"` matches 29 tracks (from the exact tag)
