### PR TITLE
Fix: Use correct ItemType for Open5e in canDelete()

### DIFF
--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -921,7 +921,7 @@ class SidebarListItem {
         return true;
       case ItemType.PC:
       case ItemType.Monster:
-      case ItemType.isTypeOpen5eMonster:
+      case ItemType.Open5e:
       case ItemType.BuiltinToken:
       case ItemType.Encounter:
         if(this.encounterId != undefined)


### PR DESCRIPTION
**The bug:** `canDelete()` in SidebarPanel.js line 924 uses `ItemType.isTypeOpen5eMonster` — but that's a **method** on the `SidebarListItem` prototype, not an `ItemType` enum value. `ItemType.isTypeOpen5eMonster` evaluates to `undefined`, so the `case` never matches.

Open5e monsters fall through to `default: return false`, making them **undeletable from the sidebar**. Meanwhile, DDB Monsters (`ItemType.Monster`), Builtin Tokens, and PCs all match correctly and can be deleted.

**The fix:** Change `ItemType.isTypeOpen5eMonster` to `ItemType.Open5e`, which is the correct enum value (`"open5e"`). This matches the pattern used everywhere else in the codebase:
- Line 730: `SidebarListItem` constructor uses `ItemType.Open5e`
- Line 894: `canEdit()` uses `ItemType.Open5e`  
- Lines 2034, 2217, 2880: other switch statements use `ItemType.Open5e`

**Verified in Chrome:**
```
ItemType.isTypeOpen5eMonster → undefined (never matches)
ItemType.Open5e → "open5e" (correct value)
```

**Files changed:** `SidebarPanel.js` (+1/-1)