### PR TITLE
Fix: revert unintended .key and .size changes from file picker cleanup

### DIFF
--- a/avttS3Upload.js
+++ b/avttS3Upload.js
@@ -322,8 +322,6 @@ function avttCloneListingEntry(entry) {
     const clone = { ...entry };
     if (entry.Key) {
       clone.Key = entry.Key;
-    } else if (entry.Key) {
-      clone.Key = entry.Key;
     }
     if (typeof clone.Size === "number") {
       clone.Size = Number.isFinite(clone.Size) ? clone.Size: 0;
@@ -1608,7 +1606,7 @@ async function avttResolveMoveConflicts(moves) {
       ...move,
       toKey: targetKey,
       overwrite: action === "overwrite" && exists,
-      ...(skipDescendants.Size ? { skipDescendants: Array.from(skipDescendants) } : {}),
+      ...(skipDescendants.size ? { skipDescendants: Array.from(skipDescendants) } : {}),
     });
     if (additionalMoves.length) {
       resolved.push(...additionalMoves);
@@ -1650,7 +1648,7 @@ async function avttPromptUploadConflict({ fileName }) {
     };
 
     const onKeyDown = (event) => {
-      if (event.Key === "Escape") {
+      if (event.key === "Escape") {
         cleanup({ action: "skip", applyAll: applyAllCheckbox?.checked || false });
       }
     };
@@ -1713,9 +1711,9 @@ function avttPromptTextDialog({
     };
 
     const onKeyDown = (event) => {
-      if (event.Key === "Escape") {
+      if (event.key === "Escape") {
         cleanup(null);
-      } else if (event.Key === "Enter") {
+      } else if (event.key === "Enter") {
         event.preventDefault();
         confirmButton.click();
       }
@@ -3274,7 +3272,7 @@ async function avttMoveEntries(moves, options = {}) {
             .map((value) => avttNormalizeRelativePath(value))
             .filter(Boolean),
         );
-        if (skipSourceSet.Size > 0) {
+        if (skipSourceSet.size > 0) {
           if (Array.isArray(descendantEntries) && descendantEntries.length) {
             descendantEntries = descendantEntries.filter((entry) => {
               const candidate = avttNormalizeRelativePath(entry?.Key);
@@ -8064,7 +8062,7 @@ async function processGetFileFromS3Queue() {
         batchLookup.get(fullPath).items.push(item);
       }
 
-      if (batchLookup.Size <= 1) {
+      if (batchLookup.size <= 1) {
         for (const item of batchItems) {
           await processSingleItem(item);
         }
@@ -8103,7 +8101,7 @@ async function processGetFileFromS3Queue() {
         }
       }
 
-      if (unresolvedItems.Size > 0) {
+      if (unresolvedItems.size > 0) {
         for (const item of unresolvedItems) {
           await processSingleItem(item);
         }


### PR DESCRIPTION
## Summary

Commit `5fae402b` (file picker object keys cleanup) did a great job standardizing `.Key`/`.Size` on file entry objects. A few non-object-property uses of `.key` and `.size` got caught in the global find-and-replace:

### `event.key` → `event.Key` (3 instances — lines 1648, 1711, 1713)

DOM `KeyboardEvent` uses lowercase `.key`. The cleanup capitalized these, so `event.Key` is always `undefined` — Escape and Enter key handlers in the upload conflict dialog and text input dialog no longer respond.

**Before:** `if (event.Key === "Escape")` — never matches
**After:** `if (event.key === "Escape")` — works as intended

### `Set.size` / `Map.size` → `.Size` (4 instances — lines 1606, 3272, 8062, 8101)

Native `Set.size` and `Map.size` are read-only getters (lowercase). `.Size` is `undefined` on these objects, so conditionals like `skipDescendants.Size` and `batchLookup.Size <= 1` always evaluate incorrectly.

**Before:** `if (batchLookup.Size <= 1)` — `undefined <= 1` is `false`, skips optimization
**After:** `if (batchLookup.size <= 1)` — correctly checks map size

### Dead `else if` branch removed (line 323-326)

`avttCloneListingEntry()` had `if (entry.Key) ... else if (entry.Key)` — identical conditions after cleanup. The `else if` previously checked lowercase `entry.key` as a fallback normalizer. Now unreachable — removed.

## Files Changed

- `avttS3Upload.js` — 8 lines changed (3 event.key, 4 .size, 1 dead branch removed)