### PR TITLE
Fix: hasClass() in handle_undo() uses space-separated string that never matches

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -596,27 +596,26 @@ Mousetrap.bind('[', function(e) {
 });
 
 function handle_undo(){
-    const buttonSelectedClasses = "button-enabled ddbc-tab-options__header-heading--is-active"
 
-    if ($("#select-button").hasClass(buttonSelectedClasses)){
+    if ($("#select-button").hasClass("button-enabled")){
         undo_delete_tokens();
     }
-    else if(($("#fog_button").hasClass(buttonSelectedClasses))){
+    else if(($("#fog_button").hasClass("button-enabled"))){
         $("#fog_undo").click()
     }
-    else if($("#draw_button").hasClass(buttonSelectedClasses)){
+    else if($("#draw_button").hasClass("button-enabled")){
         $("#draw_undo").click()
     }
-    else if($("#vision_button").hasClass(buttonSelectedClasses)){
+    else if($("#vision_button").hasClass("button-enabled")){
         $("#light_undo").click()
     }
-    else if(($("#text_button").hasClass(buttonSelectedClasses))){
+    else if(($("#text_button").hasClass("button-enabled"))){
         $("#text_undo").click()
     }
-    else if(($("#wall_button").hasClass(buttonSelectedClasses))){
+    else if(($("#wall_button").hasClass("button-enabled"))){
         $("#wall_undo").click()
     }
-    else if(($("#elev_button").hasClass(buttonSelectedClasses))){
+    else if(($("#elev_button").hasClass("button-enabled"))){
         $("#elev_undo").click()
     }
 


### PR DESCRIPTION
## Summary
- `handle_undo()` passes a space-separated two-class string to jQuery's `hasClass()`, which only accepts a single class name
- The string `"button-enabled ddbc-tab-options__header-heading--is-active"` is treated as one class name, which never matches any element
- **Result: Ctrl+Z undo is completely non-functional** for all tools (select, fog, draw, vision, text, wall, elevation)
- Fix: use `hasClass("button-enabled")` which is sufficient to identify the active tool button

## Test plan
- [ ] Open AboveVTT as DM
- [ ] Select the Draw tool, draw something, press Ctrl+Z — should undo
- [ ] Select the Fog tool, draw fog, press Ctrl+Z — should undo
- [ ] Select tokens, delete them, press Ctrl+Z — should undo
- [ ] Repeat for wall, text, elevation, vision tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)