### PR TITLE
Fix: add missing optional chaining for customStat in rollInit

### DIFF
--- a/StatHandler.js
+++ b/StatHandler.js
@@ -128,7 +128,7 @@ class StatHandler {
 			const options = currentToken?.options;
 			const customInitStatic = options?.customInitStatic;
 			const customInitMod = options?.customInit;
-			const statMod = options?.customStat[1]?.mod || 0;
+			const statMod = options?.customStat?.[1]?.mod || 0;
 			let total;
 			if(!customInitMod && customInitStatic != undefined){
 				let decimalAdd = statMod ? ((parseInt(statMod) * 2) + 10) / 100 : 0


### PR DESCRIPTION
## The Bug

Rolling initiative for a custom stat block token that has no stats populated crashes with:

```
TypeError: Cannot read properties of undefined (reading '1')
    at StatHandler.rollInit (StatHandler.js:131)
```

Line 131: `options?.customStat[1]?.mod` — the `?.` after `options` protects against `options` being undefined, but if `options` exists and `customStat` is undefined, `undefined[1]` throws a TypeError.

Other accesses of `customStat[1]` in this file (lines 65, 67, 141) are already guarded by a preceding `customStat != undefined` check with short-circuit `&&`. Only line 131 is unguarded.

## The Fix

```diff
- const statMod = options?.customStat[1]?.mod || 0;
+ const statMod = options?.customStat?.[1]?.mod || 0;
```

## Why This Works

Adding `?.` before `[1]` makes the entire chain short-circuit to `undefined` when `customStat` is undefined, which then falls through to `|| 0` — the same default value used elsewhere in the function. The happy path (customStat with data) is unchanged because `?.[]` on a defined array behaves identically to `[]`.

## Verified in Chrome

- **Before fix:** `options = { monster: 'customStat' }` → `options?.customStat[1]?.mod` → TypeError
- **After fix:** same input → returns `0` (safe default, no crash)
- **Happy path:** `options = { customStat: [null, { mod: 3 }] }` → returns `3`

## Files Changed

- `StatHandler.js` — line 131, add `?.` before bracket access