### PR TITLE
Fix: wrong variable in imageHtml catch handlers

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -138,7 +138,7 @@ const debounceHandleInjected = mydebounce(() => {
 										nextUrl = parts.join("/");
 										el.attr("data-current-avatar-url", "hacky");
 									} catch (error) {
-										console.warn("imageHtml failed to hack the largeAvatarUrl", el, e);
+										console.warn("imageHtml failed to hack the largeAvatarUrl", el, error);
 										nextUrl = el.attr("data-avatar-url");
 										el.attr("data-current-avatar-url", "avatarUrl");
 									}

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -1732,7 +1732,7 @@ class MonsterStatBlock {
                     nextUrl = parts.join("/");
                     el.attr("data-current-avatar-url", "hacky");
                 } catch (error) {
-                    console.warn("imageHtml failed to hack the largeAvatarUrl", el, e);
+                    console.warn("imageHtml failed to hack the largeAvatarUrl", el, error);
                     nextUrl = el.attr("data-avatar-url");
                     el.attr("data-current-avatar-url", "avatarUrl");
                 }


### PR DESCRIPTION
## Bug

Both `MessageBroker.js` and `MonsterStatBlock.js` contain an identical `imageHtml` error handler that attempts to hack a large avatar URL by rewriting the path segments. When this fails, the `catch` block should log the error and fall back to the standard avatar URL.

However, both catch blocks declare `catch (error)` but reference `e` — the outer jQuery event parameter — instead of `error`:

```javascript
// Both files — identical pattern
img.on("error", function (e) {         // <-- outer event parameter is `e`
    // ...
    try {
        // hack the avatar URL
    } catch (error) {                  // <-- catch parameter is `error`
        console.warn("imageHtml failed to hack the largeAvatarUrl", el, e);  // BUG: `e` is not `error`
        nextUrl = el.attr("data-avatar-url");        // never reached
        el.attr("data-current-avatar-url", "avatarUrl");  // never reached
    }
```

`e` here resolves to the outer jQuery error event (not the catch exception), so the `console.warn` logs the wrong object. More importantly, if `e` were ever out of scope, this would throw a `ReferenceError` inside the catch block, preventing the fallback URL assignment on the next two lines from executing.

## Fix

Change `e` to `error` in both catch blocks so the actual exception is logged:

- **MessageBroker.js line 141** — `e` → `error`
- **MonsterStatBlock.js line 1735** — `e` → `error`

Both files have the identical function (likely copy-pasted), so both get the same one-character fix.

## Files Changed

| File | Line | Change |
|---|---|---|
| MessageBroker.js | 141 | `e` → `error` in console.warn |
| MonsterStatBlock.js | 1735 | `e` → `error` in console.warn |