### PR TITLE
QoL - Move drawings under fog overlay

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1172,14 +1172,16 @@ function draw_wizarding_box() {
 	}
 
 }
-function ctxScale(canvasid){
+function ctxScale(canvasid, transform){
 	let canvas = document.getElementById(canvasid);
 	canvas.width = $("#scene_map").width();
   	canvas.height = $("#scene_map").height();
-	$(canvas).css({
-		'transform-origin': 'top left',
-		'transform': 'scale(var(--scene-scale))'
-	});
+	if(transform){
+		$(canvas).css({
+			'transform-origin': 'top left',
+			'transform': 'scale(var(--scene-scale))'
+		});
+	}
 }
 
 function reset_canvas(apply_zoom=true) {
@@ -1189,13 +1191,13 @@ function reset_canvas(apply_zoom=true) {
 	$('#darkness_layer').css({"width": sceneMapWidth, "height": sceneMapHeight});
 	$("#scene_map_container").css({"width": sceneMapWidth, "height": sceneMapHeight});
 
-	ctxScale('peer_overlay');
-	ctxScale('temp_overlay');
-	ctxScale('fog_overlay');
-	ctxScale('grid_overlay');	
-	ctxScale('draw_overlay');
-	ctxScale('walls_layer');
-	ctxScale('elev_overlay');
+	ctxScale('peer_overlay', true);
+	ctxScale('temp_overlay', true);
+	ctxScale('fog_overlay', true);
+	ctxScale('grid_overlay', true);	
+	ctxScale('draw_overlay', false);
+	ctxScale('walls_layer', true);
+	ctxScale('elev_overlay', true);
 
 	let canvas = document.getElementById('raycastingCanvas');
 	canvas.width = $("#scene_map").width();

--- a/Main.js
+++ b/Main.js
@@ -532,6 +532,7 @@ async function load_scenemap(url, is_video = false, width = null, height = null,
 			newmap.on("load", callback);
 		}
 		$("#map_items").append(newmap);
+		document.getElementById('map_items').appendChild(  document.getElementById('draw_overlay') )
 
 
 	}
@@ -589,6 +590,7 @@ async function load_scenemap(url, is_video = false, width = null, height = null,
 			$("#scene_map_container").toggleClass('map-loading', false);
 		}
 		$("#map_items").append(newmap);
+		document.getElementById('map_items').appendChild(  document.getElementById('draw_overlay') )
 
 	}
 


### PR DESCRIPTION
Prior to this PR, drawings would appear above the fog layer (so players could see the drawings outside of their vision)