### PR TITLE
Fix: text shadow regex crash on rgba() color values

### DIFF
--- a/Text.js
+++ b/Text.js
@@ -638,9 +638,12 @@ function draw_text(
 
     let shadowStyle ='';
     if (font.shadow && font.shadow !== "none"){
-        const shadowRegex = /(rgb\(.*\))\s(\d+px)\s(\d+px)\s(\d+px)/
-        const [_, shadowColor, shadowOffsetX, shadowOffsetY, shadowBlur ] = font.shadow.match(shadowRegex)
-        shadowStyle = `drop-shadow(${shadowOffsetX} ${shadowOffsetY} ${shadowBlur} ${shadowColor})`
+        const shadowRegex = /(rgba?\(.*?\))\s(\d+px)\s(\d+px)\s(\d+px)/
+        const shadowMatch = font.shadow.match(shadowRegex)
+        if (shadowMatch) {
+            const [_, shadowColor, shadowOffsetX, shadowOffsetY, shadowBlur ] = shadowMatch
+            shadowStyle = `drop-shadow(${shadowOffsetX} ${shadowOffsetY} ${shadowBlur} ${shadowColor})`
+        }
     }
     
     let x = (font.align == 'right') ? '100%' : ((font.align=='center') ? '50%' : '0');


### PR DESCRIPTION
## Summary
- `draw_text()` parses shadow CSS with a regex that only matches `rgb(...)`, not `rgba(...)`
- When the shadow color is in `rgba()` format, `.match()` returns `null` and destructuring crashes with TypeError
- Fix: update regex to `rgba?` and add null guard — fallback to no shadow instead of crashing

## Test plan
- [ ] Add text with shadow enabled to a scene
- [ ] Verify shadow renders correctly with default color
- [ ] Change shadow color to one that produces rgba() format
- [ ] Verify text still renders (with or without shadow) — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)