### PR TITLE
Fix: Replace undefined ddbMessage with firstPending in sendNewFulfilled

### DIFF
--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -1112,9 +1112,9 @@ class DiceRoller {
         this.ddbDispatch(alteredMessage);
         if(this.#multiRollArray.length>0){
             const self = this;
-            const nextCritRange = self.#pendingMessages[ddbMessage.data.rollId].pendingCritRange;
-            const nextCritType = self.#pendingMessages[ddbMessage.data.rollId].pendingCritType;
-            const nextDamageType = self.#pendingMessages[ddbMessage.data.rollId].pendingDamageType;
+            const nextCritRange = self.#pendingMessages[firstPending]?.pendingCritRange;
+            const nextCritType = self.#pendingMessages[firstPending]?.pendingCritType;
+            const nextDamageType = self.#pendingMessages[firstPending]?.pendingDamageType;
             setTimeout(function () {
                 if (newDice) {
                     self.nextRoll(alteredMessage, nextCritRange, nextCritType, nextDamageType);


### PR DESCRIPTION
**The bug:** DiceRoller.js lines 1115-1117 reference `ddbMessage.data.rollId` inside `sendNewFulfilled()`, but `ddbMessage` is not defined in that scope. The correct variable is `firstPending` (line 1098), which is used correctly everywhere else in the function (lines 1099, 1104, 1111, 1124).

This throws a `ReferenceError` when multi-rolling (e.g., attack + damage) with the new DDB dice UI, breaking the crit range/type/damage type propagation to subsequent rolls.

**Fix:** Replace `ddbMessage.data.rollId` with `firstPending` on all three lines. Added optional chaining (`?.`) since the pending message at `firstPending` is nulled at line 1124, and the setTimeout at line 1118 could fire after that.

**Files changed:** `DiceRoller.js` (+3/-3)