### PR TITLE
Fix: Check diceCurrentPeers instead of currentPeers in getDiceMedia

### DIFF
--- a/peerDice.js
+++ b/peerDice.js
@@ -169,7 +169,7 @@ function getDiceMedia(){
     let diceRollPanel = $(".dice-rolling-panel__container, canvas[style*='z-index: 99999999;']:not([id]):not([class])");
     window.MYMEDIASTREAM = diceRollPanel[0].captureStream(30)
 
-    if(window.currentPeers.length == 0){
+    if(window.diceCurrentPeers.length == 0){
         window.MB.sendMessage("custom/myVTT/diceVideoPeerConnect", {id: diceplayer_id});  
     }
     else{


### PR DESCRIPTION
**The bug:** In `getDiceMedia()` (peerDice.js line 172), `window.currentPeers.length == 0` checks the **video** peer array (from peerVideo.js) instead of the **dice** peer array (`window.diceCurrentPeers`, declared at peerDice.js line 7).

When video peers exist but dice peers don't, the code skips the `sendMessage("diceVideoPeerConnect")` announcement and falls through to iterating `diceCurrentPeers` (which is empty), so dice streaming silently fails to initialize.

Line 176 correctly uses `window.diceCurrentPeers`, confirming the inconsistency.

**Verified in Chrome:** `window.currentPeers` and `window.diceCurrentPeers` are confirmed as two separate arrays.

**Fix:** Change `window.currentPeers` to `window.diceCurrentPeers` on line 172.

**Files changed:** `peerDice.js` (+1/-1)