### PR TITLE
Fix: duplicate id='addTrack' on two different buttons in audio UI

### DIFF
--- a/audio/ui.js
+++ b/audio/ui.js
@@ -767,7 +767,7 @@ function init_trackLibrary() {
     const cancelButton = $('<button class="add-track-cancel-button">X</button>');  
 
     // Mixer/ Track List QOL updates
-    const addTracksToMixer = $(`<button id='addTrack'>Add Visible to Mixer</button>`);
+    const addTracksToMixer = $(`<button id='addTracksToMixer'>Add Visible to Mixer</button>`);
     const addShuffledToMixer = $('<button id="addShuffledToMixer">Add Shuffled to Mixer</button>');
 
     // Click handlers


### PR DESCRIPTION
## Summary
- Two buttons in the track library UI share `id='addTrack'`: "Add Track" (line 762) and "Add Visible to Mixer" (line 770)
- Duplicate HTML IDs violate the spec and cause `$('#addTrack')` to only match the first element
- Fix: rename the second button's ID to `addTracksToMixer` (matching its variable name)

## Test plan
- [ ] Open the audio track library as DM
- [ ] Verify "Add Track" button works (opens import fields)
- [ ] Verify "Add Visible to Mixer" button works (adds filtered tracks to mixer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)