### PR TITLE
Fix: add return in unreachable else branch to prevent diceRoll undefined access

### DIFF
--- a/DiceContextMenu/DiceContextMenu.js
+++ b/DiceContextMenu/DiceContextMenu.js
@@ -136,6 +136,7 @@ function damage_dice_context_menu(diceExpression, modifierString = "", action = 
             }
              else { // not possible
                 console.warn("DiceContextMenu unexpectedly gave an  invalid row index for section 1! rollAsIndex: ", rollAsIndex, ", dcm: ", dcm);
+                return;
             }
 
 


### PR DESCRIPTION
## Summary
- `damage_dice_context_menu()` has an `else` branch (line 137) for an "impossible" row index
- The branch logs a warning but doesn't `return`, so execution falls through to `diceRoll.sendToOverride` where `diceRoll` is `undefined` → TypeError
- Fix: add `return` after the warning to prevent the fall-through crash

## Test plan
- [ ] Right-click a damage roll button on a monster stat block
- [ ] Select each option (Crit, Perfect Crit, Double Damage, Flat) — all should roll correctly
- [ ] Verify no console errors during normal dice rolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)