### PR TITLE
Fix: missing closing parentheses in CSS blur() and rgba() template strings

### DIFF
--- a/WeatherOverlay.js
+++ b/WeatherOverlay.js
@@ -51,7 +51,7 @@ class WeatherOverlay {
             
             if (this.type === 'fog') {
                 $(this.canvas).css({
-                    filter: `blur(${ window.CURRENT_SCENE_DATA.hpps }px`
+                    filter: `blur(${ window.CURRENT_SCENE_DATA.hpps }px)`
                 })
             }
             else if (this.type === 'faerieLight' || this.type === 'fireflies') {
@@ -67,7 +67,7 @@ class WeatherOverlay {
             
             if (weatherData?.lit) {
                 $(this.lightCanvas).css({
-                    filter: `blur(${window.CURRENT_SCENE_DATA.hpps / window.CURRENT_SCENE_DATA.scale_factor}px`
+                    filter: `blur(${window.CURRENT_SCENE_DATA.hpps / window.CURRENT_SCENE_DATA.scale_factor}px)`
                 })
             }
             else{
@@ -947,7 +947,7 @@ class WeatherOverlay {
             const cy = p.y + Math.cos(t * 0.5 + p.phase) * 12;
             const baseR = p.r;
             const baseAspect = p.aspect;
-            const fogColor = `rgba(120, 120, 120, ${(p.alpha * 1.2 + 0.22).toFixed(3)}`;
+            const fogColor = `rgba(120, 120, 120, ${(p.alpha * 1.2 + 0.22).toFixed(3)})`;
             let fade = 1;
             if (p.fadeIn !== undefined && p.fadeIn < (p.fadeInFrames || 10)) {
                 fade = p.fadeIn / (p.fadeInFrames || 10);


### PR DESCRIPTION
Three template literals in WeatherOverlay.js are missing closing `)` in CSS function values:

- **Line 54**: `blur(${hpps}px` → `blur(${hpps}px)`
- **Line 70**: `blur(${hpps/scale}px` → `blur(${hpps/scale}px)`
- **Line 950**: `rgba(120, 120, 120, ${alpha}` → `rgba(120, 120, 120, ${alpha})`

All three produce invalid CSS that silently fails — fog blur filter doesn't apply, fog color is ignored.

Reworked from closed #4198 (removed unrelated KeypressHandler.js changes that leaked from another branch).