### PR TITLE
Fix: Use correct abort controller variable in getAllUserFiles

### DIFF
--- a/avttS3Upload.js
+++ b/avttS3Upload.js
@@ -8575,9 +8575,9 @@ async function getAllUserFiles(options = {}) {
   if (signal) {
     linkedAbortHandler = () => {
       try {
-        abortController.abort(signal.reason);
+        window.abortGetAllUserFilesController.abort(signal.reason);
       } catch (_) {
-        abortController.abort();
+        window.abortGetAllUserFilesController.abort();
       }
     };
     if (signal.aborted) {


### PR DESCRIPTION
**The bug:** In `getAllUserFiles()` (avttS3Upload.js lines 8578-8580), the linked abort handler references bare `abortController` which is not declared in scope. The correct variable is `window.abortGetAllUserFilesController` (created at line 8572). When an external signal aborts, this throws a `ReferenceError` instead of cleanly propagating the abort.

**Verified in Chrome:** `abortController` is undefined in this scope. `window.abortGetAllUserFilesController` is the variable created 6 lines earlier.

**Fix:** Replace `abortController` with `window.abortGetAllUserFilesController` on both lines.

**Files changed:** `avttS3Upload.js` (+2/-2)