### PR TITLE
Fix: Correct property name targetFlip to tokenFlip

### DIFF
--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -2943,7 +2943,7 @@ function display_aoe_token_configuration_modal(listItem, placedToken = undefined
     });
     inputWrapper.append(imageZoomWrapper);
 
-    let startingTokenFlip = targetOptions.targetFlip || 0;
+    let startingTokenFlip = targetOptions.tokenFlip || 0;
     let tokenFlipWrapper = build_token_flip_input(startingTokenFlip, function (tokenFlip) { 
         customization.setTokenOption("tokenFlip", tokenFlip);
         persist_token_customization(customization);


### PR DESCRIPTION
**The bug:** TokensPanel.js line 2946 reads `targetOptions.targetFlip` to initialize the token flip input. The property name is `tokenFlip` (as seen at line 2948 where `setTokenOption("tokenFlip", ...)` saves it correctly). Since `targetFlip` doesn't exist, `|| 0` always fires and saved flip customizations are ignored.

**Fix:** Change `targetFlip` to `tokenFlip`.

**Files changed:** `TokensPanel.js` (+1/-1)