### PR TITLE
Wall point snapping and circular-poly walls

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -6295,7 +6295,7 @@ function init_walls_menu(buttons){
 	wall_menu.append(
 		`<div class='ddbc-tab-options--layout-pill menu-option data-skip='true''>
 			<button id='snap_walls' data-toggle='true' class='drawbutton menu-option ddbc-tab-options__header-heading ${(window.snapWallsToggle) ? "button-enabled" : ''}'>
-				Wall Snap
+				Join Snap
 			</button>
 		</div>`);
 	wall_menu.append(

--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -261,6 +261,12 @@ Mousetrap.bind('shift+w', function () {
     }
        
 });
+Mousetrap.bind('j', function () {
+    if(window.DM){
+        $('#snap_walls').toggleClass(['button-enabled', 'ddbc-tab-options__header-heading--is-active']);
+    }
+});
+    
 Mousetrap.bind('shift+e', function () {
     if(window.DM){
         $('#show_elev').toggleClass(['button-enabled', 'ddbc-tab-options__header-heading--is-active']);


### PR DESCRIPTION
Added a "circular poly" (limited segment circle-like) drawing for walls.  This is a compromise with actual circles to keep wall count down.  It's a 3-point mode: click one end of arc, then center radius, then clockwise around to the end arc.

Made snapping for wall draw-line (and new circular poly) mode snap to wall points rather than grid.
(If we want the grid mode too, then we need to find another mod key somewhere - need to decide)

