### PR TITLE
Fix: Replace undefined importData with sceneData in catch handler

### DIFF
--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -3608,7 +3608,7 @@ async function build_source_book_chapter_import_section(sceneSet) {
 			})
 			.catch(error => {
 				$(`body>.import-loading-indicator`).remove();
-				showError(error, "Failed to import scene", importData);
+				showError(error, "Failed to import scene", sceneData);
 			});
 	})
 		


### PR DESCRIPTION
**The bug:** ScenesPanel.js line 3611 references `importData` in a `.catch()` handler, but `importData` is not defined in this scope. The correct variable is `sceneData` (used at lines 3602-3606 in the `.then()` handler of the same promise chain).

This throws a `ReferenceError` inside the error handler, masking the original scene import error. Users would see a confusing secondary crash instead of the actual import failure message.

**Note:** Line 3885 has the same `showError(error, "Failed to import scene", importData)` pattern, but in that scope `importData` IS correctly defined (lines 3872-3880). Only line 3611 is the bug.

**Fix:** Change `importData` to `sceneData` on line 3611.

**Files changed:** `ScenesPanel.js` (+1/-1)