### PR TITLE
Fix - DM map is used on DD2VTT map files if available

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1874,10 +1874,21 @@ class MessageBroker {
 				if(data.UVTTFile == 1){
 					build_import_loading_indicator("Loading UVTT Map");
 					try{
-						data.map = await get_map_from_uvtt_file(data.player_map);
+						if(window.DM && data.dm_map && data.dm_map_usable){
+							data.map = await get_map_from_uvtt_file(data.map)
+						}
+						else{
+							data.map = await get_map_from_uvtt_file(data.player_map);
+						}			
 					}
 					catch{
-						data.UVTTFile = 0;
+						console.log('non-UVTT file found for map')
+						if(window.DM && data.dm_map && data.dm_map_usable){
+							data.map = data.dm_map;
+						}
+						else{
+							data.map = data.player_map;
+						}
 					}
 				}
 				else{

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1919,7 +1919,7 @@ class MessageBroker {
 						data.is_video = data.player_map_is_video;
 					}
 
-					load_scenemap(data.dm_map && data.dm_map_usable && window.DM ?data.dm_map : data.map, data.is_video, data.width, data.height, data.UVTTFile, async function() {
+					load_scenemap(data.map, data.is_video, data.width, data.height, data.UVTTFile, async function() {
 						console.group("load_scenemap callback")
 						if(!window.CURRENT_SCENE_DATA.scale_factor)
 							window.CURRENT_SCENE_DATA.scale_factor = 1;

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1908,7 +1908,7 @@ class MessageBroker {
 						data.is_video = data.player_map_is_video;
 					}
 
-					load_scenemap(data.map, data.is_video, data.width, data.height, data.UVTTFile, async function() {
+					load_scenemap(data.dm_map && data.dm_map_usable && window.DM ?data.dm_map : data.map, data.is_video, data.width, data.height, data.UVTTFile, async function() {
 						console.group("load_scenemap callback")
 						if(!window.CURRENT_SCENE_DATA.scale_factor)
 							window.CURRENT_SCENE_DATA.scale_factor = 1;


### PR DESCRIPTION
If a map used a DD2VTT (or a UVTT) file as its base, and an image file is added as a DM map, the DM map would not appear for the DM (IE  the DM would see the player map)