### PR TITLE
Fix: self-closing style tag drops mixer paused CSS rule

### DIFF
--- a/audio/ui.js
+++ b/audio/ui.js
@@ -425,7 +425,7 @@ function init_mixer() {
                 mixer_pause_svg.css('display', 'none');
                 playPauseMixer.toggleClass('playing', false);
                 playPauseMixer.toggleClass('pressed', false);
-                $('head').append(`<style id="mixer-paused" />#sounds-panel button.pressed.playing{background: #ffd03b45 !important;}</style>`);
+                $('head').append(`<style id="mixer-paused">#sounds-panel button.pressed.playing{background: #ffd03b45 !important;}</style>`);
             }
             else {
                 mixer_pause_svg.css('display', 'block');
@@ -598,7 +598,7 @@ function init_mixer() {
         pause_svg.css('display', 'none');
         playPause.toggleClass('playing', false);
         playPause.toggleClass('pressed', false);
-        $('head').append(`<style id="mixer-paused" />#sounds-panel button.pressed.playing{background: #ffd03b45 !important;}</style>`);
+        $('head').append(`<style id="mixer-paused">#sounds-panel button.pressed.playing{background: #ffd03b45 !important;}</style>`);
     }
     else {
         pause_svg.css('display', 'block');
@@ -621,7 +621,7 @@ function init_mixer() {
             pause_svg.css('display', 'none');
             playPause.toggleClass('playing', false);
             playPause.toggleClass('pressed', false);
-             $('head').append(`<style id="mixer-paused" />#sounds-panel button.pressed.playing{background: #ffd03b45 !important;}</style>`);
+             $('head').append(`<style id="mixer-paused">#sounds-panel button.pressed.playing{background: #ffd03b45 !important;}</style>`);
            
         }
         else {


### PR DESCRIPTION
## Summary
- Three `<style>` elements use self-closing `/>` syntax (`<style id="mixer-paused" />`)
- HTML's `<style>` is not a void element — `/>` closes the tag immediately
- The CSS rule text (`#sounds-panel button.pressed.playing{...}`) becomes an orphaned text node, never applied as styling
- Fix: change `/>` to `>` so the CSS rule is inside the style element

## Test plan
- [ ] Open the audio mixer as DM
- [ ] Play a track, then pause the mixer
- [ ] Verify the paused state shows the gold highlight background on the play/pause button
- [ ] Resume playback — gold highlight should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)