### PR TITLE
Fix: guard filter result in text dblclick edit handler

### DIFF
--- a/Text.js
+++ b/Text.js
@@ -754,6 +754,7 @@ function draw_text(
         });
         textSVG.on('dblclick', function(){
             let text_data = window.DRAWINGS.filter(d => d[9] == this.id)[0];
+            if (!text_data) return;
             if(window.TEXTDATA == undefined){
                 window.TEXTDATA = {};
             }


### PR DESCRIPTION
## Summary
- Double-clicking map text to edit it filters `window.DRAWINGS` for a matching entry
- If the drawing was deleted between render and double-click, `.filter()[0]` returns `undefined`
- Subsequent property access on `undefined` throws TypeError, crashing the edit flow
- Fix: add early return if no matching drawing is found

## Test plan
- [ ] Double-click existing map text — should open the edit box with current text/styles
- [ ] Verify editing and re-submitting text works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)