### PR TITLE
Create scene notes

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -2276,8 +2276,6 @@ class JournalManager{
 		$("textarea[data-note-id]").each(function(){
 			let taid=$(this).attr('id')
 			tinyMCE.get(taid)?.execCommand('mceSave');
-			console.log('Closing notes');
-			console.log(window.JOURNAL);
 			const self = window.JOURNAL;
 			if (self.notes && onSaveCallback) {
 				Object.keys(self.notes).forEach(noteId => {
@@ -2287,7 +2285,6 @@ class JournalManager{
 					}
 				});
 			}
-			console.log(window.JOURNAL);
 			$(this).closest(".note")?.dialog("close");
 		});
 	}
@@ -2340,7 +2337,6 @@ class JournalManager{
 				let taid=$(event.target).find("textarea").attr('id');
 				tinyMCE.get(taid).execCommand('mceSave');
 				if (self.notes && onSaveCallback) {
-					console.log(self.notes)
 					Object.keys(self.notes).forEach(noteId => {
 						if (self.notes[noteId]?.isSceneNote ) {
 							onSaveCallback(self.notes[noteId]);
@@ -2348,7 +2344,6 @@ class JournalManager{
 						}
 					});
 				}
-				console.log(self.notes)
 				$(this).remove();
 			}
 		});

--- a/Journal.js
+++ b/Journal.js
@@ -2272,17 +2272,29 @@ class JournalManager{
 		this.persist();
 	}
 	
-	close_all_notes(){
+	close_all_notes(onSaveCallback, id){
 		$("textarea[data-note-id]").each(function(){
 			let taid=$(this).attr('id')
 			tinyMCE.get(taid)?.execCommand('mceSave');
+			console.log('Closing notes');
+			console.log(window.JOURNAL);
+			const self = window.JOURNAL;
+			if (self.notes && onSaveCallback) {
+				Object.keys(self.notes).forEach(noteId => {
+					if (self.notes[noteId]?.isSceneNote ) {
+						onSaveCallback(self.notes[noteId]);
+						delete self.notes[noteId];
+					}
+				});
+			}
+			console.log(window.JOURNAL);
 			$(this).closest(".note")?.dialog("close");
 		});
 	}
 
-	edit_note(id, statBlock = false){
+	edit_note(id, statBlock = false, onSaveCallback){
 		$(`div.note[data-id='${id}']`)?.dialog("close");
-		this.close_all_notes();
+		this.close_all_notes(onSaveCallback, id);
 		let self=this;
 		
 		let note=$("<div class='note'></div>");
@@ -2315,7 +2327,11 @@ class JournalManager{
 				let btn_view=$(`<button class='journal-view-button journal-button'><img height="10" src="${window.EXTENSION_PATH}assets/icons/view.svg"></button>"`);
 				$(this).siblings('.ui-dialog-titlebar').prepend(btn_view);
 				btn_view.click(function(){	
-					self.close_all_notes();
+					if(onSaveCallback) {
+						self.close_all_notes(onSaveCallback, id);
+					}else {
+						self.close_all_notes();
+					}
 					self.display_note(id, statBlock);
 				});
 			},
@@ -2323,6 +2339,16 @@ class JournalManager{
 				// console.log(event);
 				let taid=$(event.target).find("textarea").attr('id');
 				tinyMCE.get(taid).execCommand('mceSave');
+				if (self.notes && onSaveCallback) {
+					console.log(self.notes)
+					Object.keys(self.notes).forEach(noteId => {
+						if (self.notes[noteId]?.isSceneNote ) {
+							onSaveCallback(self.notes[noteId]);
+							delete self.notes[noteId];
+						}
+					});
+				}
+				console.log(self.notes)
 				$(this).remove();
 			}
 		});

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -2331,7 +2331,6 @@ function register_scene_row_context_menu() {
 					name: "Open Scene Note",
 					callback: function(itemKey, opt, originalEvent) {
 						let self=window.JOURNAL;
-						console.log(self);
 						let item = find_sidebar_list_item(opt.$trigger);
 						let new_noteid=uuid();
 

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -2327,6 +2327,41 @@ function register_scene_row_context_menu() {
 						export_scene_context(itemToEdit.id)
 					}
 				};
+				menuItems["openSceneNote"] = {
+					name: "Open Scene Note",
+					callback: function(itemKey, opt, originalEvent) {
+						let self=window.JOURNAL;
+						console.log(self);
+						let item = find_sidebar_list_item(opt.$trigger);
+						let new_noteid=uuid();
+
+						if(item.noteData){
+							self.notes[new_noteid]={
+								...item.noteData,
+								isSceneNote: true, 
+								forScene: item.id,
+							};
+						}else {
+							self.notes[new_noteid]={
+								title: item.name,
+								text: "",
+								player: false,
+								plain: "",
+								isSceneNote: true, 
+								forScene: item.id,
+							};
+						}
+						self.edit_note(new_noteid, false, (note) => {
+							let sceneIndex = window.ScenesHandler.scenes.findIndex((scene) => scene.id == item.id);
+							if (sceneIndex !== -1) {
+								let scene = window.ScenesHandler.scenes[sceneIndex];
+								scene.noteData = note;
+								window.ScenesHandler.persist_scene(sceneIndex, false);
+								rebuild_scene_items_list();
+							}
+						});
+					}
+				}
 			}
 			if(rowItem.isTypeFolder()){
 				menuItems["export"] = {

--- a/Settings.js
+++ b/Settings.js
@@ -1647,6 +1647,10 @@ async function export_scene_context(sceneId){
 	$(".import-loading-indicator").remove();
 }
 
+async function open_scene_note(sceneId){
+	window.JOURNAL.display_note(sceneId, false);
+}
+
 
 
 async function export_scenes_folder_context(folderId){

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -777,6 +777,7 @@ class SidebarListItem {
     let item = new SidebarListItem(sceneData.id, name, sceneData.player_map, ItemType.Scene, folderPath, parentId);
     console.debug(`SidebarListItem.Scene ${item.fullPath()}`);
     item.isVideo = sceneData.player_map_is_video == "1"; // explicity using `==` instead of `===` in case it's ever `1` or `"1"`
+    item.noteData = sceneData.noteData || undefined;
     return item;
   }
 


### PR DESCRIPTION
The idea here is to create a note that applies to a given scene.
It does this by 
1. When the 'Open Scene Note' option is selected, create a hidden note within the journals and open it for editing.
2. User can edit the note as normal.
3. When the user closes the note, the note data is saved to the scene and the hidden note is deleted.
4. When the user selects the 'Open Scene Note' option again, the saved note data is used to re-generate the hidden note and open it for editing.

I did it this way to reuse as much of the existing note infrastructure as possible. Also, since the note data is saved to the scene it should be exported with the rest of the scene data if needed.

Possible next step - if a scene has note data, add an icon on the scene that opens the note without having to use the dropdown menu.

https://github.com/user-attachments/assets/435c56df-9099-49b9-b364-e8cd37a2cb22

