### PR TITLE
Fix: guard prompt() result in DM Screen Add Page

### DIFF
--- a/DMScreen.js
+++ b/DMScreen.js
@@ -75,8 +75,9 @@ async function buildDMScreen(container) {
             container.append(cont);
             const dmScreenBlocks = $("#dmScreenBlocks");
             $('#addDmScreenPageButton').off('click.addDmPage').on('click.addDmPage', function () {
-                const newId = uuid();
                 const name = prompt("Enter the title for the new DM Screen page:");
+                if (name === null || name.trim() === '') return;
+                const newId = uuid();
                 window.JOURNAL.notes[newId] = {
                     title: name,
                     text: "",


### PR DESCRIPTION
Fixes a minor UX bug in the DM Screen "Add Page" button.

## The Bug

Clicking the **+** button in the DM Screen opens a `prompt()` dialog. If the user clicks **Cancel** (returns `null`) or clicks **OK** with empty text (returns `""`), a journal note is created with the title `"null"` (string coercion of `null`) or an empty title. The TinyMCE editor opens immediately for the unwanted page.

## The Fix

```diff
 $('#addDmScreenPageButton').off('click.addDmPage').on('click.addDmPage', function () {
-    const newId = uuid();
     const name = prompt("Enter the title for the new DM Screen page:");
+    if (name === null || name.trim() === '') return;
+    const newId = uuid();
     window.JOURNAL.notes[newId] = {
```

Adds a null/empty check after `prompt()` — exits early on Cancel or blank input. Also moves `uuid()` after the check so no ID is wasted on cancelled actions.

## Why This Works

- `prompt()` returns `null` on Cancel, `""` on empty OK — both are caught
- `name.trim() === ''` also catches whitespace-only input
- Early `return` exits the click handler before any note/editor is created
- Happy path (user enters a title) is unchanged

## Files Changed

- `DMScreen.js` — line 78-80 (1 line added, 1 line moved)

## Reproduction

1. Open DM Screen (scrollable_header icon in toolbar)
2. Click the **+** button
3. Click **Cancel** on the prompt dialog
4. **Before fix:** A page titled "null" is created and the editor opens
5. **After fix:** Nothing happens — prompt is dismissed cleanly