### PR TITLE
Fix: remove unmatched ctx.restore() in _drawLightning

### DIFF
--- a/WeatherOverlay.js
+++ b/WeatherOverlay.js
@@ -788,7 +788,6 @@ class WeatherOverlay {
             this.offscreenCtx.restore();
             this._lightningAlpha -= 0.012;
             this._lightningFlashFrames--;
-            this.offscreenCtx.restore();
         } else {
             this._lightningAlpha = 0;
         }


### PR DESCRIPTION
## Summary
- `_drawLightning()` has two matched `save()`/`restore()` pairs (glow ellipse at lines 759/775, bolt stroke at 777/788)
- An extra `restore()` at line 791 has no corresponding `save()`, popping an extra state from the canvas stack
- Fix: remove the unmatched `restore()`

## Test plan
- [ ] Set weather to "Lightning" on a scene
- [ ] Verify lightning flashes render correctly (bolt + glow)
- [ ] Verify rain still renders correctly after lightning flashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)