### PR TITLE
Fix: Change assignment to comparison in TokenMenu conditions

### DIFF
--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -3116,7 +3116,7 @@ function build_notes_flyout_menu(tokenIds, flyout) {
 	});
 	let editNoteButton = $(`<button class="icon-note material-icons">Create Note</button>`)
 
-	if(tokenIds.length=1){
+	if(tokenIds.length==1){
 		let has_note=id in window.JOURNAL.notes;
 		if(has_note){
 			let viewNoteButton = $(`<button class="icon-view-note material-icons">View Note</button>`)		
@@ -4043,7 +4043,7 @@ function build_options_flyout_menu(tokenIds) {
 
 		let tokenSettings = tokens.map(t => t.options[setting.name]);
 		let uniqueSettings = [...new Set(tokenSettings)].filter(d => d != undefined);
-		if(uniqueSettings.length = 0)
+		if(uniqueSettings.length == 0)
 			uniqueSettings = [undefined]
 		let currentValue = null; // passing null will set the switch as unknown; undefined is the same as false
 		if (uniqueSettings.length === 1) {


### PR DESCRIPTION
**Two assignment-instead-of-comparison bugs in TokenMenu.js:**

**Line 3119:** `if(tokenIds.length=1)` — uses `=` (assignment) instead of `==` (comparison). This assigns 1 to `.length`, truncating the array to 1 element. The condition always evaluates truthy, so the notes flyout code always runs regardless of how many tokens are selected.

**Line 4046:** `if(uniqueSettings.length = 0)` — same pattern. Assigns 0 to `.length`, truncating the array to empty. The condition always evaluates falsy, so the `[undefined]` fallback on line 4047 is dead code.

**Fix:** Changed `=` to `==` on both lines.

**Verified in Chrome:** `[1,2,3].length = 1` returns `1` (truthy) and truncates the array to `[1]`. `[1,2,3].length = 0` returns `0` (falsy) and truncates to `[]`.

**Files changed:** `TokenMenu.js` (+2/-2)