### PR TITLE
Fix: remove dead 'n' key binding overridden by later binding

### DIFF
--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -39,12 +39,6 @@ Mousetrap.bind('f', function () {       //fog menu
 });
 
 
-Mousetrap.bind('n', function () {   //while combat menu is open, press n to cycle next in initiative order
-    if(window.DM && $('#combat_tracker_inside').attr('style') == 'display: block;') {
-        $('#combat_next_button').click()
-    }
-});
-
 Mousetrap.bind('r', function () {       //ruler
     $('#ruler_button').click()
 });


### PR DESCRIPTION
The first `Mousetrap.bind('n')` at line 42 (with combat tracker visibility guard) is immediately overridden by the second binding at line 104. Only the last binding fires — the first is dead code.

This just removes the dead first binding. The second binding is left as-is per feedback on #4197 — advancing the tracker when it's not visible is intended for carousel use.

Reworked from closed #4197.