### PR TITLE
Automatic lair action token

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -1660,7 +1660,30 @@ function ct_load(data=null){
 		for(let tokenID in window.all_token_objects){
 			if( window.all_token_objects[tokenID].options.ct_show == true || (window.DM && window.all_token_objects[tokenID].options.ct_show !== undefined)) 
 			{		
-				ct_add_token(window.all_token_objects[tokenID],false,true);
+				const token = window.all_token_objects[tokenID];
+				ct_add_token(token,false,true);
+
+				const addLairToken = token?.options?.lairTokenId;
+
+				if(addLairToken) {
+					const id = uuid();
+					const lairToken = new Token({
+						...token.options,
+						name: `${token.options.name} (Lair)`,
+						image: "https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/EXCLAMATION.png",
+						imgsrc: "https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/EXCLAMATION.png",
+						id: id,
+						init: 20,
+						ct_show: false,
+						revealname: false,
+						hasLair: false, 
+						isLairToken: true,
+					});
+					window.TOKEN_OBJECTS[id] = lairToken
+					window.all_token_objects[id] = lairToken;
+					window.all_token_objects[token.options.id].options.lairTokenId = id;
+					ct_add_token(lairToken, false, true, false, false);
+				}
 			}		
 		}
 		if(data.current){

--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -1734,16 +1734,24 @@ function ct_load(data=null){
 
 
 function ct_remove_token(token,persist=true) {
-
-	let id = token.options.id;
-	if ($("#combat_area tr[data-target='" + id + "']").length > 0) {
-		if ($("#combat_area tr[data-target='" + id + "']").attr('data-current') == "1") {
-			$("#combat_next_button").click();
+	if(token){
+		let id = token.options.id;
+		if ($("#combat_area tr[data-target='" + id + "']").length > 0) {
+			if ($("#combat_area tr[data-target='" + id + "']").attr('data-current') == "1") {
+				$("#combat_next_button").click();
+			}
+			$("#combat_area tr[data-target='" + id + "']").remove(); // delete token from the combat tracker if it's there
 		}
-		$("#combat_area tr[data-target='" + id + "']").remove(); // delete token from the combat tracker if it's there
-	}
-	ct_update_popout()
-	if (persist) {
-		debounceCombatPersist();
+		if(token?.options.lairTokenId){
+			let lairTokenId = token.options.lairTokenId;
+			ct_remove_token(window.all_token_objects[lairTokenId]);
+			if(window.all_token_objects[lairTokenId]){
+				window.all_token_objects[lairTokenId].delete();
+			}
+		}
+		ct_update_popout()
+		if (persist) {
+			debounceCombatPersist();
+		}
 	}
 }

--- a/Fog.js
+++ b/Fog.js
@@ -4635,29 +4635,33 @@ function drawing_mouseup(e) {
 			let curr = window.TOKEN_OBJECTS[id];
 
 
-			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0].getBoundingClientRect();	
-			let size = window.TOKEN_OBJECTS[curr.options.id].options.size;	
-			let toktop = (parseInt(tokenImageRect.top) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
-			let tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
-			let tokright = (parseInt(tokenImageRect.right) + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
-			let tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
-			let scaledRemainderTop = (tokbottom-toktop-size)/2;
-			let scaledRemainderLeft = (tokright-tokleft-size)/2;
-			if(window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'circle' || window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'square' || $("#tokens>div[data-id='" + curr.options.id + "']").hasClass("isAoe")){
-				scaledRemainderTop = 0;
-				scaledRemainderLeft = 0;
-			}
-			if (Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom-scaledRemainderTop) == tokbottom-scaledRemainderTop || Math.max(window.BEGIN_MOUSEY, mouseY, toktop+scaledRemainderTop) == toktop+scaledRemainderTop)
-				continue;
-			if (Math.min(window.BEGIN_MOUSEX, mouseX, tokright-scaledRemainderLeft) == tokright-scaledRemainderLeft || Math.max(window.BEGIN_MOUSEX, mouseX, tokleft+scaledRemainderLeft) == tokleft+scaledRemainderLeft)
-				continue;
+			// Optional chaining and condition implemented to stop errors with lair tokens, as lair tokens are 'created' in window.TOKEN_OBJECTS,
+			// but not placed on the map, and thus do not have a token image element to get the bounding rect of.
+			let tokenImageRect = $("#tokens>div[data-id='" + curr.options.id + "'] .token-image")[0]?.getBoundingClientRect();	
+			if(tokenImageRect){
+				let size = window.TOKEN_OBJECTS[curr.options.id].options.size;	
+				let toktop = (parseInt(tokenImageRect.top) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
+				let tokleft = (parseInt(tokenImageRect.left)  + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
+				let tokright = (parseInt(tokenImageRect.right) + window.scrollX - window.VTTMargin) * (1.0 / window.ZOOM);
+				let tokbottom = (parseInt(tokenImageRect.bottom) + window.scrollY - window.VTTMargin) * (1.0 / window.ZOOM);
+				let scaledRemainderTop = (tokbottom-toktop-size)/2;
+				let scaledRemainderLeft = (tokright-tokleft-size)/2;
+				if(window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'circle' || window.TOKEN_OBJECTS[curr.options.id].options.tokenStyleSelect == 'square' || $("#tokens>div[data-id='" + curr.options.id + "']").hasClass("isAoe")){
+					scaledRemainderTop = 0;
+					scaledRemainderLeft = 0;
+				}
+				if (Math.min(window.BEGIN_MOUSEY, mouseY, tokbottom-scaledRemainderTop) == tokbottom-scaledRemainderTop || Math.max(window.BEGIN_MOUSEY, mouseY, toktop+scaledRemainderTop) == toktop+scaledRemainderTop)
+					continue;
+				if (Math.min(window.BEGIN_MOUSEX, mouseX, tokright-scaledRemainderLeft) == tokright-scaledRemainderLeft || Math.max(window.BEGIN_MOUSEX, mouseX, tokleft+scaledRemainderLeft) == tokleft+scaledRemainderLeft)
+					continue;
 
-			c++;
-			// TOKEN IS INSIDE THE SELECTION
-			if (window.DM || !curr.options.hidden) {
-				let tokenDiv = curr.isLineAoe() ? $(`#tokens>div[data-id='${curr.options.id}'] [data-img]`) : $(`#tokens>div[data-id='${curr.options.id}']`)
-				if(tokenDiv.css("pointer-events")!="none" && tokenDiv.css("display")!="none" && !tokenDiv.hasClass("ui-draggable-disabled")) {
-					curr.selected = true;
+				c++;
+				// TOKEN IS INSIDE THE SELECTION
+				if (window.DM || !curr.options.hidden) {
+					let tokenDiv = curr.isLineAoe() ? $(`#tokens>div[data-id='${curr.options.id}'] [data-img]`) : $(`#tokens>div[data-id='${curr.options.id}']`)
+					if(tokenDiv.css("pointer-events")!="none" && tokenDiv.css("display")!="none" && !tokenDiv.hasClass("ui-draggable-disabled")) {
+						curr.selected = true;
+					}
 				}
 			}
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -1176,8 +1176,43 @@ function token_context_menu_expanded(tokenIds, e) {
 							t.options.init = undefined;
 							window.all_token_objects[t.options.id].options.init = undefined;
 						}
-						ct_add_token(t, false, undefined, clickEvent.shiftKey, clickEvent.ctrlKey)
-						t.update_and_sync();
+						const callback = (monsterItem) => {
+							ct_add_token(t, false, undefined, clickEvent.shiftKey, clickEvent.ctrlKey)
+
+							const addLairToken = monsterItem?.monsterData?.hasLair;
+							
+							if(addLairToken) {
+								const id = uuid();
+								const lairToken = new Token({
+									...t.options,
+									name: `${t.options.name} (Lair)`,
+									image: "https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/EXCLAMATION.png",
+									imgsrc: "https://abovevtt-assets.s3.eu-central-1.amazonaws.com/letters/EXCLAMATION.png",
+									id: id,
+									init: 20,
+									ct_show: false,
+									revealname: false,
+									hasLair: false, 
+								});
+								window.TOKEN_OBJECTS[id] = lairToken
+								window.all_token_objects[id] = lairToken;
+								window.all_token_objects[t.options.id].options.lairTokenId = id;
+								ct_add_token(lairToken, false, true, false, false);
+							}
+							t.update_and_sync();
+						}
+						if(t.options.monster > 0 || t.options.monster == 'open5e' || t.options.monster == 'customStat' ){
+							const open5e = t.options.monster == 'open5e';
+							const monsterId = open5e ? t.options.itemId : t.options.monster;
+							let cachedMonsterItem = open5e ? cached_open5e_items[monsterId] : cached_monster_items[monsterId];
+							if (cachedMonsterItem) {
+								callback(cachedMonsterItem);
+							} else {
+								fetch_and_cache_monsters([t], callback(cachedMonsterItem));
+							}
+						}else {
+							callback();
+						}
 					});
 				}
 			}


### PR DESCRIPTION
When adding a token (for example, ancient red dragon) to the combat tracker, it checks the monster's attribute 'hasLair'. If the attribute is true, then it adds a second item to the initiative tracker at initiative count 20, with the name "_MonsterName_ (Lair)" and the exclamation point image. The lair token is hidden from the players.

https://github.com/user-attachments/assets/7bfa1fa0-c494-46af-ad1f-94ab39f94516

When the dragon is removed from the combat tracker (whether by deleting it from the tracker, via the token menu or by deleting the entire monster from the scene), its lair action token is also deleted.

https://github.com/user-attachments/assets/c4bccfb6-c950-4aeb-82ba-69254159649a

The lair token can also be deleted without affecting the original  token.

https://github.com/user-attachments/assets/e05a9abb-c7e1-4803-b99c-e9c280da2c36

