### PR TITLE
correct build extension in environment.js for safari build

### DIFF
--- a/.github/workflows/safari-release-build.yml
+++ b/.github/workflows/safari-release-build.yml
@@ -9,6 +9,13 @@ on:
         options:
           - UPLOAD
           - NOUPLOAD
+     build_type:
+        type: choice
+        description: "type of build"
+        options:
+          - local
+          - beta
+          - prod
   
 jobs:
   build-safari:
@@ -67,3 +74,6 @@ jobs:
       - name: Run build script
         run: ./build.sh ${{inputs.upload_build}}
         working-directory: safari
+        env:
+          AVTT_BUILD: ${{inputs.build_type}}
+

--- a/safari/build.sh
+++ b/safari/build.sh
@@ -50,6 +50,22 @@ set -e
     MARKETING_VERSION=`python -c 'import json; print(json.loads(open("../manifest.json").read()).get("version"))'`
 #fi
 
+# revert to default
+git checkout -- ../environment.js        
+case $AVTT_BUILD in
+    "prod")
+        echo "--------production build-------------"
+        sed -i '' 's/-local//g' ../environment.js        
+        ;;
+    "beta")
+        echo "--------beta build-------------------"
+        sed -i '' 's/-local/-beta/g' ../environment.js        
+        ;;
+    *)
+        echo "-----default to local build----------"
+        ;;
+esac
+
 echo "----Set marketing version to ${MARKETING_VERSION}"
 echo "MARKETING_VERSION=${MARKETING_VERSION}" > Config.xcconfig
 


### PR DESCRIPTION
I missed a workflow option to get the right build extension into environment.js for safari (no changes except safari build)
