### PR TITLE
Fix: Correct string length validation in campaign info functions

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2101,15 +2101,15 @@ function projector_scroll_event(event){
 function store_campaign_info() {
   const campaignId = window.gameId;
   const campaignSecret = window.CAMPAIGN_SECRET;
-  if (typeof campaignId !== "string" || campaignId.length < 0) return;
-  if (typeof campaignSecret !== "string" || campaignSecret.length < 0) return;
+  if (typeof campaignId !== "string" || campaignId.length <= 0) return;
+  if (typeof campaignSecret !== "string" || campaignSecret.length <= 0) return;
   localStorage.setItem(`AVTT-CampaignInfo-${campaignId}`, campaignSecret);
 }
 
 /** @param {string} campaignId the DDB id of the campaign
  * @return {string|undefined} the join link secret if it exists */
 function read_campaign_info(campaignId) {
-  if (typeof campaignId !== "string" || campaignId.length < 0) return undefined;
+  if (typeof campaignId !== "string" || campaignId.length <= 0) return undefined;
   const cs = localStorage.getItem(`AVTT-CampaignInfo-${campaignId}`);
   if (typeof cs === "string" && cs.length > 0) return cs;
   return undefined;


### PR DESCRIPTION
**The bug:** `store_campaign_info()` and `read_campaign_info()` in CoreFunctions.js use `campaignId.length < 0` to reject invalid strings. Since `string.length` is never negative, this check always passes — empty strings are stored/read as valid campaign IDs.

**The fix:** Changed `< 0` to `<= 0` on all 3 occurrences (lines 2104, 2105, 2112). This matches the pattern already used at line 2114 (`cs.length > 0`).

**Impact:** Low — the `typeof` check already catches null/undefined. This only affects the empty string edge case, which would require upstream URL parsing to fail first. But it's a correctness fix that makes the guards work as intended.

**Files changed:** `CoreFunctions.js` (+3/-3)