### PR TITLE
Fix: Swim Speed visibility checks wrong variable

### DIFF
--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1041,7 +1041,7 @@ function update_pc_token_rows() {
             } else{
                 row.find(".subtitle-attibute[title='Fly Speed']").hide()
             }
-            if(flyingSpeed > 0) {
+            if(swimmingSpeed > 0) {
                 row.find(".subtitle-attibute[title='Swim Speed']").show()
             } else {
                 row.find(".subtitle-attibute[title='Swim Speed']").hide()


### PR DESCRIPTION
**The bug:** TokensPanel.js line 1044 checks `flyingSpeed > 0` to show/hide the Swim Speed element. This is a copy-paste from the Fly Speed check at line 1039. The `swimmingSpeed` variable is computed at line 1032 and used to set the text value at line 1033, but the visibility check uses the wrong variable.

Characters with swim speed but no fly speed would have their Swim Speed hidden.

**Fix:** Change `flyingSpeed` to `swimmingSpeed` on line 1044.

**Files changed:** `TokensPanel.js` (+1/-1)