### PR TITLE
Fix: Swap inverted isNaN branches in AoE size parsing

### DIFF
--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -791,9 +791,9 @@ class SidebarListItem {
     item.shape = shape;
     let parsedSize = parseInt(size);
     if (isNaN(parsedSize)) {
-      item.size = parsedSize;
-    } else {
       item.size = 1;
+    } else {
+      item.size = parsedSize;
     }
     item.style = style;
     return item;


### PR DESCRIPTION
**The bug:** In `SidebarListItem.Aoe()` (SidebarPanel.js line 792-797), the `isNaN` check branches are swapped. When `parseInt(size)` succeeds with a valid number, the code discards it and sets `item.size = 1`. When it fails (NaN), the code assigns NaN as the size.

```javascript
// Before (broken)
if (isNaN(parsedSize)) {
  item.size = parsedSize;   // assigns NaN — wrong
} else {
  item.size = 1;            // discards valid size — wrong
}

// After (fixed)
if (isNaN(parsedSize)) {
  item.size = 1;            // safe fallback
} else {
  item.size = parsedSize;   // uses the parsed value
}
```

**Why it went unnoticed:** The four default AoE items in `init_tokens_panel()` all pass `size = 1`, and `parseInt(1)` → `1` → `isNaN(1)` is false → else branch sets `item.size = 1`. So the defaults work by accident. The DM's AoE modal drag path also masks the bug because it overwrites `draggedItem.size` from the feet input field (TokensPanel.js line 794).

**What it breaks:** AoE templates constructed with non-1 sizes — primarily the player sheet spell AoE path (TokensPanel.js line 802-808), where spell data attributes like `data-size="20"` are read from the character sheet and passed to `SidebarListItem.Aoe()`. These would all render as size 1 instead of the spell's actual area.

**Verified in Chrome** on the live VTT by calling `SidebarListItem.Aoe()` directly:
- `Aoe("circle", 20, "acid").size` → was **1**, now **20**
- `Aoe("cone", "4", "fire").size` → was **1**, now **4**
- `Aoe("line", "abc", "acid").size` → was **NaN**, now **1**
- `Aoe("square", 1, "acid").size` → was **1**, still **1** (no change for defaults)

**Files changed:** `SidebarPanel.js` (+2/-2)