### PR TITLE
Fix: Guard audio track access in video call when mic unavailable

### DIFF
--- a/peerVideo.js
+++ b/peerVideo.js
@@ -54,7 +54,10 @@ function init_peerVideo_box() {
 
     $("#peerVideo_mute_mic").off('click.mute').on('click.mute', function(){
         $(this).toggleClass('muted');
-        window.myLocalVideostream.getAudioTracks()[0].enabled = !$(this).hasClass('muted');
+        const audioTrack = window.myLocalVideostream?.getAudioTracks()[0];
+        if (audioTrack) {
+            audioTrack.enabled = !$(this).hasClass('muted');
+        }
     });
     $("#peerVideo_echo_cancel").off('click.echo').on('click.echo', function(){
         $(this).toggleClass('enabled');
@@ -283,7 +286,10 @@ function getMediaDevice(){
             audio: audioConditions,
         }).then( (stream) => {
         window.myLocalVideostream = stream;
-        window.myLocalVideostream.getAudioTracks()[0].enabled = !$("#peerVideo_mute_mic").hasClass('muted');
+        const audioTrack = window.myLocalVideostream.getAudioTracks()[0];
+        if (audioTrack) {
+            audioTrack.enabled = !$("#peerVideo_mute_mic").hasClass('muted');
+        }
         setLocalStream(window.myLocalVideostream)
         if(window.currentPeers.length == 0){
             window.MB.sendMessage("custom/myVTT/videoPeerConnect", {id: window.myVideoPeerID});  
@@ -327,7 +333,10 @@ function startScreenShare() {
             stopScreenSharing()
         }
 
-        screenStream.addTrack(window.myLocalVideostream.getAudioTracks()[0])
+        const micTrack = window.myLocalVideostream?.getAudioTracks()[0];
+        if (micTrack) {
+            screenStream.addTrack(micTrack);
+        }
         for(let i=0; i<window.currentPeers.length; i++){
           let call = window.videoPeer.call(window.currentPeers[i].peer, screenStream)
           call.on('stream', (stream) => {


### PR DESCRIPTION
**The bug:** peerVideo.js lines 57, 286, and 330 access \`getAudioTracks()[0]\` without checking if the stream exists or has audio tracks. When microphone permission is denied or no mic is available, \`myLocalVideostream\` is undefined (line 57) or has zero audio tracks (lines 286, 330), causing a TypeError.

**Reproduced in Chrome:**
1. Denied microphone permission via Chrome site settings
2. Opened video call → \`myLocalVideostream\` is undefined
3. Clicked mute mic button → \`TypeError: Cannot read properties of undefined (reading 'getAudioTracks')\`

**Fix:** Guard all 3 instances — extract the audio track first, only operate on it if it exists. When no mic is available, the mute toggle and screen share audio injection are silently skipped (expected behavior — can't mute a mic that doesn't exist).

**Files changed:** \`peerVideo.js\` (+9/-3)