### PR TITLE
Fix: guard TRACK_LIBRARY.find() result in Edit and Tags context menu

### DIFF
--- a/audio/ui.js
+++ b/audio/ui.js
@@ -935,7 +935,9 @@ function init_trackLibrary() {
                     const trackSrcInput = $(`<input class='trackSrc trackInput' placeholder='https://.../example.mp3'/>`)
                     const okButton = $('<button class="add-track-ok-button">OK</button>');  
                     const cancelButton = $('<button class="add-track-cancel-button">X</button>');  
-                    const trackTags = window.TRACK_LIBRARY.find(trackName, trackSrc)[1].tags;
+                    const findResult = window.TRACK_LIBRARY.find(trackName, trackSrc);
+                    if (!findResult) return;
+                    const trackTags = findResult[1].tags;
                     trackNameInput.val(trackName);
                     trackSrcInput.val(trackSrc);
                     
@@ -962,7 +964,7 @@ function init_trackLibrary() {
                     const okButton = $('<button class="add-track-ok-button">OK</button>');  
                     const cancelButton = $('<button class="add-track-cancel-button">X</button>');  
                     const currentTrack = window.TRACK_LIBRARY.find(trackName, trackSrc);
-
+                    if (!currentTrack) return;
                     trackTagsInput.val(currentTrack[1].tags.join(', '));
 
                     


### PR DESCRIPTION
## Summary
- The Edit and Tags context menu callbacks call `TRACK_LIBRARY.find()` which returns `undefined` when no track matches
- Accessing `[1].tags` on `undefined` throws TypeError, crashing the context menu
- This can happen if the track was deleted between opening the context menu and clicking an option
- Fix: add null check before accessing the result

## Test plan
- [ ] Open the track library, right-click a track
- [ ] Click "Edit" — should open edit fields without error
- [ ] Click "Tags" — should open tag editor without error
- [ ] Verify both work correctly for existing tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)