### PR TITLE
Fix: condition bar height uses sizeWidth instead of sizeHeight

### DIFF
--- a/Token.js
+++ b/Token.js
@@ -1629,7 +1629,7 @@ class Token {
 		moreCond.css('left', this.sizeWidth() - symbolSize);
 		[cond, moreCond].forEach(cond_bar => {
 			cond_bar.width(symbolSize);
-			cond_bar.height(this.sizeWidth() - bar_width); // height or width???
+			cond_bar.height(this.sizeHeight() - bar_width);
 		})
 		if (this.isPlayer() && (this.options.inspiration || find_pc_by_player_id(this.options.id, false)?.inspiration)){
 			if (!this.hasCondition("Inspiration")){


### PR DESCRIPTION
## Summary

Token condition bar overlay height was calculated using `sizeWidth()` instead of `sizeHeight()` (line 1632), causing incorrect sizing on non-square tokens (e.g., large/huge creatures where width ≠ height).

Same class of bug fixed in #4178 (line 2092, `sizeWidth` → `sizeHeight` for `top` positioning) but at a different location.

**Before:** `cond_bar.height(this.sizeWidth() - bar_width); // height or width???`
**After:** `cond_bar.height(this.sizeHeight() - bar_width);`

The original developer's comment `// height or width???` flagged the uncertainty.

## Files Changed

- `Token.js` — 1 line changed