### PR TITLE
Fix: Add response.ok check to fetchMembership

### DIFF
--- a/avttS3Upload.js
+++ b/avttS3Upload.js
@@ -4631,6 +4631,10 @@ const PatreonAuth = (() => {
       },
     );
     
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'Unknown error');
+      throw new Error(`Patreon membership check failed (HTTP ${response.status}): ${errorText}`);
+    }
     const { user } = await response.json();
     activeUserLimit = user.limit;
     activeUserTier = user;


### PR DESCRIPTION
**The bug:** In `fetchMembership()` (avttS3Upload.js line 4634), `const { user } = await response.json()` runs regardless of HTTP status. If the server returns an error:
- Non-JSON body (e.g., HTML error page) → `response.json()` throws a confusing parse error
- Error JSON without `user` property → `user` is `undefined` → `user.limit` throws `TypeError`

**Fix:** Add `if (!response.ok)` check before parsing, throwing a descriptive error with the HTTP status code. This matches the pattern used in `avttFetchWithRetry` and other fetch calls in the file.

**Files changed:** `avttS3Upload.js` (+4/-0)