### PR TITLE
Fix: replace all drop notation markers in dice expressions

### DIFF
--- a/DiceRoller.js
+++ b/DiceRoller.js
@@ -957,7 +957,7 @@ class DiceRoller {
                         let cleanerString = currentRoll.toString()
                             .replace("[", "(")    // swap square brackets with parenthesis
                             .replace("]", ")")    // swap square brackets with parenthesis
-                            .replace("d", "")     // remove all drop notations
+                            .replace(/d/g, "")     // remove all drop notations
                             .replace(/\s+/g, ''); // remove all whitespace
                         convertedExpression.push(cleanerString);
                     } else {


### PR DESCRIPTION
## Bug

`DiceRoller.js:960` — `.replace("d", "")` uses a string argument, which only removes the **first** occurrence. The rpg-dice-roller library marks dropped dice with trailing "d" in its `.toString()` output (e.g., `[5d, 5, 4d, 1d]` for `4d6kh1`). When multiple dice are dropped, only the first "d" marker is removed, corrupting the expression string.

**Before:** `(5,5,4d,1d)` — leftover "d" markers in expression
**After:** `(5,5,4,1)` — all drop markers removed

## Fix

Change `.replace("d", "")` to `.replace(/d/g, "")` so all occurrences are removed.

## Verified in Chrome

Rolled `4d6kh1` in DM session. `rpgDiceRoller.DiceRoll("4d6kh1").rolls[0].toString()` produces `[5d, 5, 4d, 1d]` — confirmed the string replace only removes the first "d".

## Files Changed
- `DiceRoller.js` — 1 line changed