### PR TITLE
Fix syntax error: remove double comma in quickToggleDefaults options

### DIFF
--- a/Settings.js
+++ b/Settings.js
@@ -642,7 +642,7 @@ function avtt_settings() {
 			{ name: "centerPing", label: "Center Player View on Ping", defaultValue: true, dmOnly: true, type: 'toggle',options: [
 				{ value: true, label: "Enabled", description: `` },
 				{ value: false, label: "Disabled", description: `` }
-			], },,
+			], },
 			{ name: "selectLocked", label: "Locked Tokens Selectable", defaultValue: true, dmOnly: true, type: 'toggle',options: [
 				{ value: true, label: "Enabled", description: `` },
 				{ value: false, label: "Disabled", description: `` }


### PR DESCRIPTION
## Summary
Fixed a syntax error in Settings.js at line 645 where a double comma creates an empty array element in the `quickToggleDefaults` options array.

## Issue
The double comma (`], },,`) creates an empty array slot between the `centerPing` and `selectLocked` option objects.

## Changes
- Settings.js:645 - Changed `], },,` to `], },`

## History
This syntax error has existed since the feature was added in March 2025 (commit 8d1933d3).