### PR TITLE
Fix: Add missing $() wrapper for temp HP selector

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -976,7 +976,7 @@ function read_temp_hp(container = $(document)) {
   }
   if (container.find(`.ct-status-summary-mobile__hp--has-temp`).length) {
     if(container.find('.ct-health-manager__health-item--temp').length){
-        return parseInt(('.ct-health-manager__health-item--temp .ct-health-manager__input').val()); // if hp side panel is open check this for temp hp
+        return parseInt($('.ct-health-manager__health-item--temp .ct-health-manager__input').val()); // if hp side panel is open check this for temp hp
       }
     // DDB doesn't display the temp value on mobile layouts so just set it to 1, so we can at least show that there is temp hp. See `read_current_hp` for the other side of this
     return 1;


### PR DESCRIPTION
**The bug:** CharactersPage.js line 979 calls `.val()` on a raw CSS selector string:
```javascript
parseInt(('.ct-health-manager__health-item--temp .ct-health-manager__input').val())
```
Strings don't have `.val()` — it throws `TypeError: not a function`. This means temp HP always reads as NaN on mobile layout when the HP side panel is open.

**Fix:** Wrap in `$()`:
```javascript
parseInt($('.ct-health-manager__health-item--temp .ct-health-manager__input').val())
```

**Verified in Chrome:** `('selector').val` is `undefined`. `$('selector').val` is a function.

**Files changed:** `CharactersPage.js` (+1/-1)