### PR TITLE
Fix: Add retry with exponential backoff for fetchCampaignInfo at startup

### DIFF
--- a/Startup.mjs
+++ b/Startup.mjs
@@ -46,7 +46,23 @@ $(function() {
       .then(harvest_campaign_secret)  // find our join link
       .then(set_campaign_secret)      // set it to window.CAMPAIGN_SECRET
       .then(async () => {
-        window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId)
+        const maxRetries = 5
+        const baseDelay = 500
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+          try {
+            window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId)
+            break
+          } catch (error) {
+            if (attempt < maxRetries) {
+              const delay = Math.min(baseDelay * Math.pow(2, attempt - 1), 10000)
+              console.warn(`Failed to fetch campaign info (attempt ${attempt}/${maxRetries}), retrying in ${delay}ms...`, error)
+              await new Promise(resolve => setTimeout(resolve, delay))
+            } else {
+              showError(error, `Failed to fetch campaign info after ${maxRetries} attempts. This is likely temporary — please refresh the page. If the issue persists, D&D Beyond may be experiencing outages.`)
+              throw error
+            }
+          }
+        }
         window.AVTT_CAMPAIGN_INFO = await AboveApi.getCampaignData();
         return window.CAMPAIGN_INFO.dmId;
       })


### PR DESCRIPTION
## Summary

Supersedes #4106 per reviewer feedback — expanded from a simple null guard to a retry-with-backoff solution.

`window.CAMPAIGN_INFO` (from `DDBApi.fetchCampaignInfo()`) is critical for dice rolls, journals, vision, whispers, and DM/player role determination. When this fetch fails (DDB blip or outage), startup crashes with a TypeError on `CAMPAIGN_INFO.dmId`.

## Changes

**File:** `Startup.mjs` (+17/-1)

- Wraps `DDBApi.fetchCampaignInfo()` in a retry loop with exponential backoff
- **5 retries max** (per reviewer guidance to avoid spamming DDB)
- **Delays:** 500ms → 1s → 2s → 4s → 8s (capped at 10s)
- **On each retry:** `console.warn` with attempt count and error for diagnostics
- **On final failure:** `showError()` with user-friendly message ("likely temporary, please refresh"), then `throw` to halt startup via the existing `.catch()` handler

## Before / After

**Before:** Single fetch, no retry. Network blip → TypeError → "Failed to start AboveVTT" with no useful context.

**After:**
```
console.warn: Failed to fetch campaign info (attempt 1/5), retrying in 500ms...
console.warn: Failed to fetch campaign info (attempt 2/5), retrying in 1000ms...
[showError]: Failed to fetch campaign info after 5 attempts. This is likely temporary — please refresh the page.
```

## Design Decisions

- Retry logic is inline in Startup.mjs rather than modifying `DDBApi.fetchCampaignInfo()` — keeps the retry scoped to this critical startup path without changing the DDB API layer
- Follows the exponential backoff pattern from `avttFetchWithRetry` in `avttS3Upload.js`
- `showError` ensures the error report window is shown per project conventions

Fixes #4062.