### PR TITLE
Fix: Replace splice-in-loop with filter in rebuild_buffs()

### DIFF
--- a/CharactersPage.js
+++ b/CharactersPage.js
@@ -1400,20 +1400,12 @@ function register_buff_row_context_menu() {
 function rebuild_buffs(fullBuild = false){
   window.rollBuffs = JSON.parse(localStorage.getItem('rollBuffs' + window.PLAYER_ID)) || [];
   const buffDebuffKeys=Object.keys(buffsDebuffs);
-  for(let i in window.rollBuffs){
-    if(Array.isArray(window.rollBuffs[i])){
-      if(!buffDebuffKeys.includes(window.rollBuffs[i][0])){
-        window.rollBuffs.splice(i, 1);
-        localStorage.setItem('rollBuffs' + window.PLAYER_ID, JSON.stringify(window.rollBuffs));
-      }
-    }
-    else{
-      if(!buffDebuffKeys.includes(window.rollBuffs[i])){
-        window.rollBuffs.splice(i, 1);
-        localStorage.setItem('rollBuffs' + window.PLAYER_ID, JSON.stringify(window.rollBuffs));
-      }
-    }
-  }
+  const originalLength = window.rollBuffs.length;
+  window.rollBuffs = window.rollBuffs.filter(buff =>
+    Array.isArray(buff) ? buffDebuffKeys.includes(buff[0]) : buffDebuffKeys.includes(buff)
+  );
+  if(window.rollBuffs.length !== originalLength)
+    localStorage.setItem('rollBuffs' + window.PLAYER_ID, JSON.stringify(window.rollBuffs));
   rollBuffFavorites = JSON.parse(localStorage.getItem('rollFavoriteBuffs' + window.PLAYER_ID)) || [];
   rollBuffPins = JSON.parse(localStorage.getItem('rollBuffPins' + window.PLAYER_ID)) || [];
   let avttBuffSelect;


### PR DESCRIPTION
## Bug

`rebuild_buffs()` in CharactersPage.js uses `splice()` inside a forward `for...in` loop to remove stale buff entries. When `splice` removes an element, all subsequent indices shift down by one, but the loop variable advances — causing the next element to be skipped.

If a player has two or more adjacent stale buffs (entries referencing keys no longer in `buffsDebuffs`), only every other one gets removed. The rest persist in localStorage indefinitely.

### Before (lines 1403-1415)
```js
for(let i in window.rollBuffs){
  if(Array.isArray(window.rollBuffs[i])){
    if(!buffDebuffKeys.includes(window.rollBuffs[i][0])){
      window.rollBuffs.splice(i, 1);
      localStorage.setItem('rollBuffs' + window.PLAYER_ID, JSON.stringify(window.rollBuffs));
    }
  }
  else{
    if(!buffDebuffKeys.includes(window.rollBuffs[i])){
      window.rollBuffs.splice(i, 1);
      localStorage.setItem('rollBuffs' + window.PLAYER_ID, JSON.stringify(window.rollBuffs));
    }
  }
}
```

### After
```js
const originalLength = window.rollBuffs.length;
window.rollBuffs = window.rollBuffs.filter(buff =>
  Array.isArray(buff) ? buffDebuffKeys.includes(buff[0]) : buffDebuffKeys.includes(buff)
);
if(window.rollBuffs.length !== originalLength)
  localStorage.setItem('rollBuffs' + window.PLAYER_ID, JSON.stringify(window.rollBuffs));
```

## Verification

Tested via console injection on a live character sheet (Sovereign Test, campaign test2):

| Test | Input | Buggy Result | Fixed Result |
|---|---|---|---|
| 3 stale strings | `["FAKE1", "FAKE2", "FAKE3"]` | `["FAKE2"]` — skipped | `[]` — all removed |
| Mixed valid + stale | `["Bless", "FAKE", ["Rage","+2"], ["FAKE","x"], "FAKE2"]` | not tested | `["Bless", ["Rage","+2"]]` — valid kept, stale removed |

## Notes

- `.filter()` is already the established pattern for buff removal elsewhere in this file (lines 1514, 1518, 1583)
- Also reduces localStorage writes from one-per-removal to a single write only when something changed