### PR TITLE
Fix: firefly and rain particles missing init properties used by draw functions

### DIFF
--- a/WeatherOverlay.js
+++ b/WeatherOverlay.js
@@ -135,8 +135,9 @@ class WeatherOverlay {
                     id,
                     startX,
                     startY,
-                    endX,
-                    endY,
+                    groundX: endX,
+                    groundY: endY,
+                    wind,
                     z: z,
                     fadeIn: Math.ceil(fadeInFrames * z),
                     fadeInFrames,
@@ -298,7 +299,12 @@ class WeatherOverlay {
                     drift: -0.5 + Math.random(),
                     phase: Math.random() * Math.PI * 2,
                     fadeIn: 0,
-                    fadeInFrames: fadeInFrames
+                    fadeInFrames: fadeInFrames,
+                    blinkPhase: Math.random() * Math.PI * 2,
+                    blinkSpeed: 1.2 + Math.random() * 0.8,
+                    wanderAngle: Math.random() * Math.PI * 2,
+                    wanderSpeed: 0.2 + Math.random() * 0.2,
+                    color: Math.random() > 0.5 ? 'rgba(200,255,120,1)' : 'rgba(255,255,180,1)'
                 });
             }
         }


### PR DESCRIPTION
## Summary
- **Firefly particles** initialized without `blinkSpeed`, `blinkPhase`, `wanderAngle`, `wanderSpeed`, `color` — all read by `_drawFireflies()`. Initial particles are invisible (NaN positions/alpha) until they drift offscreen and get replenished with correct properties.
- **Rain particles** initialized with `endX`/`endY` but `_drawRain()` reads `groundX`/`groundY`/`wind` — NaN positions on first frame cycle until particles reset.
- Fix: add missing properties to firefly init (matching the replenishment block), rename rain `endX`/`endY` to `groundX`/`groundY` and add `wind` property.

## Test plan
- [ ] Set weather to "Fireflies" — particles should be visible immediately, not just after a few seconds
- [ ] Set weather to "Rain" — rain streaks should render from the first frame without visual glitches
- [ ] Set weather to "Lightning" — rain portion should also render correctly from the start

🤖 Generated with [Claude Code](https://claude.com/claude-code)