### PR TITLE
If the DM has one or more tokens selected, speak as those tokens;

### DIFF
--- a/ChatObserver.js
+++ b/ChatObserver.js
@@ -74,9 +74,17 @@ class ChatObserver {
     }
 
     async #sendChatMessage(text) {
+        let player = window.PLAYER_NAME;
+        let image = window.PLAYER_IMG;
+        if(window.DM && window.CURRENTLY_SELECTED_TOKENS.length > 0) {
+            let id = window.CURRENTLY_SELECTED_TOKENS[0];
+            let firstToken = window.TOKEN_OBJECTS[id];
+            image = firstToken.options.imgsrc;
+            player = window.CURRENTLY_SELECTED_TOKENS.map(id => window.TOKEN_OBJECTS[id].options.name).join(", ");
+        }
         let data = {
-            player: window.PLAYER_NAME,
-            img: window.PLAYER_IMG,
+            player: player,
+            img: image,
             dmonly: false,
             language: $('#chat-language').val()
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1605,7 +1605,7 @@ class MessageBroker {
 					</p>
 					<div class="tss-1e6zv06-MessageContainer-Flex">
 						<div class="tss-dr2its-Line-Flex">
-							<span class="tss-1tj70tb-Sender">${data.player}</span>
+							<span class="tss-1tj70tb-Sender" title="${data.player}">${data.player}</span>
 						</div>
 						<div class="tss-8-Collapsed-ref tss-8-Other-ref tss-11w0h4e-Message-Collapsed-Other-Flex">${data.text}</div>
 						<time datetime="${datetime}" title="${datestamp} ${timestamp}" class="tss-1yxh2yy-TimeAgo-TimeAgo">${timestamp}</time>


### PR DESCRIPTION
If the DM has one or more tokens selected, speak as those tokens;
Added title attribute to the character name span in the chat bar so that long titles (such as long character names or, more relevant to this PR, multiple character names can all be seen on hover.

#1849 

In ChatObserver, the sendChatMessage function checks whether the current user is the DM and if they have any tokens selected. 
- If the current user is a player, the message sends as that players character.
- If the current user is the DM with no tokens selected, the message sends from 'THE DM'.
- If the current user is the DM with one or more tokens selected (PC or NPC), the message sends as if from those characters.

Considerations
1. Should the DM be able to send chat messages as if from another player character? Currently with these changes, they are able to, but it should be easy to remove this ability.
2. When sending a message on behalf of multiple tokens, they are currently ordered in the chat panel in the order they were added to the scene. Should this be a different order (such as alphabetic)?

![image](https://github.com/user-attachments/assets/5db1f5de-4020-41d6-9f86-d30bb9fb8871)
