### PR TITLE
Fix undefined defaultValues causing init_zoom_buttons to crash

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -2564,7 +2564,7 @@ function init_zoom_buttons() {
 	if ($("#zoom_buttons").length > 0) {
 		return;
 	}
-	let defaultValues = get_avtt_setting_value('quickToggleDefaults');
+	let defaultValues = get_avtt_setting_value('quickToggleDefaults') || {};
 	// ZOOM BUTTON
 	let zoom_section = $("<div id='zoom_buttons' />");
 	const youtube_controls_button = $(`<div id='youtube_controls_button' class='ddbc-tab-options--layout-pill hasTooltip button-icon hideable' data-name='Quick toggle youtube controls'></div>`);


### PR DESCRIPTION
Fixes #3640

## Summary
Fixed a bug where `init_zoom_buttons()` crashes with "Cannot read properties of undefined (reading 'snapTooltoGrid')" error when loading AboveVTT on character pages.

## Root Cause
The `defaultValues` variable at Main.js:2567 is assigned from `get_avtt_setting_value('quickToggleDefaults')`, which returns `undefined` when the setting doesn't exist. The code then attempts to access properties on `defaultValues` without checking if it exists first.

## Solution
Added a fallback to an empty object (`|| {}`) to ensure `defaultValues` is always defined. This allows all subsequent property checks to safely evaluate without throwing errors.

## Changes
- Main.js:2567 - Added `|| {}` fallback after `get_avtt_setting_value('quickToggleDefaults')`

## Testing
- Tested locally by loading the extension on a D&D Beyond character page
- Verified zoom buttons initialize without errors
- Confirmed all quick toggle functionality works as expected