### PR TITLE
Fix: master volume calculation wrong for YouTube and video map audio

### DIFF
--- a/audio/ui.js
+++ b/audio/ui.js
@@ -272,10 +272,10 @@ function init_mixer() {
             const masterVolume = $("#master-volume input").val();
             if (window.YTPLAYER) {
                 window.YTPLAYER.volume = newVolume;
-                window.YTPLAYER.setVolume(window.YTPLAYER.volume*masterVolume);
+                window.YTPLAYER.setVolume(window.YTPLAYER.volume * masterVolume / 100);
             }   
             if($('video#scene_map').length > 0)
-                $('video#scene_map')[0].volume = newVolume/100 * masterVolume;  
+                $('video#scene_map')[0].volume = newVolume/100 * masterVolume/100;
 
             if(window.YTPLAYER || $('video#scene_map').length>0){
                 let data={


### PR DESCRIPTION
## Summary
- `masterVolume` comes from `$("#master-volume input").val()` which returns "0"-"100"
- Line 275 (YouTube): `volume * masterVolume` produces 0-10000, but `setVolume()` expects 0-100. Fix: divide by 100.
- Line 278 (HTML5 video): `newVolume/100 * masterVolume` produces 0-100, but `<video>.volume` expects 0.0-1.0. Fix: also divide `masterVolume` by 100.
- Result: master volume slider had no granular effect — video was always at max unless master was 0

## Test plan
- [ ] Load a scene with an animated video map (YouTube or direct video)
- [ ] Adjust the master volume slider — volume should scale smoothly from 0 to max
- [ ] Adjust the YouTube/scene volume slider — should also scale correctly
- [ ] Set master to 50%, scene to 50% — audio should be at 25% total volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)