### PR TITLE
Fix: guard itemData access in party loot click handler

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -3064,7 +3064,11 @@ class JournalManager{
 				const name = $(this).closest('tr').find('.item-link-cell a').text();
 				
 				const itemData = find_items_in_cache_by_id_and_name([{id, name}]);
-				
+				if (itemData.length === 0) {
+					console.warn("Item not found", [{id, name}]);
+					return;
+				}
+
 				console.log(`[PartyLoot] Adding ${quantity} of item ${name} to queue`);
 				
 				if (quantity > 10){


### PR DESCRIPTION
## Bug
`itemData[0]` at Journal.js lines 3079 and 3087 crashes when `find_items_in_cache_by_id_and_name()` returns an empty array. This happens when the item name in the party loot table HTML doesn't exactly match the `ITEMS_CACHE` entry name.

The table-build code at line 2973 already guards with `if (itemData.length>0)` — the click handler at line 3067 lacks the same check.

## Fix
Add the same length check used at line 2973 before accessing `itemData[0]`, with `console.warn` for log tracking per Azmoria's feedback.

```diff
  const itemData = find_items_in_cache_by_id_and_name([{id, name}]);
+ if (itemData.length === 0) {
+     console.warn("Item not found", [{id, name}]);
+     return;
+ }
  
  console.log(`[PartyLoot] Adding ${quantity} of item ${name} to queue`);
```

## Chrome Verification

**Test Environment:** Chrome/146.0.0.0, AboveVTT v1.53, macOS

**Reproduction:** `find_items_in_cache_by_id_and_name([{id: 99999999, name: "Nonexistent Item XYZ"}])` returns `[]`, then `itemData[0].quantity = 1` throws `TypeError: Cannot set properties of undefined (setting 'quantity')`

**Pre-fix behavior:** Clicking a party loot item that doesn't match `ITEMS_CACHE` crashes with TypeError.

**Post-fix behavior:** No crash. `console.warn("Item not found", [{id: 99999999, name: "Nonexistent Item XYZ"}])` logged for support tracking. Early return prevents the crash.

**Happy path:** `find_items_in_cache_by_id_and_name([{id: 4, name: "Longsword"}])` → length 1, `quantity` set correctly. 0 concerningLogs.

## Files Changed
- `Journal.js` — party loot click handler (line 3067)