### PR TITLE
Fix: damageType undefined in formula button contextmenu handler

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -1019,7 +1019,9 @@ function add_journal_roll_buttons(target, tokenId=undefined, specificImage=undef
     
     
     if (rollData.rollType === "damage") {
-      damage_dice_context_menu(rollData.expression, rollData.modifier, rollData.rollTitle, rollData.rollType, tokenName, tokenImage, entityType, tokenId, damageType, spellSave)
+      const followingText = this.nextSibling?.textContent?.trim()?.split(' ')[0]
+      const damageType = followingText && window.ddbConfigJson.damageTypes.some(d => d.name.toLowerCase() == followingText.toLowerCase()) ? followingText : undefined
+      damage_dice_context_menu(rollData.expression, rollData.modifier, rollData.rollTitle, rollData.rollType, tokenName, tokenImage, entityType, tokenId, damageType, undefined)
         .present(e.clientY, e.clientX) // TODO: convert from iframe to main window
     } else {
       standard_dice_context_menu(rollData.expression, rollData.modifier, rollData.rollTitle, rollData.rollType, tokenName, tokenImage, entityType, tokenId)


### PR DESCRIPTION
## Bug

`CoreFunctions.js:1022` — The contextmenu handler for `avtt-roll-formula-button` references `damageType` and `spellSave`, but both are undefined in that scope:

- `damageType` is defined with `const` at line 1004 inside the **click** handler closure — not accessible from the separate contextmenu handler closure at line 1008.
- `spellSave` is never defined anywhere in `add_journal_roll_buttons`.

When a user right-clicks a damage roll button on a monster stat block, the context menu always receives `undefined` for damage type.

## Fix

Compute `damageType` inside the contextmenu handler using the same logic as the click handler (check `nextSibling` text against `ddbConfigJson.damageTypes`). Pass `undefined` explicitly for `spellSave` since `damage_dice_context_menu` handles that gracefully.

## Verified in Chrome

Confirmed via live source analysis in DM session: `damageType` defined in click handler scope only, `spellSave` never defined anywhere in the function.

## Files Changed
- `CoreFunctions.js` — 3 lines added, 1 line changed