### PR TITLE
Fix - chat message history growing without bound due to broken length check

### DIFF
--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -411,7 +411,7 @@ class MessageBroker {
 			return;
 		}
 		window.MB.chat_message_history.unshift(data);
-		if (window.MB.chat_message_history > 100) {
+		if (window.MB.chat_message_history.length > 100) {
 			window.MB.chat_message_history.pop();
 		}
 	}


### PR DESCRIPTION
## Problem

`track_message_history` was supposed to cap the chat replay buffer at 100 entries so DDB's gamelog can be re-injected with recent messages. The guard was broken:

```js
// before — compares array object to number, always NaN > 100 = false → never trims
if (window.MB.chat_message_history > 100) {

// after
if (window.MB.chat_message_history.length > 100) {
```

In JavaScript, comparing an Array to a number coerces the array to `NaN`, so `NaN > 100` is always `false`. The `pop()` was never called and the array accumulated every chat message, dice roll, and character update for the lifetime of the session.

## Change

One character added (`.length`) in `MessageBroker.js`. No behaviour change for arrays under 100 entries.

## Test plan
- [ ] Run a long session with heavy chat/dice usage and confirm memory stays stable (chat history should not grow past 100 entries)
- [ ] Verify gamelog re-injection still works after a page reload — recent messages should replay correctly