### PR TITLE
Fix: merge combat tracker guard into duplicate 'n' key binding

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -39,12 +39,6 @@ Mousetrap.bind('f', function () {       //fog menu
 });
 
 
-Mousetrap.bind('n', function () {   //while combat menu is open, press n to cycle next in initiative order
-    if(window.DM && $('#combat_tracker_inside').attr('style') == 'display: block;') {
-        $('#combat_next_button').click()
-    }
-});
-
 Mousetrap.bind('r', function () {       //ruler
     $('#ruler_button').click()
 });
@@ -102,8 +96,10 @@ Mousetrap.bind(["1","2","3","4","5","6","7","8","9","shift+1","shift+2","shift+3
 
 
 Mousetrap.bind("n", function (e) {
-    if(window.DM)
-        $('#combat_next_button').click();
+    if(window.DM){
+        if($('#combat_tracker_inside').attr('style') == 'display: block;')
+            $('#combat_next_button').click();
+    }
     else
         $('#combat_tracker_inside #endplayerturn').click();
 


### PR DESCRIPTION
## Summary
- The `n` key was bound twice by Mousetrap — the second binding silently overwrites the first
- The first binding (line 42) had a guard checking that the combat tracker is visible before advancing initiative
- The second binding (line 104) was unconditional, so pressing `n` anytime as DM would advance combat even when the tracker isn't open
- Fix: merge the visibility guard into the second binding and remove the dead first binding

## Test plan
- [ ] As DM with combat tracker closed, press `n` — should do nothing
- [ ] As DM with combat tracker open, press `n` — should advance initiative
- [ ] As player during your turn, press `n` — should end your turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)