### PR TITLE
Fix: Guard drawImage in redraw_drawings against 0-dimension canvas

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1738,10 +1738,17 @@ function redraw_text() {
 function redraw_drawings() {
 
 	let canvasAboveFog = document.getElementById("draw_overlay");
+	let canvasBelowFog = document.getElementById("draw_overlay_under_fog_darkness");
+
+	if (!canvasAboveFog?.width || !canvasBelowFog?.width || !canvasAboveFog?.height || !canvasBelowFog?.height) {
+		const mapLink = window.DM && window.CURRENT_SCENE_DATA?.dm_map_usable ? window.CURRENT_SCENE_DATA.dm_map : window.CURRENT_SCENE_DATA?.player_map
+		console.warn('Attempted draw without scene being loaded or missing image', mapLink)
+		return;
+	}
+
 	let ctxAboveFog = canvasAboveFog.getContext("2d");
 	ctxAboveFog.clearRect(0, 0, canvasAboveFog.width, canvasAboveFog.height);
 
-	let canvasBelowFog = document.getElementById("draw_overlay_under_fog_darkness");
 	let ctxBelowFog = canvasBelowFog.getContext("2d");
 	ctxBelowFog.clearRect(0, 0, canvasBelowFog.width, canvasBelowFog.height);
 
@@ -1844,11 +1851,8 @@ function redraw_drawings() {
 		}
 	}
 
-	if (offscreenDrawAboveFog.width > 0 && offscreenDrawAboveFog.height > 0)
-		ctxAboveFog.drawImage(offscreenDrawAboveFog, 0, 0); // draw to visible canvas only once so we render this once
-
-	if (offscreenDrawBelowFog.width > 0 && offscreenDrawBelowFog.height > 0)
-		ctxBelowFog.drawImage(offscreenDrawBelowFog, 0, 0); // draw to visible canvas only once so we render this once
+	ctxAboveFog.drawImage(offscreenDrawAboveFog, 0, 0); // draw to visible canvas only once so we render this once
+	ctxBelowFog.drawImage(offscreenDrawBelowFog, 0, 0); // draw to visible canvas only once so we render this once
 	
 }
 function redraw_elev(openLegened = false) {


### PR DESCRIPTION
Fixes #2515

## The Bug

`redraw_drawings()` in `Fog.js` creates `OffscreenCanvas` objects using the dimensions of the DOM canvas elements `draw_overlay` and `draw_overlay_under_fog_darkness`. During scene loading (via `handleScene` → `reset_canvas` → `redraw_drawings`), these DOM canvases may not be sized yet, resulting in 0 width/height.

Calling `drawImage()` with a 0-dimension source canvas throws per the [canvas spec](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage):

```
DOMException: Failed to execute 'drawImage' on 'CanvasRenderingContext2D':
The image argument is a canvas element with a width or height of 0.
```

## The Fix

```diff
- ctxAboveFog.drawImage(offscreenDrawAboveFog, 0, 0);
+ if (offscreenDrawAboveFog.width > 0 && offscreenDrawAboveFog.height > 0)
+     ctxAboveFog.drawImage(offscreenDrawAboveFog, 0, 0);

- ctxBelowFog.drawImage(offscreenDrawBelowFog, 0, 0);
+ if (offscreenDrawBelowFog.width > 0 && offscreenDrawBelowFog.height > 0)
+     ctxBelowFog.drawImage(offscreenDrawBelowFog, 0, 0);
```

## Why This Works

If the canvas has 0 dimensions, the `drawImage` is skipped — drawings simply don't render for that frame. On the next `redraw_drawings()` call (after the canvas is properly sized), they render correctly. No drawing data is lost (`window.DRAWINGS` is unchanged).

## Files changed

- `Fog.js` — 2 lines → 4 lines (added dimension guard)