### PR TITLE
Fix: DDBApi.lookForErrors now throws on error paths

### DIFF
--- a/DDBApi.js
+++ b/DDBApi.js
@@ -27,7 +27,9 @@ class DDBApi {
       return response;
     }
     if(response.status == 410){
-      showError(new Error(`DDB 410 Error`), `<b>Try clearing <div style="backdrop-filter: brightness(0.8);padding: 0px 3px;display: inline-block;border-radius: 5px;">${navigator.userAgent.indexOf("Firefox") != -1 ? `temporary cached files and pages` : `cached images and files`}</div> and restarting the browser.</b>`, `<br/><b>As long as you do <span style='color: #900;'>not</span> clear <div style="backdrop-filter: brightness(0.8);padding: 0px 3px;display: inline-block;border-radius: 5px;">cookies and other site data</div> this should not remove any AboveVTT data.`);
+      const error = new Error(`DDB 410 Error`);
+      showError(error, `<b>Try clearing <div style="backdrop-filter: brightness(0.8);padding: 0px 3px;display: inline-block;border-radius: 5px;">${navigator.userAgent.indexOf("Firefox") != -1 ? `temporary cached files and pages` : `cached images and files`}</div> and restarting the browser.</b>`, `<br/><b>As long as you do <span style='color: #900;'>not</span> clear <div style="backdrop-filter: brightness(0.8);padding: 0px 3px;display: inline-block;border-radius: 5px;">cookies and other site data</div> this should not remove any AboveVTT data.`);
+      throw error;
     }
     else{
       // We have an error so let's try to parse it
@@ -40,7 +42,9 @@ class DDBApi {
       if(type == 'EncounterLimitException'){
         alert("Encounter limit reached. AboveVTT needs 1 encounter slot free to join as DM. If you are on a free DDB account you are limited to 8 encounter slots. Please try deleting an encounter.")
       }
-      showError(new Error(`DDB API Error: ${type} ${messages}`));
+      const error = new Error(`DDB API Error: ${type} ${messages}`);
+      showError(error);
+      throw error;
     }
 
   }


### PR DESCRIPTION
## Summary

`DDBApi.lookForErrors()` calls `showError()` on HTTP 4xx/5xx responses but did not return or throw. The function fell through to `undefined`, causing every caller to crash with a `TypeError` when trying to call `.json()` on `undefined`.

## The Bug

```javascript
// Before: lookForErrors shows the error to the user but falls through
static async lookForErrors(response) {
    if (response.status < 400) return response;
    // error paths call showError() but never return or throw
    showError(new Error(`DDB API Error: ...`));
    // falls through to undefined
}

// Callers do this:
const request = await fetch(url).then(DDBApi.lookForErrors);
return await request.json();  // TypeError: Cannot read properties of undefined
```

## The Fix

Store the Error object, pass it to `showError()` (same user-facing behavior), then `throw` it:

```javascript
const error = new Error(`DDB API Error: ...`);
showError(error);  // user still sees the error dialog
throw error;       // .then() chain properly rejects
```

This is applied to both error paths in `lookForErrors`:
- HTTP 410 path (cache clearing guidance)
- General 4xx/5xx path (API error parsing)

## Impact

Affects **every DDB API call** in the application:
- `#refreshToken()` — auth token refresh
- `fetchJsonWithToken()` — all authenticated GET requests
- `fetchJsonWithTokenOmitCred()` — CORS-omit requests
- And transitively: `fetchCharacter`, `fetchMonsters`, `fetchEncounter`, `fetchCampaignInfo`, party inventory, etc.

## What's NOT changed

- `showError()` still displays the error dialog to the user (same UX)
- The error messages are identical
- `deleteWithToken()` explicitly skips `lookForErrors` (by design) — unaffected
- No changes to any callers

## Files changed

- `DDBApi.js` — 1 file, +6/-2 lines