### PR TITLE
Fix: Use data.current instead of loop variable tokenID in ct_load

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -1768,7 +1768,7 @@ function ct_load(data=null){
 			$("#combat_area tr[data-target='"+data.current+"']").attr("data-current","1");
 			if(window.TOKEN_OBJECTS[data.current] != undefined){
 				window.TOKEN_OBJECTS[data.current].options.current = true;
-				window.TOKEN_OBJECTS[tokenID].place();
+				window.TOKEN_OBJECTS[data.current].place();
 			}
 			if(window.all_token_objects[data.current] != undefined){
 				if(window.all_token_objects[data.current].isCurrentPlayer() || window.all_token_objects[data.current].options.player_owned){


### PR DESCRIPTION
**The bug:** CombatTracker.js line 1771 calls `window.TOKEN_OBJECTS[tokenID].place()` where `tokenID` is the implicit global from the `for...in` loop at line 1762. After the loop finishes, `tokenID` holds the **last iterated key**, not the current-turn token.

Line 1770 correctly uses `data.current` to set `.options.current = true`, but line 1771 calls `.place()` on the wrong token.

**Fix:** Change `tokenID` to `data.current` on line 1771, matching the pattern on lines 1769-1770.

**Files changed:** `CombatTracker.js` (+1/-1)