### PR TITLE
Fix: correct name() lookup for path-based token customization IDs

### DIFF
--- a/TokenCustomization.js
+++ b/TokenCustomization.js
@@ -537,7 +537,7 @@ class TokenCustomization {
         } else if (RootFolder.allIds().includes(this.id)) {
             n = RootFolder.findById(this.id).name;
         } else if (RootFolder.allPaths().map(p => path_to_html_id(p)).includes(this.id)) {
-            n = RootFolder.allPaths().map(p => path_to_html_id(p)).name;
+            n = RootFolder.allValues().find(f => path_to_html_id(f.path) === this.id)?.name;
         } else {
             n = this.tokenOptions?.name;
             if (!n) {


### PR DESCRIPTION
## The Bug

`TokenCustomization.name()` has a branch (line 539-540) for customizations whose ID matches a `path_to_html_id()` result (legacy/migration IDs). The name lookup calls `.name` on the result of `Array.map()`:

```javascript
n = RootFolder.allPaths().map(p => path_to_html_id(p)).name;
```

Arrays don't have a `.name` property — this returns `undefined`, which is falsy, so `n || "undefined"` returns the string `"undefined"`. Any token customization with a path-based ID displays its name as "undefined".

## The Fix

```diff
- n = RootFolder.allPaths().map(p => path_to_html_id(p)).name;
+ n = RootFolder.allValues().find(f => path_to_html_id(f.path) === this.id)?.name;
```

## Why This Works

Instead of calling `.name` on an array, we find the matching RootFolder object and return its `.name` property. The preceding `if` condition (line 539) already confirms `this.id` is in the mapped array, so `.find()` will always match. The `?.` is a safety net.

## Verified in Chrome

- **Before fix:** Token with `id = path_to_html_id("/Players")` → `name()` returns `"undefined"`
- **After fix:** Same token → `name()` returns `"Players"`
- **All 10 root folders** resolve correctly with the fix

## Files Changed

- `TokenCustomization.js` — line 540, replace `.map().name` with `.find().name`