### PR TITLE
Fix: add callback and return after image URL scene push in build_scenes

### DIFF
--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -626,7 +626,9 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 				dm_map_usable: "0",
 				thumb: thumb,
 				tokens: {},
-			});		
+			});
+			callback();
+			return;
 		}
 
 		let f = $("<iframe src='" + chapter_url + "'></iframe>");


### PR DESCRIPTION
## Summary
- `build_scenes()` handles direct image URLs (jpg/png/etc) by pushing a scene entry
- After the push, execution falls through to create an iframe for the same URL — wasteful and could cause duplicate entries
- Fix: call `callback()` and `return` after the image push, matching the pattern used at lines 604-606 for the "already scanned" early exit

## Test plan
- [ ] Import a D&D Beyond source book that contains direct image maps
- [ ] Verify scenes are created without duplicates
- [ ] Verify the import sequence completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)