### PR TITLE
Fix: Add missing typeof in conditionImmunitiesHtml type check

### DIFF
--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -1572,7 +1572,7 @@ class MonsterStatBlock {
               return match.toUpperCase();
           });
         }
-        if (this.data.conditionImmunitiesHtml === "string" && this.data.conditionImmunitiesHtml.length > 0) {
+        if (typeof this.data.conditionImmunitiesHtml === "string" && this.data.conditionImmunitiesHtml.length > 0) {
             return this.data.conditionImmunitiesHtml;
         }
         if (!this.data.conditionImmunities || this.data.conditionImmunities.length === 0) {


### PR DESCRIPTION
**The bug:** In the `conditionImmunitiesHtml` getter (MonsterStatBlock.js line 1575), the check is:
```javascript
if (this.data.conditionImmunitiesHtml === "string" && ...)
```
This compares the **value** to the literal word `"string"` — it should be:
```javascript
if (typeof this.data.conditionImmunitiesHtml === "string" && ...)
```

**Why it matters:** The missing `typeof` means the pre-parsed HTML from DDB is never used, even when available. The code always falls through to the ID-based rebuild path (line 1581), which has a crash risk:

```javascript
this.data.conditionImmunities.map(id =>
  window.ddbConfigJson.conditions?.find(obj => obj?.definition?.id === id).definition
)
```

If `find()` doesn't match a condition ID (e.g., DDB adds a new condition before the AboveVTT config is updated), it returns `undefined`, and `.definition` throws a TypeError — crashing the entire stat block render. The pre-parsed HTML path avoids this because DDB already resolved the names.

**Verified in Chrome:** Tested with a Dragonbone Golem (6 condition immunities). The monster has a `conditionImmunitiesHtml` field (1,428 chars of pre-parsed HTML with tooltip links) that was being completely ignored. Both paths produce the same visible text ("Charmed, Exhaustion, Frightened, Paralyzed, Petrified, Poisoned"), but the pre-parsed HTML uses DDB's current rule URLs and doesn't depend on `ddbConfigJson` having every condition ID.

**Files changed:** `MonsterStatBlock.js` (+1/-1)