### PR TITLE
Fix: protect text settings JSON.parse from corrupt localStorage

### DIFF
--- a/Text.js
+++ b/Text.js
@@ -1,6 +1,18 @@
 function apply_settings_from_storage(applyFromWindow = false){
     const buttonSelectedClasses = "button-enabled ddbc-tab-options__header-heading--is-active"
-    const settings = (applyFromWindow) ? window.TEXTDATA : JSON.parse(localStorage.getItem('textSettings'));
+    let settings;
+    if (applyFromWindow) {
+        settings = window.TEXTDATA;
+    } else {
+        try {
+            settings = JSON.parse(localStorage.getItem('textSettings'));
+        } catch(e) {
+            console.warn('textSettings corrupted in localStorage, resetting to defaults');
+            localStorage.removeItem('textSettings');
+            store_text_settings();
+            return;
+        }
+    }
     window.TEXTDATA = settings
     $(`#text_controller_inside button[id^='text_']`).removeClass(buttonSelectedClasses);
     $(`#text_font option`).removeAttr('selected');


### PR DESCRIPTION
## Bug
`JSON.parse(localStorage.getItem('textSettings'))` at Text.js line 3 has no try/catch. Corrupt localStorage data crashes the text tool entirely with `SyntaxError`, and it stays broken on every subsequent open until the user manually clears localStorage via DevTools.

This is the same class of bug fixed in PR #4135 (Startup.mjs `ExperimentalSettings`).

## Chrome Testing
- Set `localStorage.setItem('textSettings', '{bad json!!!')` on a live DM session (v1.53-beta5)
- Called `apply_settings_from_storage()` → crash: `SyntaxError: Expected property name or '}' in JSON at position 1`
- Text tool completely non-functional until `localStorage.removeItem('textSettings')`
- Restored valid data after test

## Fix
Wrap in try/catch. On corrupt data: remove the bad key, call `store_text_settings()` to save current UI state as fresh defaults, and return. Next text tool open finds valid data.

```diff
- const settings = (applyFromWindow) ? window.TEXTDATA : JSON.parse(localStorage.getItem('textSettings'));
+ let settings;
+ if (applyFromWindow) {
+     settings = window.TEXTDATA;
+ } else {
+     try {
+         settings = JSON.parse(localStorage.getItem('textSettings'));
+     } catch(e) {
+         console.warn('textSettings corrupted in localStorage, resetting to defaults');
+         localStorage.removeItem('textSettings');
+         store_text_settings();
+         return;
+     }
+ }
```

Matches the pattern from merged PR #4135.

## Files Changed
- `Text.js` — `apply_settings_from_storage()` lines 1-3