### PR TITLE
Fix: Guard against undefined playerUsers in fetchCampaignCharacterIds

### DIFF
--- a/DDBApi.js
+++ b/DDBApi.js
@@ -319,8 +319,13 @@ class DDBApi {
         console.warn("fetchCampaignCharacterIds caught an error trying to collect ids from fetchActiveCharacters", error);
       } 
     }
+    if (!window.playerUsers) {
+      console.warn("fetchCampaignCharacterIds: failed to fetch campaign characters, falling back to DM");
+      window.myUser = window.CAMPAIGN_INFO?.dmId;
+      return characterIds;
+    }
     let playerUser = window.playerUsers.filter(d=> d.id == window.PLAYER_ID)[0]?.userId;
-    window.myUser = playerUser ? playerUser : window.CAMPAIGN_INFO.dmId; 
+    window.myUser = playerUser ? playerUser : window.CAMPAIGN_INFO?.dmId;
     return characterIds;
   }
 


### PR DESCRIPTION
## Summary

When both `fetchCampaignCharacters()` and `fetchActiveCharacters()` fail (e.g., DDB returns HTTP 403 or 504), `window.playerUsers` is never assigned. Line 322 then crashes calling `.filter()` on `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at DDBApi.fetchCampaignCharacterIds (DDBApi.js:281:41)
```

## Changes

**File:** `DDBApi.js` (+6/-1)

- Added null check for `window.playerUsers` before the `.filter()` call
- Returns early with `console.warn` for diagnostics
- Falls back to `CAMPAIGN_INFO.dmId` for `window.myUser` (same fallback the existing code uses)
- Added optional chaining on `CAMPAIGN_INFO.dmId` in both the new guard and the existing line for safety

## Before / After

**Before:** Both API calls fail → `window.playerUsers` is `undefined` → `.filter()` crashes → startup fails.

**After:** Both API calls fail → early return with warning → `myUser` set to DM ID as fallback → startup continues gracefully.

## Context

- PR #4093 (merged) fixed the upstream `lookForErrors` issue that caused many of these API failures, but a 403/504 from DDB can still leave `playerUsers` unset
- Related issue #3292 (Azmoria filed) documents this class of problem affecting players

Fixes #3613.