### PR TITLE
Fix: Assign filter result back to orderedChannels in deleteChannel

### DIFF
--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -605,7 +605,7 @@ class Mixer extends EventTarget {
         const state = this.state();
         delete state.channels[id];
         if(state.orderedChannels){
-            state.orderedChannels.filter(d=> d != id);
+            state.orderedChannels = state.orderedChannels.filter(d=> d != id);
         }
         this._write(state);
         this.dispatchEvent(new Event(mixerEvents.ON_CHANNEL_LIST_CHANGE));


### PR DESCRIPTION
**The bug:** In `deleteChannel()` (audio/mixer.js line 608), `state.orderedChannels.filter(d=> d != id)` creates a new filtered array but the result is never assigned back. `Array.filter()` does not mutate the original array. The deleted channel ID persists in `orderedChannels` after the channel data is removed from `state.channels`.

**Fix:** `state.orderedChannels = state.orderedChannels.filter(d=> d != id)`

**Files changed:** `audio/mixer.js` (+1/-1)