### PR TITLE
Fix: remove debug console.log in build_journal()

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -573,7 +573,6 @@ class JournalManager{
 		journalPanel.body.append(chapter_list);
 		let chaptersWithLaterParents = [];
 
-		console.log('window',window);
 		let relevantNotes = {};
 		let relevantChapters = [];
 


### PR DESCRIPTION
## Bug
`console.log('window', window)` at Journal.js line 576 fires on every `build_journal()` call, logging the entire Window object to the console.

## Chrome Testing
- Called `window.JOURNAL.build_journal()` on a live DM session (v1.53-beta5)
- Console captured `[LOG] window Window` on every call
- Fires on every journal sidebar rebuild: opening journal, searching notes, adding/deleting notes

## Fix
Remove the debug line. No behavioral side effects.

## Files Changed
- `Journal.js` — delete line 576