### PR TITLE
Fix self-comparison in color_from_pc_object()

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -1792,7 +1792,7 @@ function color_from_pc_object(pc) {
   if (!isDefaultTheme && pc.decorations?.characterTheme?.themeColor) { // only the DM can use the default theme color
     return pc.decorations.characterTheme.themeColor;
   } else {
-    const pcIndex = window.pcs.findIndex(p => p.id === p.id);
+    const pcIndex = window.pcs.findIndex(p => p.id === pc.id);
     return get_token_color_by_index(pcIndex);
   }
 }


### PR DESCRIPTION
## Summary
- `CoreFunctions.js:1795` — `window.pcs.findIndex(p => p.id === p.id)` compares callback parameter to itself (always `true`), so `findIndex` always returns `0`
- Every player without a custom DDB character theme gets the first player's index color instead of their own
- Fix: `p.id === pc.id` — compare against the outer function parameter

## Affected call sites
- `color_for_player_id()` — token border colors
- `TokensPanel.js` — player panel ability scores, token placement, border color dropdown
- `PlayerPanel.js` — player panel rendering
- `SidebarPanel.js` — sidebar player display

## Test plan
- [ ] Load a campaign with 3+ players where at least 2 have no custom DDB character theme
- [ ] Verify each player's token border color is distinct (not all matching the first player's color)
- [ ] Verify player panel and sidebar show correct per-player colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)