### PR TITLE
Improved whisper menu (including Image Popup feature); Spectator whispering; Stat block cleaner look for Send to Gamelog

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2835,9 +2835,7 @@ function display_url_embeded(url){
 
 //+++ dialog menus in the style of top level tools
 // todo:
-// -- make menu construction on-demand? (reduce resources?)
-// -- make sure dialogs fit on screen (positioning)
-// -- more general options for dialog menus
+// -- more general options for dialog menus (when used beyond send-player buttons)
 function dialogMenuOption(rootId, container, opt) {
   if(opt.type === 'hr') {
     $(`<span class="js-popup-decoration">${opt.label || ""}</span>`).appendTo(container);      
@@ -2874,6 +2872,8 @@ function createDialogMenuTrigger(iconName, menuId, create, onShow) {
   <span class="material-symbols-outlined">${iconName}</span></button>`);
   button.on('click', (e) => {
     //create the dialog on first use
+    e.preventDefault();
+    e.stopPropagation();
     const dialog = $("#"+menuId, e.target.ownerDocument)?.[0] || create(menuId, e.target);
     if(dialog.open) {
       dialog.close();
@@ -2930,8 +2930,8 @@ function createSendPlayerMenu(menuId, target) {
       //todo: if selected is everyone then use undefined here:
       send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, selected);
     } else {
-      const imgSrc = $(".magnify")?.attr("src")
-      //todo: decide to send to everyone or iterate through users....
+      //todo: deal with video
+      const imgSrc = $(".magnify, .monster-image")?.attr("src")
       if(imgSrc) {
         window.MB.sendMessage('custom/myVTT/Popup',  {
           src: imgSrc,
@@ -2939,6 +2939,8 @@ function createSendPlayerMenu(menuId, target) {
           whisper: selected,
           from:window.PLAYER_ID
         });
+      } else {
+        console.error("Could not find image to pop", imgSrc);
       }
     }
     $(e.target).removeClass('js-popup--is-active');
@@ -2974,11 +2976,11 @@ function createSendPlayerButton(parent, icon, hasPopupOption=false ) {
     $($(dialog).find("button")[1]).css("display", hasPopupOption ? "" : "none");
   });
   button.addClass("block-send-to-game-log");
+  button.addClass("send-player-button")
   if(hasPopupOption) button.addClass("has-popup-option");
-  button.css("right", "2px"); //todo: temp so we see both buttons
   return button;
 }
-//--- dialog menus 
+//-end- dialog menus 
 
 function find_or_create_generic_draggable_window(id, titleBarText, addLoadingIndicator = true, addPopoutButton = false, popoutSelector=``, width='80%', height='80%', top='10%', left='10%', showSlow = true, cancelClasses='', hideOnX = false, alwaysDisplayTitle = false) {
   console.log(`find_or_create_generic_draggable_window id: ${id}, titleBarText: ${titleBarText}, addLoadingIndicator: ${addLoadingIndicator}, addPopoutButton: ${addPopoutButton}`);

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2985,9 +2985,7 @@ function createSendPlayerButton(parent, icon, hasPopupOption=false ) {
     sendClonedElement($(e.target).closest("button").parent());
   });
   if(hasPopupOption) button.attr("data-haspopup", "1");
-  //todo: evaluate stuff in this style:
   button.addClass("block-send-to-game-log");
-  button.addClass("send-player-button")
   return button;
 }
 //-end- dialog menus 

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2841,11 +2841,9 @@ function dialogMenuOption(rootId, container, opt) {
     $(`<span class="js-popup-decoration">${opt.label || ""}</span>`).appendTo(container);      
   } else {
     const icon = opt.icon ? `<span class="material-symbols-outlined" style="font-size: inherit;">${opt.icon}</span>` : "";
-    // this method has some spacing issues:
-    // const ttip = opt.tooltip ? ` hasTooltip" data-name="${opt.tooltip}"` : '"';
-    // so doing old school for now:
-    const ttip = opt.tooltip ? `" title="${opt.tooltip}"` : '"';    
-    const button = $(`<button id='${rootId}_${opt.id}' class="js-popup-option${ttip} data-id='${opt.id}'>${icon}${opt.label}</button>`);
+    // hasTooltip style has some layout issues so doing old school for now:
+    const button = $(`<button id='${rootId}_${opt.id}' class="js-popup-option" data-id='${opt.id}'>${icon}${opt.label}</button>`);
+    if(opt.tooltip) button.attr('title', opt.tooltip)
     //ddbc-tab-options__header-heading
     const callback = opt.callback;
     const closeAfter = opt.closeAfter;
@@ -2914,10 +2912,13 @@ function dialogCloser(e, force) {
   });
 }
 function addDialogCloser(element) {
-  //named function so multiple event listeners don't happen  
-  element.ownerDocument.addEventListener('mousedown', dialogCloser);
+  const doc = element.ownerDocument;
+  //even tho named function so multiple event listeners shouldn't happen
+  //attempt to optimize
+  if (doc._hasDialogCloser) return;
+  doc.addEventListener('mousedown', dialogCloser);
+  doc._hasDialogCloser = true;
 }
-
 
 function sendClonedElement(element, whisper, popInstead) {
   const targetBlock = $(element).clone();

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2920,23 +2920,26 @@ function addDialogCloser(element) {
   doc._hasDialogCloser = true;
 }
 
-function sendClonedElement(element, whisper, popInstead) {
+function sendPopElement(element, whisper) {
+  const what = element.find(".magnify, .monster-image, video");
+  const src = what?.attr("src");
+  const video = what.prop('nodeName') === 'VIDEO';  
+  if(src) {
+    const msg = { src, timed: 10000, from: window.PLAYER_ID, type: video ? "iframe" : "image" };
+    if(whisper) msg.whisper = whisper;
+    window.MB.sendMessage('custom/myVTT/Popup',  msg);
+  } else {
+    console.error("Could not find image to pop", src);
+  }
+}
+function sendClonedElement(element, whisper) {
   const targetBlock = $(element).clone();
   targetBlock.find('button.block-send-to-game-log').remove();
-  targetBlock.find('img').removeAttr('width height style').toggleClass('magnify', true);
-  if(popInstead) {
-      //todo: deal with video
-      const imgSrc = targetBlock.find(".magnify, .monster-image")?.attr("src")
-    if(imgSrc) {
-      const msg = { src: imgSrc, timed: 10000, from:window.PLAYER_ID };
-      if(whisper) msg.whisper = whisper;
-      window.MB.sendMessage('custom/myVTT/Popup',  msg);
-    } else {
-      console.error("Could not find image to pop", imgSrc);
-    }
-  } else {
-    send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, whisper);
-  }
+  targetBlock.find('img, video').removeAttr('width height style').toggleClass('magnify', true);
+  const video = targetBlock.find('video');
+  //why?
+  if(video) video.attr("href", video.attr('src'));
+  send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, whisper);
 }
 
 function createSendPlayerMenu(menuId, target) {
@@ -2946,8 +2949,8 @@ function createSendPlayerMenu(menuId, target) {
     const options = $(e.target).closest(".js-popup-options")?.[0];
     const selected = $(options).find('.js-popup--is-active').map((i, el) => el.getAttribute('data-id')).get().filter((a)=> !a.startsWith('_'));
     const theTriggeringButton = $(`#${$(dialog).attr("data-whichbutton")}`);
-    //todo: if selected is everyone then use undefined here:    
-    sendClonedElement(theTriggeringButton.parent(), selected, verb === 'pop');
+    //todo: if selected is everyone then use undefined here:
+    ((verb === 'pop') ? sendPopElement : sendClonedElement)(theTriggeringButton.parent(), selected);
     $(e.target).removeClass('js-popup--is-active');
   };
   const toggle_everyone = (e, skipCount) => {

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2830,7 +2830,7 @@ function display_url_embeded(url){
 // -- more general options for dialog menus
 function dialogMenuOption(rootId, container, opt) {
   if(opt.type === 'hr') {
-    $('<hr style="margin-top: 1px; margin-bottom: 1px; padding: 0; border: 0; border-top: 2px solid #ccc;"/>').appendTo(container);
+    $(`<span class="js-popup-decoration">${opt.label || ""}</span>`).appendTo(container);      
   } else {
     const button = $(`<button id='${rootId}_${opt.id}' class='js-popup-option' data-id='${opt.id}'>${opt.label}</button>`);
     //ddbc-tab-options__header-heading
@@ -2853,7 +2853,7 @@ function createDialogMenu(rootId, options) {
   return dialog[0]; //note: return native element, NOT jquery
 }
 
-function createDialogMenuTrigger(iconName, menuId, create) {
+function createDialogMenuTrigger(iconName, menuId, create, onShow) {
   const buttonId = uuid();
   const button = $(`<button id="${buttonId}" class="js-popup-trigger" width="100px" height="100px">
   <span class="material-symbols-outlined">${iconName}</span></button>`);
@@ -2864,22 +2864,19 @@ function createDialogMenuTrigger(iconName, menuId, create) {
       dialog.close();
     } else {
       //right now using show (but could decide that showModal is better)
+      if(onShow) onShow(e, dialog);
       dialog.show(); //so we can get dimensions 
       $(dialog).attr("data-content", buttonId) //remember triggering button
       const rect = $(e.target)[0].getBoundingClientRect();
-      const menuRect = $(dialog)[0].getBoundingClientRect(); // The Menu
+      const menuRect = $(dialog)[0].getBoundingClientRect();
       const winW = window.innerWidth;
       const winH = window.innerHeight;
-      let top = rect.bottom;
-      let left = rect.left;
-      if (top + menuRect.height > winH) {
-        top = rect.top - menuRect.height;
-      }
-      if (left + menuRect.width > winW) {
-        left = winW - menuRect.width - 10;
-      }
-      top = Math.max(10, top);
-      left = Math.max(10, left);
+      const top = Math.max(10, (rect.bottom + menuRect.height > winH) 
+        ? rect.top - menuRect.height 
+        : rect.bottom);
+      const left = Math.max(10, (rect.left + menuRect.width > winW) 
+        ? winW - menuRect.width - 10 
+        : rect.left);      
       $(dialog).css({
         position: 'fixed', // Stays put during scroll
         top: top + 'px',
@@ -2940,12 +2937,13 @@ function createSendPlayerMenu(menuId, target) {
       selected.toggleClass('js-popup--is-active');      
     }
   }
+  const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values()];
   const menu = createDialogMenu(menuId, [
     { id: "_send", label: "📩 Send To Log", callback: (e) => callback_with_selection(e, "send")},
     { id: "_pop", label: "⬆️ Popup", callback: (e) => callback_with_selection(e, "pop")},
-    { id: "_everyone", label: "🔁 Toggle All", callback: (e) => toggle_everyone(e, 2)},
-    { type: "hr" },    
-    ...window.playerUsers.map((p)=> {return { id: p.userId, label: p.userName, active: true }})
+    { id: "_everyone", label: "🔁 Toggle All", callback: (e) => toggle_everyone(e, 3)},
+    { type: "hr", label: "Users" },
+    ...users
   ]);
   $(menu).css
   $(target).closest('body').append(menu);
@@ -2953,10 +2951,14 @@ function createSendPlayerMenu(menuId, target) {
   return menu;
 }
 
-function createSendPlayerButton(parent, icon) {
+function createSendPlayerButton(parent, icon, hasPopupOption=false ) {
   const menuId = "send-player-menu";
-  const button = createDialogMenuTrigger(icon, menuId, createSendPlayerMenu);
+  const button = createDialogMenuTrigger(icon, menuId, createSendPlayerMenu, (e,dialog) => {
+    //hide/show popup option in shared menu
+    $($(dialog).find("button")[1]).css("display", hasPopupOption ? "" : "none");
+  });
   button.addClass("block-send-to-game-log");
+  if(hasPopupOption) button.addClass("has-popup-option");
   button.css("right", "2px"); //todo: temp so we see both buttons
   return button;
 }

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2823,6 +2823,145 @@ function display_url_embeded(url){
   $('body').append(container);
 }
 
+//+++ dialog menus in the style of top level tools
+// todo:
+// -- make menu construction on-demand? (reduce resources?)
+// -- make sure dialogs fit on screen (positioning)
+// -- more general options for dialog menus
+function dialogMenuOption(rootId, container, opt) {
+  if(opt.type === 'hr') {
+    $('<hr style="margin-top: 1px; margin-bottom: 1px; padding: 0; border: 0; border-top: 2px solid #ccc;"/>').appendTo(container);
+  } else {
+    const button = $(`<button id='${rootId}_${opt.id}' class='js-popup-option' data-id='${opt.id}'>${opt.label}</button>`);
+    //ddbc-tab-options__header-heading
+    const callback = opt.callback;
+    if(opt.active) button.addClass("js-popup--is-active");
+    button.on('click', function (e) {
+      const buttonSelectedClasses = "js-popup--is-active"
+      $(this).toggleClass(buttonSelectedClasses);
+      e.preventDefault()
+      if(callback) callback(e);
+    });
+    button.appendTo(container);
+  }
+}
+function createDialogMenu(rootId, options) {
+  const dialog = $(`<dialog id="${rootId}" class="js-popup">
+  <form method="dialog"><div class="js-popup-options"/></form></dialog>`);
+  const contain = dialog.find('.js-popup-options')[0]
+  options.map((opt) => dialogMenuOption(rootId, contain, opt));
+  return dialog[0]; //note: return native element, NOT jquery
+}
+
+function createDialogMenuTrigger(iconName, menuId, create) {
+  const buttonId = uuid();
+  const button = $(`<button id="${buttonId}" class="js-popup-trigger" width="100px" height="100px">
+  <span class="material-symbols-outlined">${iconName}</span></button>`);
+  button.on('click', (e) => {
+    //create the dialog on first use
+    const dialog = $("#"+menuId, e.target.ownerDocument)?.[0] || create(menuId, e.target);
+    if(dialog.open) {
+      dialog.close();
+    } else {
+      //right now using show (but could decide that showModal is better)
+      dialog.show(); //so we can get dimensions 
+      $(dialog).attr("data-content", buttonId) //remember triggering button
+      const rect = $(e.target)[0].getBoundingClientRect();
+      const menuRect = $(dialog)[0].getBoundingClientRect(); // The Menu
+      const winW = window.innerWidth;
+      const winH = window.innerHeight;
+      let top = rect.bottom;
+      let left = rect.left;
+      if (top + menuRect.height > winH) {
+        top = rect.top - menuRect.height;
+      }
+      if (left + menuRect.width > winW) {
+        left = winW - menuRect.width - 10;
+      }
+      top = Math.max(10, top);
+      left = Math.max(10, left);
+      $(dialog).css({
+        position: 'fixed', // Stays put during scroll
+        top: top + 'px',
+        left: left + 'px',
+      });
+    }
+  });
+  return button;
+}
+
+function dialogCloser(e, force) {
+  e.target.ownerDocument.querySelectorAll('dialog.js-popup[open]').forEach(menu => {
+    const isClickInside = menu.contains(e.target);
+    const isTriggerClick = e.target.closest('.js-popup-trigger');
+    const isClickOnChild = menu.contains(e.target);
+    console.log("CLose?", force, menu, isClickInside, isTriggerClick, isClickOnChild);
+    if (!isClickInside && !isTriggerClick && !isClickOnChild || force) menu.close();
+  });
+}
+function addDialogCloser(element) {
+  //named function so multiple event listeners don't happen  
+  element.ownerDocument.addEventListener('mousedown', dialogCloser);
+}
+
+function createSendPlayerMenu(menuId, target) {
+  // If campaign changes then will need to remove and re-create menu
+  const callback_with_selection = (e, verb) => {
+    const dialog = $(e.target).closest(".js-popup")?.[0];      
+    const options = $(e.target).closest(".js-popup-options")?.[0];
+    const selected = $(options).find('.js-popup--is-active').map((i, el) => el.getAttribute('data-id')).get().filter((a)=> !a.startsWith('_'));
+    const theTriggeringButton = $(`#${$(dialog).attr("data-content")}`);
+    const targetBlock = $(theTriggeringButton).parent().clone();
+    targetBlock.find('button.block-send-to-game-log').remove();
+    targetBlock.find('img').removeAttr('width height style').toggleClass('magnify', true);
+    if(verb === 'send') {
+      //todo: if selected is everyone then use undefined here:
+      send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, selected);
+    } else {
+      const imgSrc = $(".magnify")?.attr("src")
+      console.log("POP TO PLAYERS", selected, targetBlock[0].outerHTML);
+        if(imgSrc) {
+          window.MB.sendMessage('custom/myVTT/Popup',  {
+            src: imgSrc,
+            timed: 10000,
+            from:window.PLAYER_ID
+          });
+        }
+    }
+    $(e.target).removeClass('js-popup--is-active');
+  };
+  const toggle_everyone = (e, skipCount) => {
+    $(e.target).removeClass('js-popup--is-active');    
+    const options = $(e.target).closest(".js-popup-options");
+    const selected = $(options).find('.js-popup--is-active');
+    if(selected.length === 0) {
+      options.children().slice(skipCount+1).toggleClass('js-popup--is-active');
+    } else {
+      selected.toggleClass('js-popup--is-active');      
+    }
+  }
+  const menu = createDialogMenu(menuId, [
+    { id: "_send", label: "📩 Send To Log", callback: (e) => callback_with_selection(e, "send")},
+    { id: "_pop", label: "⬆️ Popup", callback: (e) => callback_with_selection(e, "pop")},
+    { id: "_everyone", label: "🔁 Toggle All", callback: (e) => toggle_everyone(e, 2)},
+    { type: "hr" },    
+    ...window.playerUsers.map((p)=> {return { id: p.userId, label: p.userName, active: true }})
+  ]);
+  $(menu).css
+  $(target).closest('body').append(menu);
+  addDialogCloser(target);
+  return menu;
+}
+
+function createSendPlayerButton(parent, icon) {
+  const menuId = "send-player-menu";
+  const button = createDialogMenuTrigger(icon, menuId, createSendPlayerMenu);
+  button.addClass("block-send-to-game-log");
+  button.css("right", "2px"); //todo: temp so we see both buttons
+  return button;
+}
+//--- dialog menus 
+
 function find_or_create_generic_draggable_window(id, titleBarText, addLoadingIndicator = true, addPopoutButton = false, popoutSelector=``, width='80%', height='80%', top='10%', left='10%', showSlow = true, cancelClasses='', hideOnX = false, alwaysDisplayTitle = false) {
   console.log(`find_or_create_generic_draggable_window id: ${id}, titleBarText: ${titleBarText}, addLoadingIndicator: ${addLoadingIndicator}, addPopoutButton: ${addPopoutButton}`);
 

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2985,6 +2985,7 @@ function createSendPlayerButton(parent, icon, hasPopupOption=false ) {
     sendClonedElement($(e.target).closest("button").parent());
   });
   if(hasPopupOption) button.attr("data-haspopup", "1");
+  //todo: evaluate stuff in this style:
   button.addClass("block-send-to-game-log");
   button.addClass("send-player-button")
   return button;

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2948,7 +2948,7 @@ function createSendPlayerMenu(menuId, target) {
       selected.toggleClass('js-popup--is-active');      
     }
   }
-  const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values(), { id:SPECTATOR_WHISPER_ID, name: "Spectator", active: true}];
+  const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values(), { id: SPECTATOR_WHISPER_ID, label: "-Spectator-", active: true}];
   const menu = createDialogMenu(menuId, [
     { id: "_send", label: "📩 Send To Log", callback: (e) => callback_with_selection(e, "send")},
     { id: "_pop", label: "⬆️ Popup", callback: (e) => callback_with_selection(e, "pop")},

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2869,11 +2869,11 @@ function createDialogMenu(rootId, options) {
 }
 
 //turn an element into a menu trigger
-function makeDialogMenuTrigger(element, menuId, createMenu, onShow) {
+function makeDialogMenuTrigger(element, trigger, menuId, createMenu, onShow) {
   const elementId = uuid(); //give it a uuid so we can find it later in menu code
   element.attr('id', elementId);
   element.addClass("js-popup-trigger")
-  element.off('click').on('click', (e) => {
+  element.off(trigger).on(trigger, (e) => {
     //create the dialog on first use
     e.preventDefault();
     e.stopPropagation();
@@ -2910,13 +2910,32 @@ function dialogCloser(e, force) {
     const isClickInside = menu.contains(e.target);
     const isTriggerClick = e.target.closest('.js-popup-trigger');
     const isClickOnChild = menu.contains(e.target);
-    console.log("CLose?", force, menu, isClickInside, isTriggerClick, isClickOnChild);
     if (!isClickInside && !isTriggerClick && !isClickOnChild || force) menu.close();
   });
 }
 function addDialogCloser(element) {
   //named function so multiple event listeners don't happen  
   element.ownerDocument.addEventListener('mousedown', dialogCloser);
+}
+
+
+function sendClonedElement(element, whisper, popInstead) {
+  const targetBlock = $(element).clone();
+  targetBlock.find('button.block-send-to-game-log').remove();
+  targetBlock.find('img').removeAttr('width height style').toggleClass('magnify', true);
+  if(popInstead) {
+      //todo: deal with video
+      const imgSrc = targetBlock.find(".magnify, .monster-image")?.attr("src")
+    if(imgSrc) {
+      const msg = { src: imgSrc, timed: 10000, from:window.PLAYER_ID };
+      if(whisper) msg.whisper = whisper;
+      window.MB.sendMessage('custom/myVTT/Popup',  msg);
+    } else {
+      console.error("Could not find image to pop", imgSrc);
+    }
+  } else {
+    send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, whisper);
+  }
 }
 
 function createSendPlayerMenu(menuId, target) {
@@ -2926,26 +2945,8 @@ function createSendPlayerMenu(menuId, target) {
     const options = $(e.target).closest(".js-popup-options")?.[0];
     const selected = $(options).find('.js-popup--is-active').map((i, el) => el.getAttribute('data-id')).get().filter((a)=> !a.startsWith('_'));
     const theTriggeringButton = $(`#${$(dialog).attr("data-whichbutton")}`);
-    const targetBlock = $(theTriggeringButton).parent().clone();
-    targetBlock.find('button.block-send-to-game-log').remove();
-    targetBlock.find('img').removeAttr('width height style').toggleClass('magnify', true);
-    if(verb === 'send') {
-      //todo: if selected is everyone then use undefined here:
-      send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, selected);
-    } else {
-      //todo: deal with video
-      const imgSrc = $(".magnify, .monster-image")?.attr("src")
-      if(imgSrc) {
-        window.MB.sendMessage('custom/myVTT/Popup',  {
-          src: imgSrc,
-          timed: 10000,
-          whisper: selected,
-          from:window.PLAYER_ID
-        });
-      } else {
-        console.error("Could not find image to pop", imgSrc);
-      }
-    }
+    //todo: if selected is everyone then use undefined here:    
+    sendClonedElement(theTriggeringButton.parent(), selected, verb === 'pop');
     $(e.target).removeClass('js-popup--is-active');
   };
   const toggle_everyone = (e, skipCount) => {
@@ -2966,7 +2967,6 @@ function createSendPlayerMenu(menuId, target) {
     { type: "hr", label: "Users" },
     ...users
   ]);
-  $(menu).css
   $(target).closest('body').append(menu);
   addDialogCloser(target);
   return menu;
@@ -2977,8 +2977,13 @@ function setPlayerButtonSetPopupStatus(e, dialog, buttonId) {
   $("#send-player-menu__pop", e.target.ownerDocument).css("display", hasPopupOption ? "" : "none"); 
 }
 function createSendPlayerButton(parent, icon, hasPopupOption=false ) {
-  const element = $(`<button width="100px" height="100px"> <span class="material-symbols-outlined">${icon}</span></button>`);
-  const button = makeDialogMenuTrigger(element, "send-player-menu", createSendPlayerMenu, setPlayerButtonSetPopupStatus);
+  const element = $(`<button width="200px" height="200px"> <span class="material-symbols-outlined">${icon}</span></button>`);
+  const button = makeDialogMenuTrigger(element, 'contextmenu', "send-player-menu", createSendPlayerMenu, setPlayerButtonSetPopupStatus);
+  button.off('click').on('click', (e)=> {
+    e.preventDefault();
+    e.stopPropagation();
+    sendClonedElement($(e.target).closest("button").parent());
+  });
   if(hasPopupOption) button.attr("data-haspopup", "1");
   button.addClass("block-send-to-game-log");
   button.addClass("send-player-button")

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2842,7 +2842,8 @@ function dialogMenuOption(rootId, container, opt) {
   if(opt.type === 'hr') {
     $(`<span class="js-popup-decoration">${opt.label || ""}</span>`).appendTo(container);      
   } else {
-    const button = $(`<button id='${rootId}_${opt.id}' class='js-popup-option' data-id='${opt.id}'>${opt.label}</button>`);
+    const icon = opt.icon ? `<span class="material-symbols-outlined" style="font-size: inherit;">${opt.icon}</span>` : "";
+    const button = $(`<button id='${rootId}_${opt.id}' class='js-popup-option' data-id='${opt.id}'>${icon}${opt.label}</button>`);
     //ddbc-tab-options__header-heading
     const callback = opt.callback;
     if(opt.active) button.addClass("js-popup--is-active");
@@ -2950,9 +2951,9 @@ function createSendPlayerMenu(menuId, target) {
   }
   const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values(), { id: SPECTATOR_WHISPER_ID, label: "-Spectator-", active: true}];
   const menu = createDialogMenu(menuId, [
-    { id: "_send", label: "📩 Send To Log", callback: (e) => callback_with_selection(e, "send")},
-    { id: "_pop", label: "⬆️ Popup", callback: (e) => callback_with_selection(e, "pop")},
-    { id: "_everyone", label: "🔁 Toggle All", callback: (e) => toggle_everyone(e, 3)},
+    { id: "_send", label: "Send To Log", callback: (e) => callback_with_selection(e, "send"), icon: "login"},
+    { id: "_pop", label: "Popup", icon: "toast", callback: (e) => callback_with_selection(e, "pop")},
+    { id: "_everyone", label: "Toggle All", icon: "toggle_on", callback: (e) => toggle_everyone(e, 3)},
     { type: "hr", label: "Users" },
     ...users
   ]);

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2848,12 +2848,14 @@ function dialogMenuOption(rootId, container, opt) {
     const button = $(`<button id='${rootId}_${opt.id}' class="js-popup-option${ttip} data-id='${opt.id}'>${icon}${opt.label}</button>`);
     //ddbc-tab-options__header-heading
     const callback = opt.callback;
+    const closeAfter = opt.closeAfter;
     if(opt.active) button.addClass("js-popup--is-active");
     button.on('click', function (e) {
       const buttonSelectedClasses = "js-popup--is-active"
       $(this).toggleClass(buttonSelectedClasses);
       e.preventDefault()
       if(callback) callback(e);
+      if(closeAfter) $(e.target).closest(".js-popup")?.[0]?.close();      
     });
     button.appendTo(container);
   }
@@ -2866,22 +2868,23 @@ function createDialogMenu(rootId, options) {
   return dialog[0]; //note: return native element, NOT jquery
 }
 
-function createDialogMenuTrigger(iconName, menuId, create, onShow) {
-  const buttonId = uuid();
-  const button = $(`<button id="${buttonId}" class="js-popup-trigger" width="100px" height="100px">
-  <span class="material-symbols-outlined">${iconName}</span></button>`);
-  button.on('click', (e) => {
+//turn an element into a menu trigger
+function makeDialogMenuTrigger(element, menuId, createMenu, onShow) {
+  const elementId = uuid(); //give it a uuid so we can find it later in menu code
+  element.attr('id', elementId);
+  element.addClass("js-popup-trigger")
+  element.off('click').on('click', (e) => {
     //create the dialog on first use
     e.preventDefault();
     e.stopPropagation();
-    const dialog = $("#"+menuId, e.target.ownerDocument)?.[0] || create(menuId, e.target);
+    const dialog = $("#"+menuId, e.target.ownerDocument)?.[0] || createMenu(menuId, e.target);
     if(dialog.open) {
       dialog.close();
     } else {
+      if(onShow) onShow(e, dialog, elementId); //before show callback
       //right now using show (but could decide that showModal is better)
-      if(onShow) onShow(e, dialog);
       dialog.show(); //so we can get dimensions 
-      $(dialog).attr("data-content", buttonId) //remember triggering button
+      $(dialog).attr("data-whichbutton", elementId) //remember who triggered
       const rect = $(e.target)[0].getBoundingClientRect();
       const menuRect = $(dialog)[0].getBoundingClientRect();
       const winW = window.innerWidth;
@@ -2899,7 +2902,7 @@ function createDialogMenuTrigger(iconName, menuId, create, onShow) {
       });
     }
   });
-  return button;
+  return element;
 }
 
 function dialogCloser(e, force) {
@@ -2922,7 +2925,7 @@ function createSendPlayerMenu(menuId, target) {
     const dialog = $(e.target).closest(".js-popup")?.[0];      
     const options = $(e.target).closest(".js-popup-options")?.[0];
     const selected = $(options).find('.js-popup--is-active').map((i, el) => el.getAttribute('data-id')).get().filter((a)=> !a.startsWith('_'));
-    const theTriggeringButton = $(`#${$(dialog).attr("data-content")}`);
+    const theTriggeringButton = $(`#${$(dialog).attr("data-whichbutton")}`);
     const targetBlock = $(theTriggeringButton).parent().clone();
     targetBlock.find('button.block-send-to-game-log').remove();
     targetBlock.find('img').removeAttr('width height style').toggleClass('magnify', true);
@@ -2957,8 +2960,8 @@ function createSendPlayerMenu(menuId, target) {
   }
   const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values(), { id: SPECTATOR_WHISPER_ID, label: "-Spectator-", active: true}];
   const menu = createDialogMenu(menuId, [
-    { id: "_send", label: "Send To Log", callback: (e) => callback_with_selection(e, "send"), icon: "login", tooltip: "Send to Gamelog of selected users"},
-    { id: "_pop", label: "Popup", icon: "toast", callback: (e) => callback_with_selection(e, "pop"), tooltip: "Popup a momentary image for selected users"},
+    { id: "_send", label: "Send To Log", callback: (e) => callback_with_selection(e, "send"), icon: "login", tooltip: "Send to Gamelog of selected users", closeAfter: true},
+    { id: "_pop", label: "Popup", icon: "toast", callback: (e) => callback_with_selection(e, "pop"), tooltip: "Popup a momentary image for selected users", closeAfter: true },
     { id: "_everyone", label: "Toggle All", icon: "toggle_on", callback: (e) => toggle_everyone(e, 3), tooltip: "Toggle user buttons below"},
     { type: "hr", label: "Users" },
     ...users
@@ -2969,15 +2972,16 @@ function createSendPlayerMenu(menuId, target) {
   return menu;
 }
 
+function setPlayerButtonSetPopupStatus(e, dialog, buttonId) {
+  const hasPopupOption = $("#"+buttonId).attr("data-haspopup");
+  $("#send-player-menu__pop", e.target.ownerDocument).css("display", hasPopupOption ? "" : "none"); 
+}
 function createSendPlayerButton(parent, icon, hasPopupOption=false ) {
-  const menuId = "send-player-menu";
-  const button = createDialogMenuTrigger(icon, menuId, createSendPlayerMenu, (e,dialog) => {
-    //hide/show popup option in shared menu
-    $($(dialog).find("button")[1]).css("display", hasPopupOption ? "" : "none");
-  });
+  const element = $(`<button width="100px" height="100px"> <span class="material-symbols-outlined">${icon}</span></button>`);
+  const button = makeDialogMenuTrigger(element, "send-player-menu", createSendPlayerMenu, setPlayerButtonSetPopupStatus);
+  if(hasPopupOption) button.attr("data-haspopup", "1");
   button.addClass("block-send-to-game-log");
   button.addClass("send-player-button")
-  if(hasPopupOption) button.addClass("has-popup-option");
   return button;
 }
 //-end- dialog menus 

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2860,7 +2860,7 @@ function dialogMenuOption(rootId, container, opt) {
 }
 function createDialogMenu(rootId, options) {
   const dialog = $(`<dialog id="${rootId}" class="js-popup">
-  <form method="dialog"><div class="js-popup-options"/></form></dialog>`);
+  <form method="dialog"><div class="js-popup-options prevent-sidebar-modal-close"/></form></dialog>`);
   const contain = dialog.find('.js-popup-options')[0]
   options.map((opt) => dialogMenuOption(rootId, contain, opt));
   return dialog[0]; //note: return native element, NOT jquery

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -1886,12 +1886,22 @@ async function rebuild_window_pcs() {
  * @returns {string[]}
  */
 function get_my_known_languages() {
+  if(is_spectator_page()) return ['Common', 'Telepathy']; //reasonable default
   const pc = find_pc_by_player_id(my_player_id())
   const knownLanguages = pc?.proficiencyGroups.find(g => g.group === "Languages")?.values?.trim().split(/\s*,\s*/gi) ?? [];
   knownLanguages?.push('Telepathy');
   return knownLanguages;
 }
 
+// the special string to whisper to spectator screens
+const SPECTATOR_WHISPER_ID = "-spectator";
+
+function canHearWhisper(whisper) {
+  if(!whisper) return true;
+  const myName = is_spectator_page() ? SPECTATOR_WHISPER_ID : window.PLAYER_NAME;
+  const myId = is_spectator_page() ? SPECTATOR_WHISPER_ID : `${window.myUser}`
+  return (whisper === myName || (Array.isArray(whisper) && whisper.includes(myId)));
+}
 
 function update_pc_with_data(playerId, data) {
   if (data.constructor !== Object) {
@@ -2916,14 +2926,15 @@ function createSendPlayerMenu(menuId, target) {
       send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, selected);
     } else {
       const imgSrc = $(".magnify")?.attr("src")
-      console.log("POP TO PLAYERS", selected, targetBlock[0].outerHTML);
-        if(imgSrc) {
-          window.MB.sendMessage('custom/myVTT/Popup',  {
-            src: imgSrc,
-            timed: 10000,
-            from:window.PLAYER_ID
-          });
-        }
+      //todo: decide to send to everyone or iterate through users....
+      if(imgSrc) {
+        window.MB.sendMessage('custom/myVTT/Popup',  {
+          src: imgSrc,
+          timed: 10000,
+          whisper: selected,
+          from:window.PLAYER_ID
+        });
+      }
     }
     $(e.target).removeClass('js-popup--is-active');
   };
@@ -2937,7 +2948,7 @@ function createSendPlayerMenu(menuId, target) {
       selected.toggleClass('js-popup--is-active');      
     }
   }
-  const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values()];
+  const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values(), { id:SPECTATOR_WHISPER_ID, name: "Spectator", active: true}];
   const menu = createDialogMenu(menuId, [
     { id: "_send", label: "📩 Send To Log", callback: (e) => callback_with_selection(e, "send")},
     { id: "_pop", label: "⬆️ Popup", callback: (e) => callback_with_selection(e, "pop")},

--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2843,7 +2843,11 @@ function dialogMenuOption(rootId, container, opt) {
     $(`<span class="js-popup-decoration">${opt.label || ""}</span>`).appendTo(container);      
   } else {
     const icon = opt.icon ? `<span class="material-symbols-outlined" style="font-size: inherit;">${opt.icon}</span>` : "";
-    const button = $(`<button id='${rootId}_${opt.id}' class='js-popup-option' data-id='${opt.id}'>${icon}${opt.label}</button>`);
+    // this method has some spacing issues:
+    // const ttip = opt.tooltip ? ` hasTooltip" data-name="${opt.tooltip}"` : '"';
+    // so doing old school for now:
+    const ttip = opt.tooltip ? `" title="${opt.tooltip}"` : '"';    
+    const button = $(`<button id='${rootId}_${opt.id}' class="js-popup-option${ttip} data-id='${opt.id}'>${icon}${opt.label}</button>`);
     //ddbc-tab-options__header-heading
     const callback = opt.callback;
     if(opt.active) button.addClass("js-popup--is-active");
@@ -2951,9 +2955,9 @@ function createSendPlayerMenu(menuId, target) {
   }
   const users = [...new Map(window.playerUsers.map(p => [p.userId, {id: p.userId, label: p.userName, active: true}])).values(), { id: SPECTATOR_WHISPER_ID, label: "-Spectator-", active: true}];
   const menu = createDialogMenu(menuId, [
-    { id: "_send", label: "Send To Log", callback: (e) => callback_with_selection(e, "send"), icon: "login"},
-    { id: "_pop", label: "Popup", icon: "toast", callback: (e) => callback_with_selection(e, "pop")},
-    { id: "_everyone", label: "Toggle All", icon: "toggle_on", callback: (e) => toggle_everyone(e, 3)},
+    { id: "_send", label: "Send To Log", callback: (e) => callback_with_selection(e, "send"), icon: "login", tooltip: "Send to Gamelog of selected users"},
+    { id: "_pop", label: "Popup", icon: "toast", callback: (e) => callback_with_selection(e, "pop"), tooltip: "Popup a momentary image for selected users"},
+    { id: "_everyone", label: "Toggle All", icon: "toggle_on", callback: (e) => toggle_everyone(e, 3), tooltip: "Toggle user buttons below"},
     { type: "hr", label: "Users" },
     ...users
   ]);

--- a/Journal.js
+++ b/Journal.js
@@ -2238,76 +2238,6 @@ class JournalManager{
 	block_send_to_buttons(target){
 		const blocks = target.find('img:not(.mon-stat-block__separator-img), .text--quote-box, .rules-text, .block-torn-paper, .read-aloud-text, .dmScreenChunk')
 
-		const sendToGamelogButton = $('<button class="block-send-to-game-log"><span class="material-symbols-outlined">login</span></button>')
-
-		
-	
-
-	    const whisper_container=$("<div class='whisper-container'/>");
-
-        for(let i=0; i<window.playerUsers.length; i++){
-			if(whisper_container.find(`input[name='${window.playerUsers[i].userId}']`).length == 0){
-				let whisper_toggle=$(`<input type='checkbox' name='${window.playerUsers[i].userId}'/>`);
-				let whisper_row = $(`<div class='whisper_toggle_row'><label>${window.playerUsers[i].userName}</label></div>`)
-				whisper_toggle.off('click.toggle').on('click.toggle', function(e){
-
-					e.stopPropagation();
-				})
-				whisper_row.find('label').off('click.stopProp').on('click.stopProp', function(e){
-					e.stopPropagation();
-					e.preventDefault();
-					$(this).next('input[type=checkbox]').click();
-				})
-				whisper_row.append(whisper_toggle)
-
-				
-				whisper_container.append(whisper_row);
-			}
-		}
-		sendToGamelogButton.off('contextmenu').on("contextmenu", function(e) {
-			e.preventDefault();
-			e.stopPropagation();
-			const checkedInputs=$(this).find('.whisper-container input:checked');
-	        checkedInputs.click();
-			$(this).find('.whisper-container').toggleClass('visible');
-
-			if($(this).find('.whisper-container').hasClass('visible')){
-		      $(document).on('click.blurWhisperHandle', function(e){
-		        if($(e.target).closest('.whisper-container').length == 0){
-		          $('.whisper-container').toggleClass('visible', false)
-		          $(document).off('click.blurWhisperHandle');
-		        }
-		      })  
-		    }
-		})
-		$(sendToGamelogButton).append(whisper_container);
-		sendToGamelogButton.off('click').on("click", function(e) {
-	        e.stopPropagation();
-	        e.preventDefault();
-	        
-	        let targetBlock = $(e.currentTarget).parent().clone();
-	        targetBlock.find('button.block-send-to-game-log').remove();
-	        targetBlock.find('img').removeAttr('width height style').toggleClass('magnify', true);
-	       	const whisper_container=$(this).find('.whisper-container');
-	        if(whisper_container.hasClass('visible')){
-	        	const checkedInputs = whisper_container.find('input:checked');
-	        	const whisperArray = [];
-	        	checkedInputs.each(function () {
-			       whisperArray.push($(this).attr('name'));
-			  	});
-			  	send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`, whisperArray)
-	        }
-	        else{
-	        	send_html_to_gamelog(`<p>${targetBlock[0].outerHTML}</p>`);
-	        }
-	        
-	    });
-
-
-		const tables = target.find('table');
-		
-		const allDiceRegex = /(\d+)?d(?:100|20|12|10|8|6|4)((?:kh|kl|ro(<|<=|>|>=|=)|min=)\d+)*/g; // ([numbers]d[diceTypes]kh[numbers] or [numbers]d[diceTypes]kl[numbers]) or [numbers]d[diceTypes]
-       	
    		blocks.wrap(function(i){
 			const container = $(`<div class='note-text' style='position:relative;max-width: 100%;'></div>`)
 			if(blocks[i] instanceof HTMLImageElement){
@@ -2320,23 +2250,23 @@ class JournalManager{
 			return container;
 		});
 		blocks.each((i, block) => {
-			createSendPlayerButton(block, "send", block instanceof HTMLImageElement).insertAfter(block);			
+			createSendPlayerButton(block, "login", block instanceof HTMLImageElement).insertAfter(block);			
 		});
 		//todo: decide if we like new method and cleanup this old one
-		sendToGamelogButton.clone(true, true).insertAfter(blocks);
+		//sendToGamelogButton.clone(true, true).insertAfter(blocks);
 
-		
+		const tables = target.find('table');
+		const allDiceRegex = /(\d+)?d(?:100|20|12|10|8|6|4)((?:kh|kl|ro(<|<=|>|>=|=)|min=)\d+)*/g; // ([numbers]d[diceTypes]kh[numbers] or [numbers]d[diceTypes]kl[numbers]) or [numbers]d[diceTypes]
 		if(allDiceRegex.test($(tables).find('tr:first-of-type>:first-child').text())){
 			let result = $(tables).find(`tbody > tr td:last-of-type`);
 			$(tables).find('td').css({
 				'position': 'relative',
 				'padding-right': '10px'
 			});
-			result.append(sendToGamelogButton.clone(true, true)); 
+			//result.append(sendToGamelogButton.clone(true, true));
+			result.each((i, block) =>
+				block.append(createSendPlayerButton(block, "login")));
 		}
-
-
-		
 	}
 				   
 	replaceNoteEmbed(text, notesIncluded=[]){

--- a/Journal.js
+++ b/Journal.js
@@ -2261,8 +2261,6 @@ class JournalManager{
 		blocks.each((i, block) => {
 			createSendPlayerButton(block, "login", block instanceof HTMLImageElement).insertAfter(block);			
 		});
-		//todo: decide if we like new method and cleanup this old one
-		//sendToGamelogButton.clone(true, true).insertAfter(blocks);
 
 		const tables = target.find('table');
 		const allDiceRegex = /(\d+)?d(?:100|20|12|10|8|6|4)((?:kh|kl|ro(<|<=|>|>=|=)|min=)\d+)*/g; // ([numbers]d[diceTypes]kh[numbers] or [numbers]d[diceTypes]kl[numbers]) or [numbers]d[diceTypes]
@@ -2272,7 +2270,6 @@ class JournalManager{
 				'position': 'relative',
 				'padding-right': '10px'
 			});
-			//result.append(sendToGamelogButton.clone(true, true));
 			result.each((i, block) =>
 				block.append(createSendPlayerButton(block, "login")));
 		}

--- a/Journal.js
+++ b/Journal.js
@@ -2319,9 +2319,12 @@ class JournalManager{
 			}
 			return container;
 		});
+		blocks.each((i, block) => {
+			createSendPlayerButton(block, "send", block instanceof HTMLImageElement).insertAfter(block);			
+		});
 		//todo: decide if we like new method and cleanup this old one
 		sendToGamelogButton.clone(true, true).insertAfter(blocks);
-		createSendPlayerButton(blocks, "send").insertAfter(blocks);
+
 		
 		if(allDiceRegex.test($(tables).find('tr:first-of-type>:first-child').text())){
 			let result = $(tables).find(`tbody > tr td:last-of-type`);

--- a/Journal.js
+++ b/Journal.js
@@ -2271,7 +2271,7 @@ class JournalManager{
 				'padding-right': '10px'
 			});
 			result.each((i, block) =>
-				block.append(createSendPlayerButton(block, "login")));
+				$(block).append(createSendPlayerButton(block, "login")));
 		}
 	}
 				   

--- a/Journal.js
+++ b/Journal.js
@@ -2245,7 +2245,7 @@ class JournalManager{
 	    }
 	}
 	block_send_to_buttons(target){
-		const blocks = target.find('img:not(.mon-stat-block__separator-img), .text--quote-box, .rules-text, .block-torn-paper, .read-aloud-text, .dmScreenChunk')
+		const blocks = target.find('img:not(.mon-stat-block__separator-img), video, .text--quote-box, .rules-text, .block-torn-paper, .read-aloud-text, .dmScreenChunk')
 
    		blocks.wrap(function(i){
 			const container = $(`<div class='note-text' style='position:relative;max-width: 100%;'></div>`)

--- a/Journal.js
+++ b/Journal.js
@@ -2247,7 +2247,6 @@ class JournalManager{
 
         for(let i=0; i<window.playerUsers.length; i++){
 			if(whisper_container.find(`input[name='${window.playerUsers[i].userId}']`).length == 0){
-				const randomId = uuid();
 				let whisper_toggle=$(`<input type='checkbox' name='${window.playerUsers[i].userId}'/>`);
 				let whisper_row = $(`<div class='whisper_toggle_row'><label>${window.playerUsers[i].userName}</label></div>`)
 				whisper_toggle.off('click.toggle').on('click.toggle', function(e){
@@ -2320,7 +2319,10 @@ class JournalManager{
 			}
 			return container;
 		});
+		//todo: decide if we like new method and cleanup this old one
 		sendToGamelogButton.clone(true, true).insertAfter(blocks);
+		createSendPlayerButton(blocks, "send").insertAfter(blocks);
+		
 		if(allDiceRegex.test($(tables).find('tr:first-of-type>:first-child').text())){
 			let result = $(tables).find(`tbody > tr td:last-of-type`);
 			$(tables).find('td').css({

--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -321,12 +321,13 @@ if(is_spectator_page()){
         sendPointerEvent('#lock_view_button')
     });
 }
-Mousetrap.bind('esc', function () {     //deselect all buttons
+Mousetrap.bind('esc', function (e) {     //deselect all buttons
     clear_temp_canvas();
     close_splash();
     $('#displayedDiceFormula').remove();
     delete window.numpadRollFormulaMod;
     delete window.numpadRollFormula;
+    dialogCloser(e, true);
 
     //reselect the current menu to trigger draw stop/reset, allows cancelling polygons or other drawings
     //ensure menu stays open if it was open, as clicking the button again would close it

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1124,8 +1124,8 @@ class MessageBroker {
 				}
 			} else if(msg.eventType=="custom/myVTT/Popup"){
 				if(!window.DM &&
-				   !(msg.data.from && msg.data.from != window.PLAYER_ID) &&
-				   !(msg.data.to && msg.data.to != "everyone" && msg.data.to != window.PLAYER_ID)) {
+   				   !(msg.data.from && msg.data.from != window.PLAYER_ID) &&
+				   canHearWhisper(msg.data.whisper)) {
 					if(msg.data.delete == true){
 						$.magnificPopup.close();
 					} else {
@@ -1326,11 +1326,11 @@ class MessageBroker {
 				dicePeer.close();
 				if(msg.data.to != "everyone"){
 					window.MB.inject_chat({
-              player: window.PLAYER_NAME,
-              img: window.PLAYER_IMG,
-              text: `<span class="flex-wrap-center-chat-message">One of your dice stream connections has failed/disconnected. Try reconnecting to the dice stream if this was not intentional.<br/><br/></div>`,
-              whisper: window.PLAYER_NAME
-          });
+						player: window.PLAYER_NAME,
+						img: window.PLAYER_IMG,
+						text: `<span class="flex-wrap-center-chat-message">One of your dice stream connections has failed/disconnected. Try reconnecting to the dice stream if this was not intentional.<br/><br/></div>`,
+						whisper: window.PLAYER_NAME
+					});
 				}
 			} else if(msg.eventType == "custom/myVTT/disabledicestream"){
 				enable_dice_streaming_feature(false);
@@ -1371,21 +1371,21 @@ class MessageBroker {
 				peer.onconnectionstatechange=() => {
 					if(peer.connectionState=="connected"){
 						window.MB.inject_chat({
-                player: window.PLAYER_NAME,
-                img: window.PLAYER_IMG,
-                text: `<span class="flex-wrap-center-chat-message"><p>A dice stream peer has ${peer.connectionState}. <br/><br/></div>`,
-                whisper: window.PLAYER_NAME,
-	          });
+							player: window.PLAYER_NAME,
+							img: window.PLAYER_IMG,
+							text: `<span class="flex-wrap-center-chat-message"><p>A dice stream peer has ${peer.connectionState}. <br/><br/></div>`,
+							whisper: window.PLAYER_NAME,
+						});
 					}
-
+					
 					if(peer.connectionState=="closed" || peer.connectionState=="failed" || peer.connectionState == "disconnected"){
 						peer.restartIce();
 						window.MB.inject_chat({
-                player: window.PLAYER_NAME,
-                img: window.PLAYER_IMG,
-                text: `<span class="flex-wrap-center-chat-message"><p>A dice stream connection has ${peer.connectionState}.</p><p> An automatic reconnect is being attempted. </p><p>If you are still unable to see one or more of your groups dice you may have to manually disable then reenable your dice stream in the chat above.</p><br/><br/></div>`,
-                whisper: window.PLAYER_NAME,
-	          });	          
+							player: window.PLAYER_NAME,
+							img: window.PLAYER_IMG,
+							text: `<span class="flex-wrap-center-chat-message"><p>A dice stream connection has ${peer.connectionState}.</p><p> An automatic reconnect is being attempted. </p><p>If you are still unable to see one or more of your groups dice you may have to manually disable then reenable your dice stream in the chat above.</p><br/><br/></div>`,
+							whisper: window.PLAYER_NAME,
+						});	          
 					}
 				};
 				peer.onnegotiationneeded = () => {
@@ -1463,20 +1463,20 @@ class MessageBroker {
 				peer.onconnectionstatechange=() => {
 					if(peer.connectionState=="connected"){
 						window.MB.inject_chat({
-                player: window.PLAYER_NAME,
-                img: window.PLAYER_IMG,
-                text: `<span class="flex-wrap-center-chat-message"><p>A dice stream peer has ${peer.connectionState}. <br/><br/></div>`,
-                whisper: window.PLAYER_NAME,
-	          });
+							player: window.PLAYER_NAME,
+							img: window.PLAYER_IMG,
+							text: `<span class="flex-wrap-center-chat-message"><p>A dice stream peer has ${peer.connectionState}. <br/><br/></div>`,
+							whisper: window.PLAYER_NAME,
+						});
 					}
 					if((peer.connectionState=="closed") || (peer.connectionState=="failed" || peer.connectionState == "disconnected")){
 						peer.restartIce();
 						window.MB.inject_chat({
-                player: window.PLAYER_NAME,
-                img: window.PLAYER_IMG,
-                text: `<span class="flex-wrap-center-chat-message"><p>A dice stream connection has ${peer.connectionState}.</p><p> An automatic reconnect is being attempted. </p><p>If you are still unable to see one or more of your groups dice you may have to manually disable then reenable your dice stream in the chat above.</p><br/><br/></div>`,
-                whisper: window.PLAYER_NAME,
-	          });
+							player: window.PLAYER_NAME,
+							img: window.PLAYER_IMG,
+							text: `<span class="flex-wrap-center-chat-message"><p>A dice stream connection has ${peer.connectionState}.</p><p> An automatic reconnect is being attempted. </p><p>If you are still unable to see one or more of your groups dice you may have to manually disable then reenable your dice stream in the chat above.</p><br/><br/></div>`,
+							whisper: window.PLAYER_NAME,
+						});
 					}
 				};
 		
@@ -2057,8 +2057,8 @@ class MessageBroker {
 
 		if(data.dmonly && !(window.DM) && !local) // /dmroll only for DM of or the user who initiated it
 			return $("<div/>");
-				
-		if(data.whisper && (data.whisper!=window.PLAYER_NAME && !(Array.isArray(data.whisper) && data.whisper.includes(`${window.myUser}`))) && (!local))
+
+		if(!canHearWhisper(data.whisper) && (!local))
 			return $("<div/>");
 		//notify_gamelog();
 

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -626,7 +626,8 @@ class MessageBroker {
 					notify_gamelog();
 					self.handle_injected_data(msg);
 				}
-			}
+				return;
+			} else
 			if (msg.eventType == "dice/roll/fulfilled") {
 				notify_gamelog();
 				const gamelogItem = $(`ol[class*='-GameLogEntries'] li`).first();
@@ -908,7 +909,7 @@ class MessageBroker {
 					}
 
 				}
-
+				return;
 			}
 			// WE NEED TO IGNORE CERTAIN MESSAGE IF THEY'RE NOT FROM THE CURRENT SCENE
 			if (window.CURRENT_SCENE_DATA == undefined || (msg.sceneId && window.CURRENT_SCENE_DATA && msg.sceneId !== window.CURRENT_SCENE_DATA.id && [
@@ -928,17 +929,17 @@ class MessageBroker {
 			if (msg.eventType == "character-sheet/item-shared/fulfilled"){
 				DDBApi.debounceGetPartyInventory();
 				return;
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/token" && (msg.sceneId == window.CURRENT_SCENE_DATA.id || msg.data.id in window.TOKEN_OBJECTS)) {
 				self.handleToken(msg);
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/delete_token"){
 				let tokenid=msg.data.id;
 				if(tokenid in window.TOKEN_OBJECTS){
 					window.TOKEN_OBJECTS[tokenid].options.deleteableByPlayers = true;
 					window.TOKEN_OBJECTS[tokenid].delete(false);
 				}
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/createtoken"){
 				if(window.DM){
 					let left = parseInt(msg.data.left);
@@ -949,16 +950,16 @@ class MessageBroker {
 						place_token_in_center_of_view(msg.data);
 					}
 				}
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/deleteExplore"){
 				if(!window.DM){
 					deleteExploredScene(msg.data.sceneId)
 				}
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/campaignData"){
 				window.AVTT_CAMPAIGN_INFO = msg.data;
 				window.MB.checkHideSceneFromPlayers();
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/place-extras-token"){
 				if(window.DM){
 					let left = parseInt(msg.data.centerView.x);
@@ -968,7 +969,7 @@ class MessageBroker {
 						create_and_place_token(window.cached_monster_items[monsterId], undefined, undefined, left, top, undefined, undefined, true, msg.data.extraOptions)
 					});
 				}
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/createTimer"){
 				const {type, message, startTime, duration, remove} = msg.data;
 				if(type === "gamelog"){
@@ -985,11 +986,11 @@ class MessageBroker {
 					}
 					create_combat_tracker_timer(duration, startTime)
 				}
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/open-url-embed"){
 				const url = msg.data;
 				display_url_embeded(url);
-			}
+			} else
 			if (msg.eventType === "custom/myVTT/fetchscene") {
 
 				if(msg.data.sceneid.players){
@@ -1018,7 +1019,7 @@ class MessageBroker {
 					
 				}
 				delete window.startupSceneId; // we only want to prevent a double load of the initial scene, so we want to delete this no matter what.
-			}
+			} else
 
 			if(msg.eventType == "custom/myVTT/update_dm_player_scenes"){
 				if(window.DM){
@@ -1026,35 +1027,35 @@ class MessageBroker {
 					did_update_scenes();
 				}
 				
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/scene") {
 				self.handleScene(msg);
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/syncmeup") {
 				self.handleSyncMeUp(msg);
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/audioPlayingSyncMe") {
 				self.handleAudioPlayingSync(msg);
-			}
+			} else
 			if(msg.eventType == ('custom/myVTT/character-update')){
 				update_pc_with_data(msg.data.characterId, msg.data.pcData);
-			}
+			} else
 			if(msg.eventType == ('character-sheet/character-update/fulfilled')) {
 				console.log('update_pc character-sheet/character-update/fulfilled', msg);
 				update_pc_with_api_call(msg.data?.characterId);
-			}
+			} else
 
 			if (msg.eventType == "custom/myVTT/reveal") {
 				window.REVEALED.push(msg.data);
 				redraw_fog();
 				check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
-			}
+			} else
 
 			if(msg.eventType== "custom/myVTT/fogdata"){ // WE RESEND ALL THE FOG EVERYTIME NOW
 				window.REVEALED=msg.data;
 				redraw_fog();
 				check_token_visibility();
-			}
+			} else
 
 			if (msg.eventType == "custom/myVTT/drawing") {
 				window.DRAWINGS.push(msg.data);
@@ -1065,7 +1066,7 @@ class MessageBroker {
 				redraw_drawn_light();
 				redraw_light();
 
-			}
+			} else
 
 			if(msg.eventType=="custom/myVTT/drawdata"){
 				window.DRAWINGS=msg.data;
@@ -1075,27 +1076,27 @@ class MessageBroker {
 				redraw_text();
 				redraw_drawn_light();
 				redraw_light();
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/forceRedrawLight"){
 				redraw_light(true);
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/chat") { // DEPRECATED!!!!!!!!!
 				if(!window.NOTIFIEDOLDVERSION){
 					alert('One of the player is using AboveTT 0.0.51 or less. Please update everyone to 0.0.52 or higher');
 					window.NOTIFIEDOLDVERSION=true;
 				}
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/CT" && (!window.DM)) {
 				self.handleCT(msg.data);
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/highlight") {
 				if (msg.data.id in window.TOKEN_OBJECTS) {
 					window.TOKEN_OBJECTS[msg.data.id].highlight(true);
 				}
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/pointer") {
 				set_pointer(msg.data,(!msg.data.dm || (msg.data.dm && !msg.data.center_on_ping)));
-			}
+			} else
 
 			if (msg.eventType == "custom/myVTT/lock") {
 				if (window.DM)
@@ -1131,7 +1132,7 @@ class MessageBroker {
 					}
 
 				}
-			}
+			} else
 			if (msg.eventType == "custom/myVTT/unlock") {
 				if (window.DM)
 				{
@@ -1145,7 +1146,7 @@ class MessageBroker {
 					$("#sheet iframe").css('opacity', '1');
 					$("#sheet iframe").attr('src', function(i, val) { return val; }); // RELOAD IFRAME
 				}
-			}
+			} else
 
 			if (msg.eventType == "custom/myVTT/player_sheet_closed") {
 				if (window.DM)
@@ -1154,7 +1155,7 @@ class MessageBroker {
 					$("[id='PlayerSheet"+getPlayerIDFromSheet(msg.data.player_sheet)+"']").attr('data-changed', 'true');
 					return;
 				}
-			}
+			} else
 			
 			
 			if(msg.eventType=="custom/myVTT/JournalChapters"){
@@ -1163,8 +1164,33 @@ class MessageBroker {
 					window.JOURNAL.build_journal();
 					window.JOURNAL.persist(true);
 				}
-			}
-			
+			} else
+
+			if(msg.eventType=="custom/myVTT/Popup"){
+				if(!window.DM &&
+				   !(msg.data.from && msg.data.from != window.PLAYER_ID) &&
+				   !(msg.data.to && msg.data.to != "everyone" && msg.data.to != window.PLAYER_ID)) {
+					if(msg.data.delete == true){
+						$.magnificPopup.close();
+					} else {
+						const popup = {
+							items: { src: msg.data.src },
+							type: (msg.data.type || 'image'),
+							closeOnContentClick: true							
+						};
+						if(msg.data.timed) {
+							popup.callbacks = {
+								open: function() {
+									var self = this;
+									setTimeout(function() { self.close() }, msg.data.timed);
+								}
+							};
+						}
+						$.magnificPopup.open(popup);
+					}
+				}
+			} else
+							
 			if(msg.eventType=="custom/myVTT/note"){
 				if(!window.DM || (msg.data.from && msg.data.from != window.PLAYER_ID)){
 					if(msg.data.delete == true){
@@ -1210,7 +1236,7 @@ class MessageBroker {
 					window.JOURNAL.persist(true);
 
 				}
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/notesSync"){
 				if(!window.DM){
 					for(let i in msg.data.notes){
@@ -1225,11 +1251,11 @@ class MessageBroker {
 					window.JOURNAL.build_journal();			
 					window.JOURNAL.persist(true);	
 				}
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/DMAvatar"){
 				dmAvatarUrl = msg.data.avatar;
 				$(`.player-card[data-player-id=''] .player-token img`).attr('src', dmAvatarUrl);
-			}
+			} else
 		
 			if(msg.eventType=="custom/myVTT/pausePlayer"){
 				if(!window.DM){
@@ -1252,7 +1278,7 @@ class MessageBroker {
 				else{
 					$(".paused-indicator").remove();
 				}
-			}
+			} else
 			
 			if(msg.eventType=="custom/myVTT/playerjoin"){
 				if (window.DM) {										
@@ -1293,35 +1319,35 @@ class MessageBroker {
 						pc: read_pc_object_from_character_sheet(window.PLAYER_ID)
 					});
 				}
-			}
+			} else
 			if(msg.eventType==="custom/myVTT/pcsync"){
 				// a player just sent us their pc data, so let's update our window.pcs with what they gave us
 				if (msg.data && msg.data.player_id && msg.data.pc) {
 					update_pc_with_data(msg.data.player_id, msg.data.pc);
 				}
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/endplayerturn" && window.DM){
 				let tokenId = $("#combat_area tr[data-current=1]").attr('data-target');
 				if(tokenId.endsWith(`characters/${msg.data.from}`) || window.all_token_objects[tokenId].options.player_owned)
 					$("#combat_next_button").click();				
 
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/mixer"){
 				handle_mixer_event(msg.data);
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/soundpad"){
 				build_soundpad(msg.data.soundpad, msg.data.playing);
-			}
+			} else
 
 			if(msg.eventType=="custom/myVTT/playchannel"){
 				audio_playchannel(msg.data.channel,msg.data.time,msg.data.volume);
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/pausechannel"){
 				audio_pausechannel(msg.data.channel);
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/changechannel"){
 				audio_changesettings(msg.data.channel,msg.data.volume,msg.data.loop);
-			}
+			} else
 			if(msg.eventType=="custom/myVTT/changeyoutube"){
 				if(window.YTPLAYER?.setVolume){
 						window.YTPLAYER.setVolume(msg.data.volume*$("#master-volume input").val());
@@ -1331,7 +1357,7 @@ class MessageBroker {
 					$('video#scene_map').attr('data-volume', msg.data.volume/100)
 				}
 
-			}
+			} else
 
 
 			
@@ -1357,7 +1383,7 @@ class MessageBroker {
 						streamid: diceplayer_id
 					});
 				}
-			}
+			} else
 
 			if(msg.eventType == "custom/myVTT/turnoffsingledicestream"){
 				let dicePeer = window.diceCurrentPeers.filter(d=> d.peer==msg.data.from)[0]
@@ -1374,11 +1400,11 @@ class MessageBroker {
               whisper: window.PLAYER_NAME
           });
 				}
-			}
+			} else
 
 			if(msg.eventType == "custom/myVTT/disabledicestream"){
 				enable_dice_streaming_feature(false);
-			}
+			} else
 
 			if(msg.eventType == "custom/myVTT/showonlytodmdicestream"){
 				if(!window.DM){		
@@ -1387,16 +1413,16 @@ class MessageBroker {
 				else{
 					revealDiceVideo(msg.data.streamid);
 				}
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/hidemydicestream"){
 					hideDiceVideo(msg.data.streamid);
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/revealmydicestream"){
 					revealDiceVideo(msg.data.streamid);
-			}
+			} else
 			if(msg.eventType == "custom/myVTT/enabledicestreamingfeature"){
 					enable_dice_streaming_feature(true);				
-			}
+			} else
 					
 
 
@@ -1471,7 +1497,7 @@ class MessageBroker {
 					})
 				};				
 				window.STREAMPEERS[msg.data.from]=peer;				
-			}
+			} else
 
 
 			if(msg.eventType == "custom/myVTT/okletmeseeyourdice"){
@@ -1572,7 +1598,7 @@ class MessageBroker {
 			});
 				
 				window.STREAMPEERS[msg.data.from] = peer;					
-			}
+			} else
 
 			if(msg.eventType == "custom/myVTT/okseethem"){
 				if( !window.JOINTHEDICESTREAM)
@@ -1583,16 +1609,16 @@ class MessageBroker {
 				let peer=window.STREAMPEERS[msg.data.from];
 				peer.setRemoteDescription(msg.data.answer);
 				console.log("fatto setRemoteDescription");
-			}
+			} else
 
 
 
 			if (msg.eventType === "custom/myVTT/peerReady") {
 				window.PeerManager.receivedPeerReady(msg);
-			}
+			} else
 			if (msg.eventType === "custom/myVTT/peerConnect") {
 				window.PeerManager.receivedPeerConnect(msg);
-			}
+			} else
 			if (msg.eventType === "custom/myVTT/videoPeerConnect") {
 				if(msg.data.id != window.myVideoPeerID){
 					let call = window.videoPeer.call(msg.data.id, window.myLocalVideostream)
@@ -1606,10 +1632,10 @@ class MessageBroker {
 					window.currentPeers = window.currentPeers.filter(d=> d.peer != call.peer)
 					window.currentPeers.push(call);
 				}
-			}
+			} else
 			if (msg.eventType === "custom/myVTT/videoPeerDisconnect") {
 					$(`.video-meet-area video#${msg.data.id}`).remove();
-			}
+			} else
 
 			if (msg.eventType === "custom/myVTT/diceVideoPeerConnect") {
 				if(msg.data.id != diceplayer_id){

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -627,8 +627,7 @@ class MessageBroker {
 					self.handle_injected_data(msg);
 				}
 				return;
-			} else
-			if (msg.eventType == "dice/roll/fulfilled") {
+			} else if (msg.eventType == "dice/roll/fulfilled") {
 				notify_gamelog();
 				const gamelogItem = $(`ol[class*='-GameLogEntries'] li`).first();
 
@@ -929,18 +928,15 @@ class MessageBroker {
 			if (msg.eventType == "character-sheet/item-shared/fulfilled"){
 				DDBApi.debounceGetPartyInventory();
 				return;
-			} else
-			if (msg.eventType == "custom/myVTT/token" && (msg.sceneId == window.CURRENT_SCENE_DATA.id || msg.data.id in window.TOKEN_OBJECTS)) {
+			} else if (msg.eventType == "custom/myVTT/token" && (msg.sceneId == window.CURRENT_SCENE_DATA.id || msg.data.id in window.TOKEN_OBJECTS)) {
 				self.handleToken(msg);
-			} else
-			if(msg.eventType=="custom/myVTT/delete_token"){
+			} else if(msg.eventType=="custom/myVTT/delete_token"){
 				let tokenid=msg.data.id;
 				if(tokenid in window.TOKEN_OBJECTS){
 					window.TOKEN_OBJECTS[tokenid].options.deleteableByPlayers = true;
 					window.TOKEN_OBJECTS[tokenid].delete(false);
 				}
-			} else
-			if(msg.eventType == "custom/myVTT/createtoken"){
+			} else if(msg.eventType == "custom/myVTT/createtoken"){
 				if(window.DM){
 					let left = parseInt(msg.data.left);
 					let top = parseInt(msg.data.top);
@@ -950,17 +946,14 @@ class MessageBroker {
 						place_token_in_center_of_view(msg.data);
 					}
 				}
-			} else
-			if(msg.eventType == "custom/myVTT/deleteExplore"){
+			} else if(msg.eventType == "custom/myVTT/deleteExplore"){
 				if(!window.DM){
 					deleteExploredScene(msg.data.sceneId)
 				}
-			} else
-			if (msg.eventType == "custom/myVTT/campaignData"){
+			} else if (msg.eventType == "custom/myVTT/campaignData"){
 				window.AVTT_CAMPAIGN_INFO = msg.data;
 				window.MB.checkHideSceneFromPlayers();
-			} else
-			if(msg.eventType == "custom/myVTT/place-extras-token"){
+			} else if(msg.eventType == "custom/myVTT/place-extras-token"){
 				if(window.DM){
 					let left = parseInt(msg.data.centerView.x);
 					let top = parseInt(msg.data.centerView.y);
@@ -969,8 +962,7 @@ class MessageBroker {
 						create_and_place_token(window.cached_monster_items[monsterId], undefined, undefined, left, top, undefined, undefined, true, msg.data.extraOptions)
 					});
 				}
-			} else
-			if(msg.eventType == "custom/myVTT/createTimer"){
+			} else if(msg.eventType == "custom/myVTT/createTimer"){
 				const {type, message, startTime, duration, remove} = msg.data;
 				if(type === "gamelog"){
 					create_gamelog_timer(message, duration, startTime)
@@ -986,12 +978,10 @@ class MessageBroker {
 					}
 					create_combat_tracker_timer(duration, startTime)
 				}
-			} else
-			if (msg.eventType == "custom/myVTT/open-url-embed"){
+			} else if (msg.eventType == "custom/myVTT/open-url-embed"){
 				const url = msg.data;
 				display_url_embeded(url);
-			} else
-			if (msg.eventType === "custom/myVTT/fetchscene") {
+			} else if (msg.eventType === "custom/myVTT/fetchscene") {
 
 				if(msg.data.sceneid.players){
 					if(msg.data.sceneid[window.PLAYER_ID] !== undefined)
@@ -1019,45 +1009,32 @@ class MessageBroker {
 					
 				}
 				delete window.startupSceneId; // we only want to prevent a double load of the initial scene, so we want to delete this no matter what.
-			} else
-
-			if(msg.eventType == "custom/myVTT/update_dm_player_scenes"){
+			} else if(msg.eventType == "custom/myVTT/update_dm_player_scenes"){
 				if(window.DM){
 					window.splitPlayerScenes = msg.data.splitPlayerScenes;
 					did_update_scenes();
 				}
 				
-			} else
-			if (msg.eventType == "custom/myVTT/scene") {
+			} else if (msg.eventType == "custom/myVTT/scene") {
 				self.handleScene(msg);
-			} else
-			if (msg.eventType == "custom/myVTT/syncmeup") {
+			} else if (msg.eventType == "custom/myVTT/syncmeup") {
 				self.handleSyncMeUp(msg);
-			} else
-			if (msg.eventType == "custom/myVTT/audioPlayingSyncMe") {
+			} else if (msg.eventType == "custom/myVTT/audioPlayingSyncMe") {
 				self.handleAudioPlayingSync(msg);
-			} else
-			if(msg.eventType == ('custom/myVTT/character-update')){
+			} else if(msg.eventType == ('custom/myVTT/character-update')){
 				update_pc_with_data(msg.data.characterId, msg.data.pcData);
-			} else
-			if(msg.eventType == ('character-sheet/character-update/fulfilled')) {
+			} else if(msg.eventType == ('character-sheet/character-update/fulfilled')) {
 				console.log('update_pc character-sheet/character-update/fulfilled', msg);
 				update_pc_with_api_call(msg.data?.characterId);
-			} else
-
-			if (msg.eventType == "custom/myVTT/reveal") {
+			} else if (msg.eventType == "custom/myVTT/reveal") {
 				window.REVEALED.push(msg.data);
 				redraw_fog();
 				check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
-			} else
-
-			if(msg.eventType== "custom/myVTT/fogdata"){ // WE RESEND ALL THE FOG EVERYTIME NOW
+			} else if(msg.eventType== "custom/myVTT/fogdata"){ // WE RESEND ALL THE FOG EVERYTIME NOW
 				window.REVEALED=msg.data;
 				redraw_fog();
 				check_token_visibility();
-			} else
-
-			if (msg.eventType == "custom/myVTT/drawing") {
+			} else if (msg.eventType == "custom/myVTT/drawing") {
 				window.DRAWINGS.push(msg.data);
 				redraw_light_walls();		
 				redraw_drawings();
@@ -1066,9 +1043,7 @@ class MessageBroker {
 				redraw_drawn_light();
 				redraw_light();
 
-			} else
-
-			if(msg.eventType=="custom/myVTT/drawdata"){
+			} else if(msg.eventType=="custom/myVTT/drawdata"){
 				window.DRAWINGS=msg.data;
 				redraw_light_walls();
 				redraw_elev();
@@ -1076,29 +1051,22 @@ class MessageBroker {
 				redraw_text();
 				redraw_drawn_light();
 				redraw_light();
-			} else
-			if(msg.eventType=="custom/myVTT/forceRedrawLight"){
+			} else if(msg.eventType=="custom/myVTT/forceRedrawLight"){
 				redraw_light(true);
-			} else
-			if (msg.eventType == "custom/myVTT/chat") { // DEPRECATED!!!!!!!!!
+			} else if (msg.eventType == "custom/myVTT/chat") { // DEPRECATED!!!!!!!!!
 				if(!window.NOTIFIEDOLDVERSION){
 					alert('One of the player is using AboveTT 0.0.51 or less. Please update everyone to 0.0.52 or higher');
 					window.NOTIFIEDOLDVERSION=true;
 				}
-			} else
-			if (msg.eventType == "custom/myVTT/CT" && (!window.DM)) {
+			} else if (msg.eventType == "custom/myVTT/CT" && (!window.DM)) {
 				self.handleCT(msg.data);
-			} else
-			if (msg.eventType == "custom/myVTT/highlight") {
+			} else if (msg.eventType == "custom/myVTT/highlight") {
 				if (msg.data.id in window.TOKEN_OBJECTS) {
 					window.TOKEN_OBJECTS[msg.data.id].highlight(true);
 				}
-			} else
-			if (msg.eventType == "custom/myVTT/pointer") {
+			} else if (msg.eventType == "custom/myVTT/pointer") {
 				set_pointer(msg.data,(!msg.data.dm || (msg.data.dm && !msg.data.center_on_ping)));
-			} else
-
-			if (msg.eventType == "custom/myVTT/lock") {
+			} else if (msg.eventType == "custom/myVTT/lock") {
 				if (window.DM)
 					return;
 				if (getPlayerIDFromSheet(msg.data.player_sheet) == window.PLAYER_ID) {
@@ -1132,8 +1100,7 @@ class MessageBroker {
 					}
 
 				}
-			} else
-			if (msg.eventType == "custom/myVTT/unlock") {
+			} else if (msg.eventType == "custom/myVTT/unlock") {
 				if (window.DM)
 				{
 					return;
@@ -1146,27 +1113,20 @@ class MessageBroker {
 					$("#sheet iframe").css('opacity', '1');
 					$("#sheet iframe").attr('src', function(i, val) { return val; }); // RELOAD IFRAME
 				}
-			} else
-
-			if (msg.eventType == "custom/myVTT/player_sheet_closed") {
+			} else if (msg.eventType == "custom/myVTT/player_sheet_closed") {
 				if (window.DM)
 				{
 					//$("[id='PlayerSheet"+getPlayerIDFromSheet(msg.data.player_sheet)+"']").attr('src', function(i, val) { return val; });
 					$("[id='PlayerSheet"+getPlayerIDFromSheet(msg.data.player_sheet)+"']").attr('data-changed', 'true');
 					return;
 				}
-			} else
-			
-			
-			if(msg.eventType=="custom/myVTT/JournalChapters"){
+			} else if(msg.eventType=="custom/myVTT/JournalChapters"){
 				if(!window.DM){
 					window.JOURNAL.chapters=msg.data.chapters;
 					window.JOURNAL.build_journal();
 					window.JOURNAL.persist(true);
 				}
-			} else
-
-			if(msg.eventType=="custom/myVTT/Popup"){
+			} else if(msg.eventType=="custom/myVTT/Popup"){
 				if(!window.DM &&
 				   !(msg.data.from && msg.data.from != window.PLAYER_ID) &&
 				   !(msg.data.to && msg.data.to != "everyone" && msg.data.to != window.PLAYER_ID)) {
@@ -1189,9 +1149,7 @@ class MessageBroker {
 						$.magnificPopup.open(popup);
 					}
 				}
-			} else
-							
-			if(msg.eventType=="custom/myVTT/note"){
+			} else if(msg.eventType=="custom/myVTT/note"){
 				if(!window.DM || (msg.data.from && msg.data.from != window.PLAYER_ID)){
 					if(msg.data.delete == true){
 						delete window.JOURNAL.notes[msg.data.id]
@@ -1236,8 +1194,7 @@ class MessageBroker {
 					window.JOURNAL.persist(true);
 
 				}
-			} else
-			if(msg.eventType=="custom/myVTT/notesSync"){
+			} else if(msg.eventType=="custom/myVTT/notesSync"){
 				if(!window.DM){
 					for(let i in msg.data.notes){
 						let noteId = msg.data.notes[i].id;
@@ -1251,13 +1208,10 @@ class MessageBroker {
 					window.JOURNAL.build_journal();			
 					window.JOURNAL.persist(true);	
 				}
-			} else
-			if(msg.eventType=="custom/myVTT/DMAvatar"){
+			} else if(msg.eventType=="custom/myVTT/DMAvatar"){
 				dmAvatarUrl = msg.data.avatar;
 				$(`.player-card[data-player-id=''] .player-token img`).attr('src', dmAvatarUrl);
-			} else
-		
-			if(msg.eventType=="custom/myVTT/pausePlayer"){
+			} else if(msg.eventType=="custom/myVTT/pausePlayer"){
 				if(!window.DM){
 					$("#VTT").toggleClass('paused', msg.data.paused);
 				}
@@ -1278,9 +1232,7 @@ class MessageBroker {
 				else{
 					$(".paused-indicator").remove();
 				}
-			} else
-			
-			if(msg.eventType=="custom/myVTT/playerjoin"){
+			} else if(msg.eventType=="custom/myVTT/playerjoin"){
 				if (window.DM) {										
 					if (msg.data == null || typeof msg.data.abovevtt_version === "undefined") {
 						// Player with version <= 0.64 - avoiding popping too many alert messages
@@ -1319,36 +1271,27 @@ class MessageBroker {
 						pc: read_pc_object_from_character_sheet(window.PLAYER_ID)
 					});
 				}
-			} else
-			if(msg.eventType==="custom/myVTT/pcsync"){
+			} else if(msg.eventType==="custom/myVTT/pcsync"){
 				// a player just sent us their pc data, so let's update our window.pcs with what they gave us
 				if (msg.data && msg.data.player_id && msg.data.pc) {
 					update_pc_with_data(msg.data.player_id, msg.data.pc);
 				}
-			} else
-			if(msg.eventType == "custom/myVTT/endplayerturn" && window.DM){
+			} else if(msg.eventType == "custom/myVTT/endplayerturn" && window.DM){
 				let tokenId = $("#combat_area tr[data-current=1]").attr('data-target');
 				if(tokenId.endsWith(`characters/${msg.data.from}`) || window.all_token_objects[tokenId].options.player_owned)
 					$("#combat_next_button").click();				
 
-			} else
-			if(msg.eventType=="custom/myVTT/mixer"){
+			} else if(msg.eventType=="custom/myVTT/mixer"){
 				handle_mixer_event(msg.data);
-			} else
-			if(msg.eventType=="custom/myVTT/soundpad"){
+			} else if(msg.eventType=="custom/myVTT/soundpad"){
 				build_soundpad(msg.data.soundpad, msg.data.playing);
-			} else
-
-			if(msg.eventType=="custom/myVTT/playchannel"){
+			} else if(msg.eventType=="custom/myVTT/playchannel"){
 				audio_playchannel(msg.data.channel,msg.data.time,msg.data.volume);
-			} else
-			if(msg.eventType=="custom/myVTT/pausechannel"){
+			} else if(msg.eventType=="custom/myVTT/pausechannel"){
 				audio_pausechannel(msg.data.channel);
-			} else
-			if(msg.eventType=="custom/myVTT/changechannel"){
+			} else if(msg.eventType=="custom/myVTT/changechannel"){
 				audio_changesettings(msg.data.channel,msg.data.volume,msg.data.loop);
-			} else
-			if(msg.eventType=="custom/myVTT/changeyoutube"){
+			} else if(msg.eventType=="custom/myVTT/changeyoutube"){
 				if(window.YTPLAYER?.setVolume){
 						window.YTPLAYER.setVolume(msg.data.volume*$("#master-volume input").val());
 				}
@@ -1357,12 +1300,7 @@ class MessageBroker {
 					$('video#scene_map').attr('data-volume', msg.data.volume/100)
 				}
 
-			} else
-
-
-			
-
-			if(msg.eventType == "custom/myVTT/whatsyourdicerolldefault"){
+			} else if(msg.eventType == "custom/myVTT/whatsyourdicerolldefault"){
 				if( !window.JOINTHEDICESTREAM)
 					return;
 				if( (!diceplayer_id)  || (msg.data.to!= diceplayer_id) )
@@ -1383,9 +1321,7 @@ class MessageBroker {
 						streamid: diceplayer_id
 					});
 				}
-			} else
-
-			if(msg.eventType == "custom/myVTT/turnoffsingledicestream"){
+			} else if(msg.eventType == "custom/myVTT/turnoffsingledicestream"){
 				let dicePeer = window.diceCurrentPeers.filter(d=> d.peer==msg.data.from)[0]
 				if(dicePeer === undefined || (msg.data.to != "everyone" && msg.data.to != diceplayer_id)){
 				 return;
@@ -1400,33 +1336,22 @@ class MessageBroker {
               whisper: window.PLAYER_NAME
           });
 				}
-			} else
-
-			if(msg.eventType == "custom/myVTT/disabledicestream"){
+			} else if(msg.eventType == "custom/myVTT/disabledicestream"){
 				enable_dice_streaming_feature(false);
-			} else
-
-			if(msg.eventType == "custom/myVTT/showonlytodmdicestream"){
+			} else if(msg.eventType == "custom/myVTT/showonlytodmdicestream"){
 				if(!window.DM){		
 					hideDiceVideo(msg.data.streamid);
 				}		
 				else{
 					revealDiceVideo(msg.data.streamid);
 				}
-			} else
-			if(msg.eventType == "custom/myVTT/hidemydicestream"){
+			} else if(msg.eventType == "custom/myVTT/hidemydicestream"){
 					hideDiceVideo(msg.data.streamid);
-			} else
-			if(msg.eventType == "custom/myVTT/revealmydicestream"){
+			} else if(msg.eventType == "custom/myVTT/revealmydicestream"){
 					revealDiceVideo(msg.data.streamid);
-			} else
-			if(msg.eventType == "custom/myVTT/enabledicestreamingfeature"){
+			} else if(msg.eventType == "custom/myVTT/enabledicestreamingfeature"){
 					enable_dice_streaming_feature(true);				
-			} else
-					
-
-
-			if(msg.eventType == "custom/myVTT/wannaseemydicecollection"){
+			} else if(msg.eventType == "custom/myVTT/wannaseemydicecollection"){
 				if( !window.JOINTHEDICESTREAM)
 					return;
 				if( (!window.MYSTREAMID))
@@ -1497,10 +1422,7 @@ class MessageBroker {
 					})
 				};				
 				window.STREAMPEERS[msg.data.from]=peer;				
-			} else
-
-
-			if(msg.eventType == "custom/myVTT/okletmeseeyourdice"){
+			} else if(msg.eventType == "custom/myVTT/okletmeseeyourdice"){
 				if( !window.JOINTHEDICESTREAM)
 					return;
 				if( (!window.MYSTREAMID)  || (msg.data.to!= window.MYSTREAMID) )
@@ -1598,9 +1520,7 @@ class MessageBroker {
 			});
 				
 				window.STREAMPEERS[msg.data.from] = peer;					
-			} else
-
-			if(msg.eventType == "custom/myVTT/okseethem"){
+			} else if(msg.eventType == "custom/myVTT/okseethem"){
 				if( !window.JOINTHEDICESTREAM)
 					return;
 				if( (!window.MYSTREAMID)  || (msg.data.to!= window.MYSTREAMID) )
@@ -1609,17 +1529,11 @@ class MessageBroker {
 				let peer=window.STREAMPEERS[msg.data.from];
 				peer.setRemoteDescription(msg.data.answer);
 				console.log("fatto setRemoteDescription");
-			} else
-
-
-
-			if (msg.eventType === "custom/myVTT/peerReady") {
+			} else if (msg.eventType === "custom/myVTT/peerReady") {
 				window.PeerManager.receivedPeerReady(msg);
-			} else
-			if (msg.eventType === "custom/myVTT/peerConnect") {
+			} else if (msg.eventType === "custom/myVTT/peerConnect") {
 				window.PeerManager.receivedPeerConnect(msg);
-			} else
-			if (msg.eventType === "custom/myVTT/videoPeerConnect") {
+			} else if (msg.eventType === "custom/myVTT/videoPeerConnect") {
 				if(msg.data.id != window.myVideoPeerID){
 					let call = window.videoPeer.call(msg.data.id, window.myLocalVideostream)
 					call.on('stream', (stream) => {
@@ -1632,12 +1546,9 @@ class MessageBroker {
 					window.currentPeers = window.currentPeers.filter(d=> d.peer != call.peer)
 					window.currentPeers.push(call);
 				}
-			} else
-			if (msg.eventType === "custom/myVTT/videoPeerDisconnect") {
+			} else if (msg.eventType === "custom/myVTT/videoPeerDisconnect") {
 					$(`.video-meet-area video#${msg.data.id}`).remove();
-			} else
-
-			if (msg.eventType === "custom/myVTT/diceVideoPeerConnect") {
+			} else if (msg.eventType === "custom/myVTT/diceVideoPeerConnect") {
 				if(msg.data.id != diceplayer_id){
 					let call = window.diceVideoPeer.call(msg.data.id, window.MYMEDIASTREAM)
 					call.on('stream', (stream) => {

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1033,15 +1033,6 @@ class MessageBroker {
 				window.REVEALED=msg.data;
 				redraw_fog();
 				check_token_visibility();
-			} else if (msg.eventType == "custom/myVTT/drawing") {
-				window.DRAWINGS.push(msg.data);
-				redraw_light_walls();		
-				redraw_drawings();
-				redraw_elev();
-				redraw_text();
-				redraw_drawn_light();
-				redraw_light();
-
 			} else if(msg.eventType=="custom/myVTT/drawdata"){
 				const wallsChanged = msg.data?.[0] == 'wallsChanged';
 				if(wallsChanged){

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -97,9 +97,9 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
   
     add_aoe_statblock_click(container, tokenId);
 
-  container.find("img.monster-image, .monster-image").each((i,block) => {
-    createSendPlayerButton(block, "login", true).insertAfter(block);
-  });
+    container.find("img.monster-image, .monster-image").each((i,block) => {
+      createSendPlayerButton(block, "login", true).insertAfter(block);
+    });
     //Note: this is async - that is why code just above here isn't lower down
     if(!customStatBlock){
       statBlock.imageHtml(token, statBlock.data.url).then(theImage => {

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -97,14 +97,10 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
   
     add_aoe_statblock_click(container, tokenId);
 
-  //todo: get rid of send to gamelog button above (as it's duplicate function)
-  //todo: fix layout
-  //todo: is this the right place? or do later in display?
   container.find("img.monster-image, .monster-image").each((i,block) => {
     createSendPlayerButton(block, "login", true).insertAfter(block);
   });
-  
-    //Note: this is async - that is why code below may not find image 
+    //Note: this is async - that is why code just above here isn't lower down
     if(!customStatBlock){
       statBlock.imageHtml(token, statBlock.data.url).then(theImage => {
         //add in send-to features

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -104,7 +104,7 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
     if(!customStatBlock){
       statBlock.imageHtml(token).then(theImage => {
         //add in send-to features
-        container.find("div.image").append(theImage).find("img.monster-image").each((i,block) => {
+        container.find("div.image").append(theImage).find("img.monster-image, video").each((i,block) => {
           createSendPlayerButton(block, "login", true).insertAfter(block);
         });
       })

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -105,7 +105,6 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
       statBlock.imageHtml(token, statBlock.data.url).then(theImage => {
         //add in send-to features
         container.find("div.image").append(theImage).find("img.monster-image").each((i,block) => {
-          //patch div so that we place correctly (todo: is there a better place to put this?)
           createSendPlayerButton(block, "login", true).insertAfter(block);
         });
       })

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -92,22 +92,10 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
             src="${imageUrl}"    
             class="monster-image"
             style="max-width: 100%;">
-            </div>
-            <div style="display:flex;flex-direction:row;width:100%;justify-content:space-between;padding:10px;">
-                <a id="monster-image-to-gamelog-link" class="ddbeb-button monster-details-link" href="${imageUrl}" target='_blank' >Send Image To Gamelog</a>
-                </div>`);
+            </div>`);
     }
   
     add_aoe_statblock_click(container, tokenId);
-    // todo: might get rid of this too
-    container.find("#monster-image-to-gamelog-link").on("click", function (e) {
-      e.stopPropagation();
-      e.preventDefault();
-      const imgContainer = $(e.target).parent().prev();
-      imgContainer.find("img, video").attr("href", imgContainer.find("img, video").attr("src"));
-      imgContainer.find("img, video").addClass("magnify");
-      send_html_to_gamelog(imgContainer[0].outerHTML);
-    });
 
   //todo: get rid of send to gamelog button above (as it's duplicate function)
   //todo: fix layout
@@ -118,9 +106,9 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
   
     //Note: this is async - that is why code below may not find image 
     if(!customStatBlock){
-      statBlock.imageHtml(token).then(imageHtml => {
+      statBlock.imageHtml(token, statBlock.data.url).then(theImage => {
         //add in send-to features
-        container.find("div.image").append(imageHtml).find("img.monster-image").each((i,block) => {
+        container.find("div.image").append(theImage).find("img.monster-image").each((i,block) => {
           //patch div so that we place correctly (todo: is there a better place to put this?)
           createSendPlayerButton(block, "login", true).insertAfter(block);
         });
@@ -482,12 +470,6 @@ async function build_monster_stat_block(statBlock, token) {
                             
                             
                   <div class="image" style="display: block;"></div>
-                  <div style="display:flex;flex-direction:row;width:100%;justify-content:space-between;padding:10px;">
-                      <a class="ddbeb-button monster-details-link" href="${statBlock.data.url}" target='_blank' >View Details Page</a>
-                      <a id="monster-image-to-gamelog-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Send Image To Gamelog</a>
-                      <a id="monster-image-popup-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Popup Image To Players</a>
-                  </div>
-
 
                   <div class="more-info-content" style="padding:10px;">
 
@@ -778,12 +760,6 @@ async function build_monster_stat_block(statBlock, token) {
 
 
                 <div class="image" style="display: block;"></div>
-                <div style="display:flex;flex-direction:row;width:100%;justify-content:space-between;padding:10px;">
-                    <a class="ddbeb-button monster-details-link" href="${statBlock.data.url}" target='_blank' >View Details</a>
-                    <a id="monster-image-to-gamelog-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Send Image To Gamelog</a>
-                      <a id="monster-image-popup-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Popup Image To Players</a>    
-                </div>
-
 
                 <div class="more-info-content" style="padding:10px;">
 
@@ -1723,7 +1699,7 @@ class MonsterStatBlock {
         return hidemeHack;
     }
 
-    async imageHtml(token) {
+    async imageHtml(token, statsUrl) {
         // const url = this.findBestAvatarUrl();
         const imageSrc = token?.options?.imgsrc?.startsWith('above-bucket-not-a-url') ? 
           await getAvttStorageUrl(token.options.imgsrc) : 
@@ -1774,9 +1750,10 @@ class MonsterStatBlock {
             el.parent().attr("data-title", `<a target='_blank' href='${nextUrl}' class='link link-full'>View Full Image</a>`);
         });
 
-      //todo: is inline-block correct here? 
-      let html = $(`<a href="${imageSrc}" style="display: inline-block; position: relative;" data-title="<a target='_blank' href='${imageSrc}' class='link link-full'>View Full Image</a>"
-           target="_blank"></a>`);
+      //todo change imageSrc -> statBlock.data.url
+      let html = $(`<a href="${statsUrl}" style="display: inline-block; position: relative;"
+                    data-title="<a target='_blank' href='${statsUrl}' class='link link-full'>View Statblock</a>"
+                    target="_blank"></a>`);
         html.append(img);
         return html;
     }

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -87,17 +87,19 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
       if(token.options.imgsrc.startsWith('above-bucket-not-a-url')){
         imageUrl = await getAvttStorageUrl(imageUrl);
       }
-      container.find(`.avtt-stat-block-container`).append(`<div class="image" style="display: block;"><${(token.options.videoToken == true || ['.mp4', '.webm', '.m4v'].some(d => token.options.imgsrc.includes(d))) ? 'video disableremoteplayback muted' : 'img'}
+      //todo: evaluate block -> inline-block change here.
+      container.find(`.avtt-stat-block-container`).append(`<div class="image" style="display: inline-block; position: relative;"><${(token.options.videoToken == true || ['.mp4', '.webm', '.m4v'].some(d => token.options.imgsrc.includes(d))) ? 'video disableremoteplayback muted' : 'img'}
             src="${imageUrl}"    
             class="monster-image"
             style="max-width: 100%;">
             </div>
             <div style="display:flex;flex-direction:row;width:100%;justify-content:space-between;padding:10px;">
                 <a id="monster-image-to-gamelog-link" class="ddbeb-button monster-details-link" href="${imageUrl}" target='_blank' >Send Image To Gamelog</a>
-                <a id="monster-image-popup-link" class="ddbeb-button monster-details-link" href="${imageUrl}" target='_blank' >Popup Image To Players</a>
-            </div>`);
+                </div>`);
     }
+  
     add_aoe_statblock_click(container, tokenId);
+    // todo: might get rid of this too
     container.find("#monster-image-to-gamelog-link").on("click", function (e) {
       e.stopPropagation();
       e.preventDefault();
@@ -106,21 +108,22 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
       imgContainer.find("img, video").addClass("magnify");
       send_html_to_gamelog(imgContainer[0].outerHTML);
     });
-    container.find("#monster-image-popup-link").on("click", function (e) { 
-      e.stopPropagation();
-      e.preventDefault();
-      const imgContainer = $(e.target).parent().prev();
-      popup = {
-        src: imgContainer.find("img, video").attr("src"),
-        timed: 10000,
-        from:window.PLAYER_ID
-      }
-      window.MB.sendMessage('custom/myVTT/Popup',  popup);
-    });
+
+  //todo: get rid of send to gamelog button above (as it's duplicate function)
+  //todo: fix layout
+  //todo: is this the right place? or do later in display?
+  container.find("img.monster-image, .monster-image").each((i,block) => {
+    createSendPlayerButton(block, "login", true).insertAfter(block);
+  });
   
+    //Note: this is async - that is why code below may not find image 
     if(!customStatBlock){
-      statBlock.imageHtml(token).then(imageHtml => { 
-        container.find("div.image").append(imageHtml); 
+      statBlock.imageHtml(token).then(imageHtml => {
+        //add in send-to features
+        container.find("div.image").append(imageHtml).find("img.monster-image").each((i,block) => {
+          //patch div so that we place correctly (todo: is there a better place to put this?)
+          createSendPlayerButton(block, "login", true).insertAfter(block);
+        });
       })
     }
       
@@ -131,6 +134,8 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
       add_ability_tracker_inputs(container, tokenId)
     // scan_creature_pane(container, statBlock.name, statBlock.image);
     add_stat_block_hover(container, tokenId);
+  
+    //todo: new sendtogamelog menu for these too?
     container.find("p>em>strong, p>strong>em, div>strong>em, div>em>strong, p>span>em>strong, p>span>strong>em").off("contextmenu.sendToGamelog").on("contextmenu.sendToGamelog", function (e) {
       e.preventDefault();
       if(e.altKey || e.shiftKey || (!isMac() && e.ctrlKey) || e.metaKey)
@@ -1769,8 +1774,8 @@ class MonsterStatBlock {
             el.parent().attr("data-title", `<a target='_blank' href='${nextUrl}' class='link link-full'>View Full Image</a>`);
         });
 
-
-      let html = $(`<a href="${imageSrc}" data-title="<a target='_blank' href='${imageSrc}' class='link link-full'>View Full Image</a>"
+      //todo: is inline-block correct here? 
+      let html = $(`<a href="${imageSrc}" style="display: inline-block; position: relative;" data-title="<a target='_blank' href='${imageSrc}' class='link link-full'>View Full Image</a>"
            target="_blank"></a>`);
         html.append(img);
         return html;

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -102,7 +102,7 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
     });
     //Note: this is async - that is why code just above here isn't lower down
     if(!customStatBlock){
-      statBlock.imageHtml(token, statBlock.data.url).then(theImage => {
+      statBlock.imageHtml(token).then(theImage => {
         //add in send-to features
         container.find("div.image").append(theImage).find("img.monster-image").each((i,block) => {
           createSendPlayerButton(block, "login", true).insertAfter(block);
@@ -1694,7 +1694,7 @@ class MonsterStatBlock {
         return hidemeHack;
     }
 
-    async imageHtml(token, statsUrl) {
+    async imageHtml(token) {
         // const url = this.findBestAvatarUrl();
         const imageSrc = token?.options?.imgsrc?.startsWith('above-bucket-not-a-url') ? 
           await getAvttStorageUrl(token.options.imgsrc) : 
@@ -1741,16 +1741,11 @@ class MonsterStatBlock {
             }
             console.log("imageHtml failed to load image. Trying nextUrl", nextUrl, el, e);
             el.attr("src", nextUrl);
-            el.parent().attr("href", nextUrl);
-            el.parent().attr("data-title", `<a target='_blank' href='${nextUrl}' class='link link-full'>View Full Image</a>`);
-        });
-
-      //todo change imageSrc -> statBlock.data.url
-      let html = $(`<a href="${statsUrl}" style="display: inline-block; position: relative;"
-                    data-title="<a target='_blank' href='${statsUrl}' class='link link-full'>View Statblock</a>"
-                    target="_blank"></a>`);
-        html.append(img);
-        return html;
+         });
+      
+      const html = $(`<div style="display: inline-block; position: relative;"></div>`);
+      html.append(img);
+      return html;
     }
 }
 

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -94,8 +94,8 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
             </div>
             <div style="display:flex;flex-direction:row;width:100%;justify-content:space-between;padding:10px;">
                 <a id="monster-image-to-gamelog-link" class="ddbeb-button monster-details-link" href="${imageUrl}" target='_blank' >Send Image To Gamelog</a>
+                <a id="monster-image-popup-link" class="ddbeb-button monster-details-link" href="${imageUrl}" target='_blank' >Popup Image To Players</a>
             </div>`);
-
     }
     add_aoe_statblock_click(container, tokenId);
     container.find("#monster-image-to-gamelog-link").on("click", function (e) {
@@ -106,7 +106,18 @@ async function display_stat_block_in_container(statBlock, container, tokenId, cu
       imgContainer.find("img, video").addClass("magnify");
       send_html_to_gamelog(imgContainer[0].outerHTML);
     });
-
+    container.find("#monster-image-popup-link").on("click", function (e) { 
+      e.stopPropagation();
+      e.preventDefault();
+      const imgContainer = $(e.target).parent().prev();
+      popup = {
+        src: imgContainer.find("img, video").attr("src"),
+        timed: 10000,
+        from:window.PLAYER_ID
+      }
+      window.MB.sendMessage('custom/myVTT/Popup',  popup);
+    });
+  
     if(!customStatBlock){
       statBlock.imageHtml(token).then(imageHtml => { 
         container.find("div.image").append(imageHtml); 
@@ -469,6 +480,7 @@ async function build_monster_stat_block(statBlock, token) {
                   <div style="display:flex;flex-direction:row;width:100%;justify-content:space-between;padding:10px;">
                       <a class="ddbeb-button monster-details-link" href="${statBlock.data.url}" target='_blank' >View Details Page</a>
                       <a id="monster-image-to-gamelog-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Send Image To Gamelog</a>
+                      <a id="monster-image-popup-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Popup Image To Players</a>
                   </div>
 
 
@@ -762,8 +774,9 @@ async function build_monster_stat_block(statBlock, token) {
 
                 <div class="image" style="display: block;"></div>
                 <div style="display:flex;flex-direction:row;width:100%;justify-content:space-between;padding:10px;">
-                    <a class="ddbeb-button monster-details-link" href="${statBlock.data.url}" target='_blank' >View Details Page</a>
+                    <a class="ddbeb-button monster-details-link" href="${statBlock.data.url}" target='_blank' >View Details</a>
                     <a id="monster-image-to-gamelog-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Send Image To Gamelog</a>
+                      <a id="monster-image-popup-link" class="ddbeb-button monster-details-link" href="${image}" target='_blank' >Popup Image To Players</a>    
                 </div>
 
 

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5230,25 +5230,27 @@ button.applyDamageButton svg {
 }
 
 .block-send-to-game-log {
-    position:absolute;
-    float:right;
-    background: none;
-    backdrop-filter: brightness(3);
-    right: 14px;
-    top: -4px;
-    font-size:10px !important;
-    padding: 2px;
+    position: absolute;
     display: flex;
     border-radius: 5px;
     border: none;
     outline: none !important;
     align-items: center;
-    direction: rtl;
-}
-.block-send-to-game-log:has(.whisper-container.visible){
-    background: revert !important;
+    padding: 0px;
+    margin: 0px;
+    background: #eee;
+    opacity: 0.5;
+    right: 4px;
+    top: 4px;
+    cursor: pointer;
 }
 
+.block-send-to-game-log:hover {
+    background-color: #888;
+    opacity: 1;    
+}
+
+/*todo: not sure what this style is for?*/
 td button.block-send-to-game-log {
     position: absolute;
     display: flex;
@@ -5257,29 +5259,11 @@ td button.block-send-to-game-log {
     right: 2px;
     transform: translate(0px, -50%);
 }
+/*size of send-to button*/
 td button.block-send-to-game-log span{
-    font-size:9px !important;
-}
-button.block-send-to-game-log:has(.whisper-container.visible){
-    border:1px solid #000;
-    z-index:10000;
-}
-.whisper-container.visible {
-    display: flex;
-    position: relative;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    align-items: flex-end;
-    margin-right:10px;
+    font-size:18px !important;
 }
 
-.whisper-container {
-    display: none;
-}
-.whisper_toggle_row {
-    display: flex;
-    align-items: center;
-}
 h3#error-message{
     max-height:100px;
     overflow:hidden;
@@ -5347,12 +5331,6 @@ div#initialPosition_row input[type=number] {
     right:5px;
     top: 15px
 }
-button.block-send-to-game-log span {
-    font-size: 13px;
-    padding: 0px;
-    margin: 0px;
-}
-
 
 .damageButtonsContainer {
     top:-15px;
@@ -14816,14 +14794,6 @@ button#displayedDiceFormulaExit:hover {
 }
 .mobileAVTTUI #sheet_resize_button{
     left: -195px !important;
-}
-
-.send-player-button {
-    position: absolute;
-    right: 4px;
-    top: 4px;
-    background: #eee;
-    opacity: 0.5;
 }
 
 .js-popup-options {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -5263,6 +5263,10 @@ td button.block-send-to-game-log {
 td button.block-send-to-game-log span{
     font-size:18px !important;
 }
+/*size of send-to button when in table*/
+td > button.block-send-to-game-log > span {
+    font-size:12px !important;
+}
 
 h3#error-message{
     max-height:100px;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -14823,7 +14823,8 @@ button#displayedDiceFormulaExit:hover {
 }
 .js-popup-option {
     width: 100%;
-    display: flex;
+    display: inline-flex;
+    align-items: center;
     border: 1px;
     flex-wrap: wrap;
     font-family: Roboto Condensed,Roboto,Helvetica,sans-serif;
@@ -14832,6 +14833,7 @@ button#displayedDiceFormulaExit:hover {
     line-height: 1;
     font-weight: 700;
     font-size: 12px;
+    gap: 4px;    
     text-transform: uppercase;
     background-color: #f2f2f2;
     border-radius: 3px;
@@ -14844,8 +14846,8 @@ button#displayedDiceFormulaExit:hover {
     width: 100%;
     display: block;
     font-family: Roboto Condensed,Roboto,Helvetica,sans-serif;
-    color: #838383;
-    font-weight: 700;
+    color: black; 
+    font-weight: bold;
     font-size: 12px;
     text-transform: uppercase;
     background-color: #f2f2f2;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -14840,6 +14840,23 @@ button#displayedDiceFormulaExit:hover {
     white-space: nowrap;
     background-image: unset;
 }
+.js-popup-decoration {
+    width: 100%;
+    display: block;
+    font-family: Roboto Condensed,Roboto,Helvetica,sans-serif;
+    color: #838383;
+    font-weight: 700;
+    font-size: 12px;
+    text-transform: uppercase;
+    background-color: #f2f2f2;
+    margin: 1px;
+    white-space: nowrap;
+    background-image: unset;
+    text-align: center;
+    padding: 0;
+    border: 0;
+    border-top: 1px solid #ccc;
+}
 .js-popup {
     padding: 0;
     z-index: 10000000;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -14818,6 +14818,49 @@ button#displayedDiceFormulaExit:hover {
     left: -195px !important;
 }
 
+.js-popup-options {
+    margin: 2px;
+}
+.js-popup-option {
+    width: 100%;
+    display: flex;
+    border: 1px;
+    flex-wrap: wrap;
+    font-family: Roboto Condensed,Roboto,Helvetica,sans-serif;
+    cursor: pointer;
+    color: #838383;
+    line-height: 1;
+    font-weight: 700;
+    font-size: 12px;
+    text-transform: uppercase;
+    background-color: #f2f2f2;
+    border-radius: 3px;
+    padding: 5px 7px;
+    margin: 1px;
+    white-space: nowrap;
+    background-image: unset;
+}
+.js-popup {
+    padding: 0;
+    z-index: 10000000;
+    position: absolute;
+    width: fit-content;
+    height: fit-content;
+    margin: 0;
+    border: none;
+}
+.js-popup form {
+    margin: 0px;
+    width: 120px;
+}
+.js-popup-option:hover {
+    color: #f2f2f2;
+    background-color: #5d5d5d;
+}
+.js-popup--is-active {
+    color: #fff;
+    background-color: #c53131;
+}
 
 
 @font-face {

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -14818,6 +14818,14 @@ button#displayedDiceFormulaExit:hover {
     left: -195px !important;
 }
 
+.send-player-button {
+    position: absolute;
+    right: 4px;
+    top: 4px;
+    background: #eee;
+    opacity: 0.5;
+}
+
 .js-popup-options {
     margin: 2px;
 }


### PR DESCRIPTION
Adds a "Popup Image to Players" button next to "send to gamelog" for monster images.

This uses magnific to popup the image directly to players for 10 seconds.  (As if it was sent to gamelog and then clicked on in the gamelog).

I added this primarily for use at my game live table - where I just want to quickly pop an image but not have to do a lot of interaction to do so.

Note: also adds else's to message handling to optimize in MessageBroker