### PR TITLE
Fix: guard null match result in whisper chat command

### DIFF
--- a/ChatObserver.js
+++ b/ChatObserver.js
@@ -110,7 +110,7 @@ class ChatObserver {
 
         if (text.startsWith("/w")) {
             let matches = text.match(/\[(.*?)] (.*)/);
-            if (matches.length === 3) {
+            if (matches !== null && matches.length === 3) {
                 data.whisper = matches[1]
                 data.text = `<div class="custom-gamelog-message"style="position: relative;margin-bottom: 12px;"><span style='font-size: 9px;position: absolute;bottom: -18px;left: 0px;opacity: 0.5;margin-top: 10px;'><b>To: ${matches[1]}</b></span>${matches[2]}</div>`;
             }


### PR DESCRIPTION
## The Bug

Typing `/w hello` or `/whisper hello` (without the `[name] message` bracket format) in the chat input crashes with:

```
TypeError: Cannot read properties of null (reading 'length')
    at #sendChatMessage (ChatObserver.js:113)
```

`text.match(/\[(.*?)] (.*)/)` returns `null` when the input doesn't contain brackets, and `matches.length` is accessed without a null check.

The whisper button in the player panel pre-fills brackets (`/whisper [Name] `), so this only affects users who manually type `/w` or `/whisper` without the bracket format.

## The Fix

```diff
- if (matches.length === 3) {
+ if (matches !== null && matches.length === 3) {
```

## Why This Works

When `matches` is null (malformed whisper), the condition is false and the code falls through to the final `else` branch (line 137-138), which sends the text as a plain chat message. No crash, reasonable fallback behavior.

## Verified in Chrome

- **Before fix:** `/w hello` → TypeError crash in console
- **After fix:** `/w hello` → sent as plain chat message (no crash)
- **Happy path:** `/w [DM] secret` → still whispers correctly

## Files Changed

- `ChatObserver.js` — line 113, add null check on regex match result