### PR TITLE
Added DM-only button to force close a note for all players

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -1090,6 +1090,18 @@ class JournalManager{
 			});
 			
 			visibility_container.append(popup_btn);
+
+			let force_close_popup_btn=$("<button>Force Close by Players</button>")
+
+			force_close_popup_btn.click(function(){
+				window.MB.sendMessage('custom/myVTT/note',{
+						id: id,
+						note:self.notes[id],
+						popup: false,
+					});
+			});
+			
+			visibility_container.append(force_close_popup_btn);
 			
 			let edit_btn=$("<button>Edit</button>");
 			edit_btn.click(function(){

--- a/Journal.js
+++ b/Journal.js
@@ -1091,7 +1091,7 @@ class JournalManager{
 			
 			visibility_container.append(popup_btn);
 
-			let force_close_popup_btn=$("<button>Force Close by Players</button>")
+			let force_close_popup_btn=$("<button>Force Closed by Players</button>")
 
 			force_close_popup_btn.click(function(){
 				window.MB.sendMessage('custom/myVTT/note',{

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -791,10 +791,12 @@ class MessageBroker {
 					if(msg.data.id in window.TOKEN_OBJECTS){
 						window.TOKEN_OBJECTS[msg.data.id].place();			
 					}			
-					const openNote = $(`.note[data-id='${msg.data.id}']`);	
-					if(msg.data.popup){
+					const openNote = $(`.note[data-id='${msg.data.id}']`);
+					// If the 'Open' button is clicked OR the note is already opened by a player and it is saved 
+					// by the DM, the note gets refreshed.
+					if (msg.data.popup == true || (msg.data.popup == undefined && openNote.length != 0)){
 						window.JOURNAL.display_note(msg.data.id);
-					}else {
+					} else if (msg.data.popup == false) {
 						openNote.remove();
 					}
 					

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -790,10 +790,13 @@ class MessageBroker {
 					
 					if(msg.data.id in window.TOKEN_OBJECTS){
 						window.TOKEN_OBJECTS[msg.data.id].place();			
-					}				
-					if(msg.data.popup)
+					}			
+					const openNote = $(`.note[data-id='${msg.data.id}']`);	
+					if(msg.data.popup){
 						window.JOURNAL.display_note(msg.data.id);
-					const openNote = $(`.note[data-id='${msg.data.id}']`);
+					}else {
+						openNote.remove();
+					}
 					
 
 					if(window.JOURNAL.notes[msg.data.id].abilityTracker && openNote.length>0){

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -3970,7 +3970,7 @@ audio::-webkit-media-controls-time-remaining-display{
     border: 1px solid #dddddd;
     background: #e9e9e9;
     padding: 5px;
-    width: 370px;
+    min-width: 370px;
     margin-right: auto;
 }
 .visibility-container button {


### PR DESCRIPTION
#2411 

Using the existing window.MB.sendMessage functionality and sending _popup: false_ instead of true. When popup == false, find the note popup with data-id == note.id and remove it from the HTML. 

Tested with 
1. Notes that were originally forced open by the DM - forces them closed.
2. Notes that were originally shared to the player and opened by them - forces them closed.
3. Multiple notes open - only forces the one note closed.

![image](https://github.com/user-attachments/assets/ee311c30-1ba7-4d2e-9eca-8b8b61f9cf84)
