### PR TITLE
Internal Beta - log errors caught/sent through showError as console.error; Add noLogError class so we can do custom showError messages and throw noLogError after to stop code; Remove some error display redundancy

### DIFF
--- a/AboveApi.js
+++ b/AboveApi.js
@@ -46,15 +46,11 @@ class AboveApi {
       request = await fetch(url);
     } catch (error) {
       const wrappedError = new Error(`AboveApi network error for '${action}': ${error.message}`);
-      console.error(wrappedError.message, error);
-      showError(wrappedError);
       throw wrappedError;
     }
     if (!request.ok) {
       const errorText = await request.text().catch(() => 'Unknown error');
       const httpError = new Error(`AboveApi HTTP ${request.status} for '${action}': ${errorText}`);
-      console.error(httpError.message);
-      showError(httpError);
       throw httpError;
     }
     let response;
@@ -62,8 +58,6 @@ class AboveApi {
       response = await request.json();
     } catch (error) {
       const parseError = new Error(`AboveApi: invalid JSON response for '${action}'`);
-      console.error(parseError.message, error);
-      showError(parseError);
       throw parseError;
     }
     this.checkForErrors(response);
@@ -126,15 +120,11 @@ class AboveApi {
       request = await fetch(url, config);
     } catch (error) {
       const wrappedError = new Error(`AboveApi network error for 'setCampaignData': ${error.message}`);
-      console.error(wrappedError.message, error);
-      showError(wrappedError);
       throw wrappedError;
     }
     if (!request.ok) {
       const errorText = await request.text().catch(() => 'Unknown error');
       const httpError = new Error(`AboveApi HTTP ${request.status} for 'setCampaignData': ${errorText}`);
-      console.error(httpError.message);
-      showError(httpError);
       throw httpError;
     }
     let response;
@@ -142,8 +132,6 @@ class AboveApi {
       response = await request.json();
     } catch (error) {
       const parseError = new Error("AboveApi: invalid JSON response for 'setCampaignData'");
-      console.error(parseError.message, error);
-      showError(parseError);
       throw parseError;
     }
     console.log("AboveApi.setCampaignData", response);
@@ -206,15 +194,11 @@ class AboveApi {
         request = await fetch(url, config);
       } catch (error) {
         const wrappedError = new Error(`AboveApi network error for 'migrateScenes': ${error.message}`);
-        console.error(wrappedError.message, error);
-        showError(wrappedError);
-        throw wrappedError;
+        throw wrappedError
       }
       if (!request.ok) {
         const errorText = await request.text().catch(() => 'Unknown error');
         const httpError = new Error(`AboveApi HTTP ${request.status} for 'migrateScenes': ${errorText}`);
-        console.error(httpError.message);
-        showError(httpError);
         throw httpError;
       }
       console.log("AboveApi.migrateScenes request", request);

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -29,6 +29,13 @@ $(function() {
   }
 });
 
+class noLogError extends Error{
+  constructor(message, options) {
+    super(message, options); 
+    this.name = "noLogError";
+  }
+}
+
 const async_sleep = m => new Promise(r => setTimeout(r, m));
 
 const charactersPageRegex = /\/characters\/\d+/;
@@ -54,6 +61,7 @@ function getAltKeyName() {
 function getShiftKeyName() {
   return isMac() ? "&#8679;" : "SHIFT";
 }
+
 
 
 function mydebounce(func, timeout = 800){  
@@ -792,10 +800,6 @@ function create_update_token(options, save = true) {
 
   if (!(id in window.TOKEN_OBJECTS)) {
     window.TOKEN_OBJECTS[id] = new Token(options);
-
-    window.TOKEN_OBJECTS[id].sync = mydebounce(function(options) {
-      window.MB.sendMessage('custom/myVTT/token', options);
-    }, 300);
   }
 
   if(options.repositionAoe != undefined){
@@ -1438,15 +1442,15 @@ function dropBoxOptions(callback, multiselect = false, fileType=['images', 'vide
 function showErrorMessage(error, ...extraInfo) {
   removeError();
   window.logSnapshot = process_monitored_logs(false);
-
-  console.log("showErrorMessage", ...extraInfo, error.stack);
   if (!(error instanceof Error)) {
     if (typeof error === "object") {
       error = JSON.stringify(error);
     } 
     error = new Error(error?.toString());
   }
+
   const stack = error.stack || new Error().stack;
+  console.error(error, ...extraInfo);
   if(stack.includes('Internal Server Error') && stack.includes('AboveApi.getScene')){
     if(!window.DM){
       extraInfo.push('<br/><b>The last scene players were on may have been deleted by the DM. Ask the DM to click the player button beside an existing scene. Even if one is already highlighted click it again to update the server info.</b>')
@@ -1553,12 +1557,16 @@ function showGoogleDriveWarning(){
  * @param {Error} error an error object to be parsed and displayed
  * @param {string|*[]} extraInfo other relevant information */
 function showError(error, ...extraInfo) {
+  if(error instanceof noLogError) 
+    return;
+  
   if (!(error instanceof Error)) {
     if (typeof error === "object") {
       error = JSON.stringify(error);
     } 
     error = new Error(error?.toString());
   }
+
   $('#loadingStyles').remove(); 
   showErrorMessage(error, ...extraInfo);
 

--- a/DDBApi.js
+++ b/DDBApi.js
@@ -29,7 +29,7 @@ class DDBApi {
     if(response.status == 410){
       const error = new Error(`DDB 410 Error`);
       showError(error, `<b>Try clearing <div style="backdrop-filter: brightness(0.8);padding: 0px 3px;display: inline-block;border-radius: 5px;">${navigator.userAgent.indexOf("Firefox") != -1 ? `temporary cached files and pages` : `cached images and files`}</div> and restarting the browser.</b>`, `<br/><b>As long as you do <span style='color: #900;'>not</span> clear <div style="backdrop-filter: brightness(0.8);padding: 0px 3px;display: inline-block;border-radius: 5px;">cookies and other site data</div> this should not remove any AboveVTT data.`);
-      throw error;
+      throw noLogError(error);
     }
     else{
       // We have an error so let's try to parse it
@@ -43,7 +43,6 @@ class DDBApi {
         alert("Encounter limit reached. AboveVTT needs 1 encounter slot free to join as DM. If you are on a free DDB account you are limited to 8 encounter slots. Please try deleting an encounter.")
       }
       const error = new Error(`DDB API Error: ${type} ${messages}`);
-      showError(error);
       throw error;
     }
 

--- a/Startup.mjs
+++ b/Startup.mjs
@@ -59,7 +59,7 @@ $(function() {
               await new Promise(resolve => setTimeout(resolve, delay))
             } else {
               showError(error, `Failed to fetch campaign info after ${maxRetries} attempts. This is likely temporary — please refresh the page. If the issue persists, D&D Beyond may be experiencing outages.`)
-              throw error
+              throw new noLogError(error.message, error.options)
             }
           }
         }


### PR DESCRIPTION
If we ever need to have a custom error display with `showError(error, 'custom string/html to add to top of error box usually instructions to try to resolve')` we can now still stop code without overriding that error box with `throw new noLogError(message, options)`

Cleans up some double error messaging when we showError and then throw it after. When there isn't any added text we can just throw the error and allow the global error handling to catch it. Only need to showError and throw a noLogError when we want custom text for troubleshooting in the error popup. 