### PR TITLE
Fix: add missing break in Fog.js switch cases

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -3807,6 +3807,7 @@ function drawing_mouseup(e) {
 				data[4] = null
 				data[5] = null
 				data[6] = window.CURRENT_SCENE_DATA.scale_factor
+				break;
 			case "paint-bucket":
 				data[0] = "paint-bucket"
 				data[7] = 0
@@ -3829,6 +3830,7 @@ function drawing_mouseup(e) {
 			data[1] = "wall"
 			data[10] = window.wallBottom
 			data[11] = window.wallTop
+			break;
 		case 'elev':
 			data[1] = "elev"
 			data[2] = window.mapElev


### PR DESCRIPTION
## The Bug

Two `switch` cases in `drawing_mouseup()` are missing `break` statements, causing fall-through that silently overwrites the primary data identifiers:

**Bug 1 — `grid-brush` falls through to `paint-bucket` (line 3809):**
```javascript
case "grid-brush":
    data[0] = "grid-brush"
    data[3] = Array.from(new Set(window.BRUSHPOINTS.map(JSON.stringify)), JSON.parse)
    data[4] = null
    data[5] = null
    data[6] = window.CURRENT_SCENE_DATA.scale_factor
    // ← missing break — falls through
case "paint-bucket":
    data[0] = "paint-bucket"  // overwrites data[0]
    data[7] = 0
```

**Bug 2 — `wall-window` falls through to `elev` (line 3832):**
```javascript
case 'wall-window':
    data[1] = "wall"
    data[10] = window.wallBottom
    data[11] = window.wallTop
    // ← missing break — falls through
case 'elev':
    data[1] = "elev"  // overwrites data[1]
    data[2] = window.mapElev
```

**Impact:** Grid-brush fog drawing always behaves as paint-bucket. Wall-windows always become elevation markers. Both features are silently broken.

## The Fix

Add `break;` after each case. Every other case in both switches already has `break`.

## Why This Works

- `grid-brush` data is complete without `data[7]` — other brush types (`brush`, `brush-arrow`) don't set it either
- `wall-window` data is complete without `data[2]` (mapElev) — it matches the `wall` and `wall-door` patterns
- No downstream code depends on the broken behavior

## Files Changed

- `Fog.js` — 2 lines added (one `break;` per case)