### PR TITLE
Fix: Protect startup settings parse from corrupted localStorage

### DIFF
--- a/Startup.mjs
+++ b/Startup.mjs
@@ -24,8 +24,20 @@ $(function() {
       .then((databases)=> {
         window.gameIndexedDb = databases[0];
         window.globalIndexedDB = databases[1];
-        const campaignSettings = JSON.parse(localStorage.getItem(`ExperimentalSettings${window.gameId}`)) || {};
-        const globalSettings = JSON.parse(localStorage.getItem(`ExperimentalSettingsGlobal`)) || {}; ;
+        let campaignSettings = {};
+        try {
+          campaignSettings = JSON.parse(localStorage.getItem(`ExperimentalSettings${window.gameId}`)) || {};
+        } catch (e) {
+          console.warn(`Failed to parse campaign settings for game ${window.gameId}, using defaults`, e);
+          localStorage.removeItem(`ExperimentalSettings${window.gameId}`);
+        }
+        let globalSettings = {};
+        try {
+          globalSettings = JSON.parse(localStorage.getItem(`ExperimentalSettingsGlobal`)) || {};
+        } catch (e) {
+          console.warn(`Failed to parse global settings, using defaults`, e);
+          localStorage.removeItem(`ExperimentalSettingsGlobal`);
+        }
         window.EXPERIMENTAL_SETTINGS = {...campaignSettings, ...globalSettings};
         delete window.EXPERIMENTAL_SETTINGS.streamDiceRolls;
         if (is_release_build()) {


### PR DESCRIPTION
Fixes #3525

**The bug:** `Startup.mjs` lines 27-28 parse campaign and global settings from localStorage using `JSON.parse(...) || {}`. The `|| {}` fallback doesn't protect against corrupted JSON — `JSON.parse` throws a `SyntaxError` before the `||` operator runs.

When this happens:
1. The `.then()` callback rejects, skipping all subsequent startup steps (splash, WebSocket, scene load)
2. Falls through to the terminal `.catch()` → generic "Failed to start AboveVTT" error
3. **No recovery through UI** — the "Delete Campaign AboveVTT Data" button on the campaign page doesn't clear `ExperimentalSettings` keys, so the user hits the crash every refresh

**The fix:** Wrap each `JSON.parse` in a separate try/catch:
- On error: `console.warn` the failure, `localStorage.removeItem` the corrupted key, continue with `{}`
- Each key is handled independently — corrupted campaign settings don't prevent loading valid global settings
- Startup continues normally with default settings

**Why `console.warn` (not `showError`):** Settings resetting to defaults is non-breaking — the VTT loads and works normally. Used `console.warn` as the conservative choice per my [comment on #3525](https://github.com/cyruzzo/AboveVTT/issues/3525#issuecomment-4107702879). Happy to upgrade to `showError` if you'd prefer it in the report window.

**Files changed:** `Startup.mjs` (+12/-2)