### PR TITLE
Fix: correct jQuery .css() getter to setter for tooltip display

### DIFF
--- a/Journal.js
+++ b/Journal.js
@@ -1978,7 +1978,7 @@ class JournalManager{
 		$(target).find('.tooltip-hover').each(function(){
 			const self = this;
 			const $self = $(self);
-			$self.css('display:inline-block');
+			$self.css('display', 'inline-block');
 			if($self.hasClass('note-tooltip')){
 				let noteId = $self.attr('data-id');
 				if(noteId.replace(/[-+*&<>]/gi, '') == $self.text().replace(/[-+*&<>\s]/gi, '')){


### PR DESCRIPTION
## Bug
`$self.css('display:inline-block')` at Journal.js line 1981 is a jQuery **getter** (single string argument returns the CSS value), not a setter. The setter form requires two arguments: `.css('display', 'inline-block')`.

As a result, non-monster `.tooltip-hover` elements (spell, item, condition) never get `display: inline-block` applied. Monster tooltips are unaffected — `addTokenDragToMonsterLink` at line 2103 correctly uses the 2-arg syntax: `$self.css('display', 'inline-block')`.

## Chrome Testing
- Opened a note with `[monster]Goblin`, `[spell]Fireball`, `[item]Longsword`, `[condition]Stunned`
- Monster (Goblin): `display: inline-block` ✅ (set by line 2103)
- Spell (Fireball): `display: inline` ❌ (line 1981 is a no-op)
- Item (Longsword): `display: inline` ❌
- Condition (Stunned): `display: inline` ❌
- Height difference: 15.5px (inline) vs 18.2px (inline-block)

## Fix
Change single-arg getter to two-arg setter, matching the existing pattern at line 2103.

```diff
- $self.css('display:inline-block');
+ $self.css('display', 'inline-block');
```

## Files Changed
- `Journal.js` — line 1981