### PR TITLE
Fix: correct AoE menu Escape key selector

### DIFF
--- a/AOETemplates.js
+++ b/AOETemplates.js
@@ -84,7 +84,7 @@ function setup_aoe_button(buttons) {
     aoeMenu.css("left", aoeButton.position().left);
 
 
-    $("#aoe_feet").keydown(function(e) {
+    $("#aoe_feet_in_menu").keydown(function(e) {
         if (e.key === "Escape") {
             $('#select-button').click();
         }


### PR DESCRIPTION
## Bug
`$("#aoe_feet")` at AOETemplates.js line 87 binds an Escape key handler to a non-existent element. The actual input has id `aoe_feet_in_menu`. Pressing Escape while focused on the AoE size input does nothing — the menu stays open.

## Chrome Testing
- `document.querySelector('#aoe_feet')` → `null`
- `document.querySelector('#aoe_feet_in_menu')` → `<input>` element
- Focused AoE feet input, pressed Escape → menu stayed open (`display: block`)
- Confirmed all AoE element IDs: `aoe_feet_in_menu`, `aoe_line_feet_in_menu`, `aoe_menu`, etc.

## Fix
```diff
- $("#aoe_feet").keydown(function(e) {
+ $("#aoe_feet_in_menu").keydown(function(e) {
```

## Files Changed
- `AOETemplates.js` — line 87