### PR TITLE
Fix: Add .catch() to CharactersPage init chain

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -1082,12 +1082,16 @@ async function init_character_sheet_page() {
         .then(set_game_id)              // set it to window.gameId
         .then(harvest_campaign_secret)  // find our join link
         .then(set_campaign_secret)      // set it to window.CAMPAIGN_SECRET
-        .then(store_campaign_info)      // store gameId and campaign secret in localStorage for use on other pages     
+        .then(store_campaign_info)      // store gameId and campaign secret in localStorage for use on other pages
         .then(async () => {
           window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId);
           if (window.myUser == undefined)
             window.myUser = $('#message-broker-client').attr('data-userid') || Cobalt?.User?.ID;
           window.MB = new MessageBroker();
+        })
+        .catch(error => {
+          console.error("Failed to initialize character page", error);
+          showError(error, "Failed to initialize character page");
         })
     }, 5000)
   }


### PR DESCRIPTION
## Summary

The `harvest_game_id().then().then()...` chain in `CharactersPage.js` had no terminal `.catch()` handler. Any failure in the chain caused an unhandled promise rejection and silently prevented the character page from initializing.

## The Bug

```javascript
harvest_game_id()
  .then(set_game_id)
  .then(harvest_campaign_secret)
  .then(set_campaign_secret)
  .then(store_campaign_info)
  .then(async () => {
    window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId);
    // ...
    window.MB = new MessageBroker();
  })
  // No .catch() — any failure silently kills init
```

## The Fix

Added `.catch()` matching the existing pattern in `CampaignPage.js` (line 56-58):

```javascript
  .catch(error => {
    console.error("Failed to initialize character page", error);
    showError(error, "Failed to initialize character page");
  })
```

## Files changed

- `CharactersPage.js` — 1 file, +5/-1 lines