### PR TITLE
Fix: guard splitPlayerScenes access in persist_current_scene

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -935,11 +935,13 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 
 		sceneData.isnewscene=false;
 		window.MB.sendMessage("custom/myVTT/update_scene",sceneData,dontswitch);
-		const currentPlayerScenes = Object.values(window.splitPlayerScenes);
-		if(window.DM && dontswitch == false && currentPlayerScenes.includes(sceneData.id)){
-			setTimeout(function(){
-				window.MB.sendMessage("custom/myVTT/switch_scene", { sceneId: window.splitPlayerScenes});
-			}, 100)
+		if(window.DM && dontswitch == false && window.splitPlayerScenes?.players != undefined){
+			const currentPlayerScenes = Object.values(window.splitPlayerScenes);
+			if(currentPlayerScenes.includes(sceneData.id)){
+				setTimeout(function(){
+					window.MB.sendMessage("custom/myVTT/switch_scene", { sceneId: window.splitPlayerScenes});
+				}, 100)
+			}
 		}
 		did_update_scenes();
 		


### PR DESCRIPTION
## Summary
- `persist_current_scene()` calls `Object.values(window.splitPlayerScenes)` without checking if it exists
- When the split-scene feature is not in use, `splitPlayerScenes` is `undefined` → TypeError crash
- The neighboring methods `persist_scene()` (line 917) and `delete_scene()` (line 959) both guard with `window.splitPlayerScenes?.players != undefined`
- Fix: add the same guard before accessing `splitPlayerScenes`

## Test plan
- [ ] Save a scene without split-scene feature active — should not crash
- [ ] If split-scene is available: save a scene with split players — should still sync correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)