### PR TITLE
QoL - Option for drawings below darkness/fog

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1172,14 +1172,16 @@ function draw_wizarding_box() {
 	}
 
 }
-function ctxScale(canvasid){
+function ctxScale(canvasid, doNotScale=false){
 	let canvas = document.getElementById(canvasid);
 	canvas.width = $("#scene_map").width();
   	canvas.height = $("#scene_map").height();
-	$(canvas).css({
-		'transform-origin': 'top left',
-		'transform': 'scale(var(--scene-scale))'
-	});
+  	if (!doNotScale) {
+		$(canvas).css({
+			'transform-origin': 'top left',
+			'transform': 'scale(var(--scene-scale))'
+		});
+	}
 }
 
 function reset_canvas(apply_zoom=true) {
@@ -1191,7 +1193,7 @@ function reset_canvas(apply_zoom=true) {
 
 	ctxScale('peer_overlay');
 	ctxScale('temp_overlay');
-	ctxScale('draw_overlay_under_fog_darkness');
+	ctxScale('draw_overlay_under_fog_darkness', true);
 	ctxScale('fog_overlay');
 	ctxScale('grid_overlay');	
 	ctxScale('draw_overlay');

--- a/Main.js
+++ b/Main.js
@@ -2426,6 +2426,12 @@ function init_ui() {
 	background.css("left", "0");
 	background.css("position", "absolute");
 	background.css("z-index", "10");
+	
+	const drawOverlayUnderFogDarkness = $("<canvas id='draw_overlay_under_fog_darkness'></canvas>");
+	drawOverlayUnderFogDarkness.css("position", "absolute");
+	drawOverlayUnderFogDarkness.css("top", "0");
+	drawOverlayUnderFogDarkness.css("left", "0");
+	drawOverlayUnderFogDarkness.css("z-index", "18");
 
 	const mapItems = $("<div id='map_items'></div>");
 	mapItems.css("top", "0");
@@ -2586,6 +2592,7 @@ function init_ui() {
 
 	VTT.append(mapContainer);
 	VTT.append(peerOverlay);
+	VTT.append(drawOverlayUnderFogDarkness);
 	VTT.append(fog);
 	VTT.append(grid);
 	VTT.append(drawOverlay);
@@ -2603,6 +2610,7 @@ function init_ui() {
 
 
 	mapItems.append(background);
+	mapItems.append(drawOverlayUnderFogDarkness);
 
 
 


### PR DESCRIPTION
Added new drawing layer;
Added location options in the draw dropdown;
Add drawing to layer based on location option selected;

The code on line 1481 should make it so that any pre-existing drawings will default to 'above fog', the way they currently are, so this shouldn't break people's current drawings.
The only things I'm a bit iffy on for these changes are

1. The location I put the new _drawOverlayUnderFogDarkness_ draw layer in the HTML - I'm happy for this to be moved somewhere that makes more sense, this was just a spot that worked.
2. The labelling in the dropdown - I wanted to make sure that the labels were short enough to not needlessly widen that dropdown, but they may not be descriptive enough? Open to change.
3. Clearing the draw layer - currently, if you click 'clear draw' in the draw dropdown, it clears both the above fog and below fog draw layers. Maybe it should only clear the currently-selected layer?

New menu options
![image](https://github.com/user-attachments/assets/6351f8ab-9d5e-48fc-8cad-d3759fe278d9)

DM view (yellow text added by me)
![image](https://github.com/user-attachments/assets/13380770-1fd6-4a1a-b110-2c0cf993d4ed)

Player view (with light/darkvision)
![image](https://github.com/user-attachments/assets/c2cdf81b-dbf6-4661-9fa0-5c58ea740bf1)

Player view (without light/darkvision)
![image](https://github.com/user-attachments/assets/ebfd4039-7522-4c8d-a8d6-4084fea555d7)
