### PR TITLE
Fix: Guard scrollIntoView with optional chaining in combat tracker

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -366,10 +366,10 @@ function init_combat_tracker(){
 		debounceCombatPersist();
 		ct_update_popout();
 		if(window.childWindows['Combat Tracker'] != undefined)
-			$(window.childWindows['Combat Tracker'].document).find("tr[data-current=1]")[0].scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });
-		$("#site tr[data-current=1]")[0].scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });	
+			$(window.childWindows['Combat Tracker'].document).find("tr[data-current=1]")[0]?.scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });
+		$("#site tr[data-current=1]")[0]?.scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });
 	});
-	
+
 	let prev=$("<button id='combat_prev_button'>PREV</button>");
 	prev.click(function(){
 		if($("#combat_area tr").length==0 || (document.getElementById('round_number').value <= 1 && $("#combat_area tr").first().attr('data-current') == 1))
@@ -430,8 +430,8 @@ function init_combat_tracker(){
 		debounceCombatPersist();
 		ct_update_popout();
 		if(window.childWindows['Combat Tracker'] != undefined)
-			$(window.childWindows['Combat Tracker'].document).find("tr[data-current=1]")[0].scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });
-		$("#site tr[data-current=1]")[0].scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });	
+			$(window.childWindows['Combat Tracker'].document).find("tr[data-current=1]")[0]?.scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });
+		$("#site tr[data-current=1]")[0]?.scrollIntoView({ behavior: 'instant', block: 'center', start: 'inline' });
 	});
 
 	let endplayerturn=$('<button id="endplayerturn">E<u>n</u>d Turn</button>');


### PR DESCRIPTION
**The bug:** CombatTracker.js lines 369-370 (NEXT button) and 433-434 (PREV button) call \`[0].scrollIntoView()\` on jQuery selectors for \`tr[data-current=1]\`. If the selector returns no results (e.g., popout combat tracker window hasn't updated yet, or combat was cleared), \`[0]\` returns \`undefined\` and \`.scrollIntoView()\` throws \`TypeError: Cannot read properties of undefined\`.

**Reproduced in Chrome:** \`\$("tr[data-nonexistent=999]")[0].scrollIntoView()\` throws \`TypeError: Cannot read properties of undefined (reading 'scrollIntoView')\`.

**Fix:** Added \`?.\` optional chaining on all 4 instances (2 in NEXT handler, 2 in PREV handler). The scroll is silently skipped when no current row exists.

**Files changed:** \`CombatTracker.js\` (+4/-4)