### PR TITLE
Fix: re-enable rebuild_peerManager with exponential backoff

### DIFF
--- a/PeerCommunication.js
+++ b/PeerCommunication.js
@@ -236,19 +236,42 @@ function disable_peer_manager() {
   window.PeerManager.enabled = false;
 }
 
-/** when we receive catastrophic errors, we need to tear down and rebuild PeerManager */
+/** Tracks rebuild state for the current session. Not reset on success — server costs are the concern. */
+let _rebuildAttempts = 0;
+const _maxRebuildAttempts = 3;
+const _rebuildBaseDelay = 2000;
+let _rebuildTimerId = undefined;
+
+/** When we receive catastrophic errors, we tear down and rebuild PeerManager.
+ * Uses exponential backoff (2s, 4s, 8s) with a per-session retry limit to avoid
+ * the WebSocket message spam that caused this to be disabled originally. */
 function rebuild_peerManager() {
-  //DO NOT REBUILD - CAUSES MESSAGE SPAM through websocket
-  // Can maybe add limited retries.
-  return;
-  /*
-    console.log("rebuild_peerManager starting");
-    disable_peer_manager();
-    window.PeerManager.tearDown();
-    window.PeerManager = new PeerManager();
-    enable_peer_manager();
-    console.log("rebuild_peerManager finished");
-  */
+  if (_rebuildTimerId) {
+    console.debug("rebuild_peerManager already scheduled, skipping");
+    return;
+  }
+  if (_rebuildAttempts >= _maxRebuildAttempts) {
+    console.warn(`rebuild_peerManager giving up after ${_maxRebuildAttempts} attempts. Cursors/rulers may not work until page refresh.`);
+    return;
+  }
+
+  _rebuildAttempts++;
+  const delay = Math.min(_rebuildBaseDelay * Math.pow(2, _rebuildAttempts - 1), 10000);
+  console.warn(`rebuild_peerManager scheduling attempt ${_rebuildAttempts}/${_maxRebuildAttempts} in ${delay}ms`);
+
+  _rebuildTimerId = setTimeout(() => {
+    _rebuildTimerId = undefined;
+    try {
+      console.log("rebuild_peerManager starting");
+      disable_peer_manager();
+      window.PeerManager.tearDown();
+      window.PeerManager = new PeerManager();
+      enable_peer_manager();
+      console.log("rebuild_peerManager finished");
+    } catch (error) {
+      console.warn("rebuild_peerManager failed", error);
+    }
+  }, delay);
 }
 
 /** Called when a new connection is opened

--- a/PeerManager.js
+++ b/PeerManager.js
@@ -82,7 +82,7 @@ class PeerManager {
       });
       conn.on("error", (error) => {
         console.error("PeerManager connection error", error);
-        // should we call rebuild_peerManager() here?
+        window.PeerManager.disconnectFromPeer(conn.peer);
       });
     });
     this.peer.on('error', function (error) {


### PR DESCRIPTION
Addresses #4173 — re-enables `rebuild_peerManager()` which was disabled due to WebSocket message spam and server costs from an infinite error loop.

## Changes

### PeerCommunication.js — `rebuild_peerManager()` (lines 239–275)

**Before:** Immediately returned (disabled). Comment: "DO NOT REBUILD - CAUSES MESSAGE SPAM through websocket. Can maybe add limited retries."

**After:** Re-enabled with per-session exponential backoff:
- **3 max retries per session** — not reset on success, since server costs are the concern
- **Exponential backoff** — 2s → 4s → 8s delays between attempts
- **Dedup** — skips if a rebuild is already scheduled (timer pending)
- **Graceful give-up** — `console.warn` after max attempts (not `showError`, since PeerJS is cosmetic only — cursors/rulers/video)
- **try/catch** around the teardown→rebuild sequence in case the peer is in a bad state

### PeerManager.js — connection error handler (line 83–86)

**Before:** Logged the error with a comment asking "should we call rebuild_peerManager() here?"

**After:** Disconnects the errored connection via `disconnectFromPeer(conn.peer)` — same pattern as the existing `close` handler on line 77. Per Azmoria's feedback: connection-level errors should disconnect that connection, not trigger a full PeerManager rebuild.

## Files Changed
- `PeerCommunication.js` — rebuild function rewrite (+36/−13)
- `PeerManager.js` — connection error handler (+1/−1)