### PR TITLE
Fix: hasClass does not accept arrays, use .is() selector

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -1262,7 +1262,7 @@ function inject_dice(){
      try {
        let mutationTarget = $(mutation.target);
        
-       if(mutationTarget.hasClass(['encounter-details', 'encounter-builder', 'release-indicator'])){
+       if(mutationTarget.is('.encounter-details, .encounter-builder, .release-indicator')){
          mutationTarget.remove();
        }
        if($(mutation.addedNodes).is('.encounter-builder, .release-indicator')){


### PR DESCRIPTION
## Bug

`CoreFunctions.js:1265` — `mutationTarget.hasClass(['encounter-details', 'encounter-builder', 'release-indicator'])` passes an array to jQuery's `hasClass()`, which only accepts a single class name string. The array coerces to `"encounter-details,encounter-builder,release-indicator"` which never matches any element.

The `.is()` selector on line 1268 (which correctly handles `encounter-builder` and `release-indicator` in `addedNodes`) shows the intended pattern.

## Fix

Change `.hasClass([...])` to `.is('.encounter-details, .encounter-builder, .release-indicator')` — matches the existing pattern on line 1268.

## Notes

The CSS in `abovevtt.css:1858-1863` already hides these elements with `scale:0 !important; visibility:hidden !important`, so the visual impact is minimal. This fix ensures the DOM cleanup works as intended as a belt-and-suspenders measure.

## Files Changed
- `CoreFunctions.js` — 1 line changed