### PR TITLE
Fix: correct invalid "onchange" event name to "change" in text auto-resize

### DIFF
--- a/Text.js
+++ b/Text.js
@@ -435,7 +435,7 @@ function create_moveable_text_box(x,y,width, height, text = undefined) {
     
     apply_settings_to_boxes()
     $(input).on("keyup", handle_key_press);
-    $(input).on("input onchange", handle_auto_resize);
+    $(input).on("input change", handle_auto_resize);
     $(input).focus();
 }
 


### PR DESCRIPTION
## The Bug

In `Text.js` line 438, `$(input).on("input onchange", handle_auto_resize)` binds jQuery's `.on()` with `"onchange"` — which is an HTML attribute name, not a valid DOM event. jQuery silently registers a handler under the non-existent event name, so it never fires.

The `"input"` event in the same binding masks the bug during typing, but `"change"` (which fires on blur after value change) is never triggered. This means text box auto-resize doesn't work on blur-after-edit scenarios (e.g., paste-then-click-away).

## The Fix

```diff
- $(input).on("input onchange", handle_auto_resize);
+ $(input).on("input change", handle_auto_resize);
```

## Verified in Chrome

- **Before fix:** `$._data(textarea, 'events')` shows `onchange` bound (never fires), `change` absent
- **After fix:** `change` properly bound, `onchange` absent
- Confirmed resize triggers on `change` event (103px → 130px with multi-line content)
- Typing resize (`input` event) unchanged

## Files Changed

- `Text.js` — 1 line changed