### PR TITLE
Fix: Add optional chaining for CAMPAIGN_INFO.dmId in Startup.mjs

### DIFF
--- a/Startup.mjs
+++ b/Startup.mjs
@@ -48,7 +48,7 @@ $(function() {
       .then(async () => {
         window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId)
         window.AVTT_CAMPAIGN_INFO = await AboveApi.getCampaignData();
-        return window.CAMPAIGN_INFO.dmId;
+        return window.CAMPAIGN_INFO?.dmId;
       })
       .then((campaignDmId) => {
         const isDmPage = is_encounters_page();


### PR DESCRIPTION
Fixes #4062

## The Bug

`Startup.mjs` line 51 accesses `window.CAMPAIGN_INFO.dmId` without a null check. If `DDBApi.fetchCampaignInfo()` returns `undefined` (network error, API failure, auth issue), the TypeError kills the entire startup chain:

```
TypeError: Cannot read properties of undefined (reading 'dmId')
Failed to start AboveVTT on https://www.dndbeyond.com/characters/...
```

## The Fix

```diff
- return window.CAMPAIGN_INFO.dmId;
+ return window.CAMPAIGN_INFO?.dmId;
```

## Why This Works

The downstream code already handles `undefined` gracefully:
- **Line 57:** `isDmPage && campaignDmId == userId` → `false` when `campaignDmId` is `undefined`
- **Line 64:** Same check → falls through to the player startup path at line 75

**Result:** AboveVTT still loads for the player instead of crashing with "Failed to start AboveVTT."

## Files changed

- `Startup.mjs` — 1 character change (`.` → `?.`)