### PR TITLE
Fix: Add .catch() to character refresh API call

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -1969,6 +1969,8 @@ const debounce_fetch_character_from_api = mydebounce(() => {
         console.log(`debounce_fetch_character_from_api is not calling update_pc_with_data for ${characterData.characterId} because ${lastSynchronized} < ${idsAndDates[characterData.characterId]}`);
       }
     });
+  }).catch(error => {
+    console.error("debounce_fetch_character_from_api: failed to fetch character details", error);
   });
 }, 5000); // wait 5 seconds before making API calls. We don't want to make these calls unless we absolutely have to
 


### PR DESCRIPTION
## Summary

`debounce_fetch_character_from_api` calls `DDBApi.fetchCharacterDetails().then()` without a terminal `.catch()`. If the API call fails, the promise rejection is unhandled and character data silently stops updating for the session.

## The Fix

```javascript
  }).catch(error => {
    console.error("debounce_fetch_character_from_api: failed to fetch character details", error);
  });
```

Logs the error for debugging. Character updates will retry on the next debounce cycle (5 seconds later) since `PC_NEEDS_API_CALL` is repopulated by incoming WebSocket messages.

## Files changed

- `CoreFunctions.js` — 1 file, +2 lines