### PR TITLE
Fix: Use regex instead of string literal for whitespace removal

### DIFF
--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -995,7 +995,7 @@ class DiceRoller {
                 }
             }
             if (sendTo == '') {
-                sendTo = gamelog_send_to_text().trim().replace('/\s/gi', '');
+                sendTo = gamelog_send_to_text().trim().replace(/\s/gi, '');
             }
             sendTo = sendTo.toLowerCase();
             const rollId = uuid();


### PR DESCRIPTION
**The bug:** DiceRoller.js line 998: `sendTo.replace('/\s/gi', '')` passes a **string literal** `'/\s/gi'` as the first argument to `.replace()`. This matches the literal characters `/\s/gi` in the string (which would never appear), not whitespace. Whitespace is never removed from the sendTo value.

**Fix:** Remove the quotes: `.replace(/\s/gi, '')` so it's treated as a regex.

**Verified in Chrome:** `'Hello World'.replace('/\\s/gi', '')` returns `'Hello World'` unchanged. `'Hello World'.replace(/\s/gi, '')` returns `'HelloWorld'`.

**Files changed:** `DiceRoller.js` (+1/-1)