### PR TITLE
Fix: add missing # to select-button selector in text controller

### DIFF
--- a/Text.js
+++ b/Text.js
@@ -86,7 +86,7 @@ function create_text_controller(applyFromWindow = false) {
     const textControllerTitleBarExit = $('<div id="text_controller_title_bar_exit"><svg class="" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><g transform="rotate(-45 50 50)"><rect></rect></g><g transform="rotate(45 50 50)"><rect></rect></g></svg></div>')
     textControllerTitleBarExit.click(function () {
         $(this).parent().parent().hide()
-        $("select-button").click();
+        $("#select-button").click();
     });
     textControllerTitleBar.append(textControllerTitleBarExit);
     textControllerInside.append(textControllerTitleBar);


### PR DESCRIPTION
## Bug
`$("select-button")` at Text.js line 89 looks for a `<select-button>` HTML element (doesn't exist). Should be `$("#select-button")`. When the user closes the text controller via the X button, the panel hides (line 88 works) but the toolbar doesn't switch back to the select tool — user stays in text mode.

## Chrome Testing
- `$("select-button").length` → 0
- `$("#select-button").length` → 1
- Every other file uses `$('#select-button')` correctly: KeypressHandler.js (6 uses), Fog.js, AOETemplates.js (2 uses), Token.js — Text.js is the only one missing `#`

## Fix
```diff
- $("select-button").click();
+ $("#select-button").click();
```

## Files Changed
- `Text.js` — line 89