### PR TITLE
Fix: Correct spellSave and damageType argument positions in roll()

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -1958,7 +1958,7 @@ function observe_character_sheet_changes(documentToObserve) {
 
         e.stopImmediatePropagation();
         
-        window.diceRoller.roll(new DiceRoll(rollData.expression, rollData.rollTitle, rollData.rollType), undefined, undefined, undefined, undefined, rollData.damageType, rollData.spellSave);
+        window.diceRoller.roll(new DiceRoll(rollData.expression, rollData.rollTitle, rollData.rollType), undefined, undefined, undefined, rollData.spellSave, rollData.damageType);
 
       };
 


### PR DESCRIPTION
**The bug:** CharactersPage.js line 1961 passes `rollData.spellSave` at position 6 of `diceRoller.roll()`, but position 6 is `forceCritType`. The `spellSave` parameter is at position 4.

```javascript
// Before (buggy):
roll(diceRoll, undefined, undefined, undefined, undefined, rollData.damageType, rollData.spellSave)
//                                               pos 4=undefined  pos 5=damageType  pos 6=spellSave→forceCritType!

// After (fixed):
roll(diceRoll, undefined, undefined, undefined, rollData.spellSave, rollData.damageType)
//                                               pos 4=spellSave   pos 5=damageType
```

This matches the correct pattern used at lines 2063 and 2348:
```javascript
roll(diceRoll, true, critRange, critType, spellSaveText, damageTypeText)
```

**Impact:** Spell save DC is lost on manual-set roll button clicks, and the spell save value may incorrectly influence crit type behavior.

**Verified in Chrome:** Confirmed `roll()` signature has `spellSave` at position 4, `damageType` at position 5, `forceCritType` at position 6.

**Files changed:** `CharactersPage.js` (+1/-1)