### PR TITLE
Fix: incorrect property access in ScenesHandler build_adventures()

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -481,7 +481,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				let keyword = url.replaceAll(/https:\/\/www\.dndbeyond\.com|^\/?sources\/|/gi, '');
 
 				if (keyword in self.sources){ // OBJECT ALREADY EXISTS... evito di riscrivere per non perdere i dati
-					scraped_sources[keyword]=self.sources.keyword;
+					scraped_sources[keyword]=self.sources[keyword];
 					return;
 				}
 				scraped_sources[keyword] = {
@@ -502,7 +502,7 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 							return ((scraped_sources[a].title == scraped_sources[b].title) ? 0 : ((scraped_sources[a].title > scraped_sources[b].title) ? 1 : -1));
 						}
 						else {
-							return (a.ddbtype == "Adventures") ? 1 : -1;
+							return (scraped_sources[a].ddbtype == "Adventures") ? 1 : -1;
 						}
 					}
 				)


### PR DESCRIPTION
## Summary

Two property access bugs in `ScenesHandler.js` `build_adventures()` — the source book scraping/sorting for scene imports.

### Bug 1 — Line 484: dot notation instead of bracket notation

```javascript
// Before — looks for literal property named "keyword" (always undefined)
scraped_sources[keyword] = self.sources.keyword;

// After — uses the variable value as the key
scraped_sources[keyword] = self.sources[keyword];
```

When a previously-scraped source exists in `self.sources`, the re-scrape assigns `undefined` instead of the cached source object (which contains chapters, etc.).

### Bug 2 — Line 505: property access on string key

```javascript
// Before — a is a string key from Object.keys(), a.ddbtype is always undefined
return (a.ddbtype == "Adventures") ? 1 : -1;

// After — access through the scraped_sources object
return (scraped_sources[a].ddbtype == "Adventures") ? 1 : -1;
```

The sort comparator accesses `ddbtype` on a string key instead of the source object. Since `a.ddbtype` is always `undefined`, Adventures never sort after Sourcebooks.

## Files changed

- `ScenesHandler.js` — 2 lines changed in `build_adventures()`