### PR TITLE
Fix: guard findIndex result before splice in delete_scene

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -948,7 +948,9 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 	delete_scene(sceneId, reloadUI = true) { // not the index, but the actual id
 		window.MB.sendMessage("custom/myVTT/delete_scene",{ id: sceneId });
 		let sceneIndex = window.ScenesHandler.scenes.findIndex(s => s.id === sceneId);
-		window.ScenesHandler.scenes.splice(sceneIndex, 1);
+		if (sceneIndex !== -1) {
+			window.ScenesHandler.scenes.splice(sceneIndex, 1);
+		}
 		if (window.JOURNAL.notes[sceneId] != undefined){
 			delete window.JOURNAL.notes[sceneId];
 			window.JOURNAL.persist();


### PR DESCRIPTION
## Summary
- `delete_scene()` uses `findIndex()` to locate a scene, then passes the result to `splice()`
- If the scene isn't found, `findIndex` returns `-1`, and `splice(-1, 1)` removes the **last** element — silently deleting the wrong scene
- Fix: check for `-1` before splicing

## Test plan
- [ ] Delete a scene from the scenes panel — should remove the correct scene
- [ ] Verify remaining scenes are unaffected after deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)