### PR TITLE
Fix: Add missing push in multi-select Place context menu

### DIFF
--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1878,6 +1878,7 @@ function register_token_row_context_menu() {
                         for (let i = 0; i < selectedItems.length; i++) {
                             let selectedRow = $(selectedItems[i]);
                             let selectedItem = find_sidebar_list_item(selectedRow);
+                            listItemArray.push(selectedItem);
                         }
                         if (listItemArray.length < 10 || confirm(`This will add ${listItemArray.length} tokens which could lead to unexpected results. Are you sure you want to add all of these tokens?`)) {
                             let distanceFromCenter = window.CURRENT_SCENE_DATA.hpps * window.ZOOM * (listItemArray.length / 8);


### PR DESCRIPTION
**The bug:** In the "Place" context menu handler (TokensPanel.js line 1878-1881), the loop iterates selected sidebar items and calls `find_sidebar_list_item(selectedRow)` but never pushes the result to `listItemArray`. The array stays empty, so multi-selecting tokens and clicking "Place" does nothing.

**The fix:** Add `listItemArray.push(selectedItem)` inside the loop.

**Files changed:** `TokensPanel.js` (+1/-0)