### PR TITLE
Fix: visibleMenuId always truthy when no menu is open

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -359,8 +359,9 @@ function moveKeyWatch() {
 
 Mousetrap.bind('up', function (e) {
     arrowKeysHeld[0] = 1;
-    const visibleMenuId = `#${$('[id*="_menu"].visible').attr("id")}`
-    if (visibleMenuId){
+    const $visibleMenu = $('[id*="_menu"].visible');
+    if ($visibleMenu.length > 0){
+        const visibleMenuId = `#${$visibleMenu.attr("id")}`;
         // prevent scrolling the window
         e.preventDefault();
         $(`${visibleMenuId} .ddbc-tab-options__header-heading--is-active`).first().parent().prevAll().not("[data-skip='true']").first().children().first().click()
@@ -369,8 +370,9 @@ Mousetrap.bind('up', function (e) {
 }, 'keydown');
 Mousetrap.bind('down', function (e) {
     arrowKeysHeld[1] = 1;
-    const visibleMenuId = `#${$('[id*="_menu"].visible').attr("id")}`
-    if (visibleMenuId){
+    const $visibleMenu = $('[id*="_menu"].visible');
+    if ($visibleMenu.length > 0){
+        const visibleMenuId = `#${$visibleMenu.attr("id")}`;
         // prevent scrolling the window
         e.preventDefault();
         $(`${visibleMenuId} .ddbc-tab-options__header-heading--is-active`).first().parent().nextAll().not("[data-skip='true']").first().children().first().click()


### PR DESCRIPTION
## Summary
- Arrow key handlers construct `visibleMenuId` by interpolating `.attr("id")` into a template string
- When no menu element matches, `.attr("id")` returns `undefined`, producing `"#undefined"` — always truthy
- This causes `e.preventDefault()` to fire for every arrow keypress, even when no menu is open
- Fix: check jQuery result length before constructing the selector string

## Test plan
- [ ] Open AboveVTT with no menus open
- [ ] Press arrow keys — should scroll/pan the map normally (no blocked behavior)
- [ ] Open a tool menu (e.g., fog submenu)
- [ ] Press up/down arrows — should navigate menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)