### PR TITLE
Most Mac users would prefer control here

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -206,7 +206,7 @@ Mousetrap.bind('enter', function () {       //zoom minus
     $('.roll-mod-container>.roll-button').click(); 
 });
 
-Mousetrap.bind('mod+space', function (e) {    
+Mousetrap.bind('ctrl+space', function (e) {    
     e.preventDefault();
     $('#combat_area tr[data-current=1] .findTokenCombatButton').click();
 });


### PR DESCRIPTION
Most Mac users have Cmd-Space bound to Spotlight globally, so I think it's preferable to have Control-space be the binding for find token (on both mac and windows)