### PR TITLE
Fix: toggleClass() passed array instead of string for wall/elevation toggles

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -256,14 +256,14 @@ Mousetrap.bind('w', function () {
 });
 Mousetrap.bind('shift+w', function () {
     if(window.DM){
-        $('#show_walls').toggleClass(['button-enabled', 'ddbc-tab-options__header-heading--is-active']);
+        $('#show_walls').toggleClass('button-enabled ddbc-tab-options__header-heading--is-active');
         redraw_light_walls();
     }
        
 });
 Mousetrap.bind('shift+e', function () {
     if(window.DM){
-        $('#show_elev').toggleClass(['button-enabled', 'ddbc-tab-options__header-heading--is-active']);
+        $('#show_elev').toggleClass('button-enabled ddbc-tab-options__header-heading--is-active');
         if($('#show_elev').hasClass('button-enabled')){
             redraw_elev(true);
         }


### PR DESCRIPTION
## Summary
- Shift+W (toggle walls) and Shift+E (toggle elevation) pass an array to jQuery's `toggleClass()`, which expects a space-separated string
- The array coerces to a comma-joined string, creating a garbled class name that doesn't match anything
- Fix: pass a space-separated string instead of an array

## Test plan
- [ ] Open AboveVTT as DM with a scene that has walls
- [ ] Press Shift+W — walls should toggle on/off visually
- [ ] Press Shift+E — elevation overlay should toggle on/off
- [ ] Verify the button styling toggles correctly (highlighted when active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)