### PR TITLE
Fix: Add retry with backoff for fetchCampaignCharacterIds

### DIFF
--- a/DDBApi.js
+++ b/DDBApi.js
@@ -300,27 +300,40 @@ class DDBApi {
       return characterIds;
     }
 
-
-    try {
-      window.playerUsers = await DDBApi.fetchCampaignCharacters(campaignId);
-      characterIds = window.playerUsers.map(c => c.id);
-    } 
-    catch (error) {
+    const maxRetries = 3;
+    const baseDelay = 1000;
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        // This is what the campaign page calls
-        window.playerUsers = await DDBApi.fetchActiveCharacters(campaignId);
-        window.playerUsers.forEach(c => {
-          if (!characterIds.includes(c.id)) {
-            characterIds.push(c.id);
-          }
-        });
-      } 
+        window.playerUsers = await DDBApi.fetchCampaignCharacters(campaignId);
+        characterIds = window.playerUsers.map(c => c.id);
+        break;
+      }
       catch (error) {
-        console.warn("fetchCampaignCharacterIds caught an error trying to collect ids from fetchActiveCharacters", error);
-      } 
+        try {
+          // This is what the campaign page calls
+          window.playerUsers = await DDBApi.fetchActiveCharacters(campaignId);
+          window.playerUsers.forEach(c => {
+            if (!characterIds.includes(c.id)) {
+              characterIds.push(c.id);
+            }
+          });
+          break;
+        }
+        catch (fallbackError) {
+          if (attempt < maxRetries) {
+            const delay = Math.min(baseDelay * Math.pow(2, attempt - 1), 8000);
+            console.warn(`fetchCampaignCharacterIds: both endpoints failed (attempt ${attempt}/${maxRetries}), retrying in ${delay}ms...`, fallbackError);
+            await new Promise(resolve => setTimeout(resolve, delay));
+          } else {
+            console.warn("fetchCampaignCharacterIds: failed to fetch campaign characters after all retries", fallbackError);
+            showError(fallbackError, "Failed to load campaign characters. Please refresh the page.");
+            return characterIds;
+          }
+        }
+      }
     }
     let playerUser = window.playerUsers.filter(d=> d.id == window.PLAYER_ID)[0]?.userId;
-    window.myUser = playerUser ? playerUser : window.CAMPAIGN_INFO.dmId; 
+    window.myUser = playerUser ? playerUser : window.CAMPAIGN_INFO.dmId;
     return characterIds;
   }
 


### PR DESCRIPTION
## Summary

Reworked from #4118 per @Azmoria's feedback — retry with exponential backoff instead of null fallback values.

When both DDB character endpoints fail (server blip or outage), `window.playerUsers` remains `undefined` and the `.filter()` call on line 322 crashes with a TypeError.

**Before:** Both endpoints fail → `window.playerUsers` is `undefined` → `undefined.filter()` → TypeError

**After:** Both endpoints fail → retry up to 3 times with exponential backoff (1s, 2s, 4s) → on final failure, `showError()` for the report window + return empty `characterIds` (downstream `fetchCharacterDetails` handles empty arrays gracefully at line 268-270)

## Changes

- Wraps existing two-step fetch logic in a retry loop (3 attempts, exponential backoff)
- `console.warn` on each retry for diagnostics
- `showError()` on final failure so it appears in the error report window
- Returns empty `characterIds` on failure instead of crashing (no null fallback values)
- Fixed inner catch variable shadowing (`catch (error)` → `catch (fallbackError)`)
- Same retry pattern as merged #4114 (`fetchCampaignInfo`)

Supersedes #4118. Fixes #3613.