### PR TITLE
Fix: Add .catch() to peerVideo promise chains

### DIFF
--- a/peerVideo.js
+++ b/peerVideo.js
@@ -212,6 +212,8 @@ function joinRoom(room = window.gameId) {
         if($('#audioSource').val() == '' || $('#videoSource option:nth-of-type(2)').val() == '' || $('#audioSource').val() == null || $('#videoSource option:nth-of-type(2)').val() == null){
             alert('It appears your camera and/or microphone permissions are disabled for dndbeyond. Please enable these in your browser settings and refresh. Alternatively you are missing a video and/or audio input device.')
         }
+    }).catch(error => {
+        console.warn("peerVideo: failed to enumerate media devices", error);
     });
 
 
@@ -319,6 +321,8 @@ function startScreenShare() {
         }
         setLocalStream(screenStream)
         console.log(screenStream)
+    }).catch(error => {
+        console.warn("peerVideo: screen share failed or was denied", error);
     })
 }
 


### PR DESCRIPTION
## Summary

Two promise chains in `peerVideo.js` had no `.catch()` handler, causing unhandled rejections when users deny permissions.

## Fixes

**1. `enumerateDevices()` (line 192)** — If media device permissions are denied or unavailable, the promise rejection was unhandled. Now logs a warning.

**2. `getDisplayMedia()` (line 303)** — If the user cancels the screen share dialog, the promise rejection was unhandled. Now logs a warning.

Both use `console.warn` rather than `showError` since these are expected user actions (denying permissions), not application errors.

## Files changed

- `peerVideo.js` — 1 file, +4 lines