### PR TITLE
Fix: await DDBApi.fetchCampaignInfo on campaign page

### DIFF
--- a/CampaignPage.js
+++ b/CampaignPage.js
@@ -16,7 +16,7 @@ $(function() {
       .then(harvest_campaign_secret)  // find our join link
       .then(set_campaign_secret)      // set it to window.CAMPAIGN_SECRET
       .then(store_campaign_info)      // store gameId and campaign secret in localStorage for use on other pages   
-      .then(() => {window.CAMPAIGN_INFO = DDBApi.fetchCampaignInfo(window.gameId)})  
+      .then(async () => {window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId)})
       .then(() => {
          openCampaignDB(async function() {
           if (is_gamelog_popout()) {


### PR DESCRIPTION
Relates to #3292

## The Bug

On the campaign page (`CampaignPage.js:19`), the `.then()` callback assigns the return value of `DDBApi.fetchCampaignInfo()` to `window.CAMPAIGN_INFO` without `await`:

```js
.then(() => {window.CAMPAIGN_INFO = DDBApi.fetchCampaignInfo(window.gameId)})
```

Since `fetchCampaignInfo` is `async`, this sets `CAMPAIGN_INFO` to a **Promise** instead of the resolved data. Any downstream code reading `CAMPAIGN_INFO.dmId` gets `undefined`, silently breaking:

- **`MessageBroker.checkHideSceneFromPlayers()`** — DM ID comparison always fails, potentially showing incorrect hide-scene messages
- **`DiceContextMenu`** — "Dungeon Master" send-to option may show/hide incorrectly
- **`DDBApi.fetchCampaignCharacterIds()`** — `window.myUser` fallback gets `undefined` instead of DM ID

## The Fix

```diff
- .then(() => {window.CAMPAIGN_INFO = DDBApi.fetchCampaignInfo(window.gameId)})
+ .then(async () => {window.CAMPAIGN_INFO = await DDBApi.fetchCampaignInfo(window.gameId)})
```

This matches the pattern already used in `Startup.mjs:64` and `CharactersPage.js:1202`.

## Verified in Chrome

- **Before fix:** `window.CAMPAIGN_INFO instanceof Promise` → `true`, `.dmId` → `undefined`
- **After fix:** `window.CAMPAIGN_INFO instanceof Promise` → `false`, `.dmId` → correct value
- No console errors, campaign page loads normally

## Files Changed

- `CampaignPage.js` — 1 line changed