### PR TITLE
Fix - wall and player draw undo buffers growing without bound

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1,4 +1,10 @@
 const POLYGON_CLOSE_DISTANCE = 15;
+const WALL_UNDO_MAX = 100;
+function pushWallUndo(entry) {
+	if (!window.wallUndo) window.wallUndo = [];
+	window.wallUndo.push(entry);
+	if (window.wallUndo.length > WALL_UNDO_MAX) window.wallUndo.shift();
+}
 const doorColors = {
 	0: {
 		'open': "rgba(255, 100, 255, 0.5)", // door
@@ -74,8 +80,9 @@ function sync_drawings(newDraw = true){
 		if(window.playerDrawUndo == undefined)
 			window.playerDrawUndo = [];
 		window.playerDrawUndo.push(window.DRAWINGS[window.DRAWINGS.length-1]);
+		if (window.playerDrawUndo.length > WALL_UNDO_MAX) window.playerDrawUndo.shift();
 	}
-	
+
 	window.MB.sendMessage("custom/myVTT/drawdata",window.DRAWINGS);
 }
 
@@ -2382,7 +2389,7 @@ function redraw_light_walls(clear=true, editingWallPoints = false){
 										(doors[0][11] != undefined ? doors[0][11] : "")
 							];	
 							window.DRAWINGS.push(data);
-							window.wallUndo.push({
+							pushWallUndo({
 								undo: [[...data]],
 								redo: [[...doors[0]]]
 							})
@@ -2847,7 +2854,7 @@ function open_close_door(x1, y1, x2, y2, type=0){
 				 (doors[0][11] != undefined ? doors[0][11] : "")
 				];	
 	window.DRAWINGS.push(data);
-	window.wallUndo.push({
+	pushWallUndo({
 		undo: [[...data]],
 		redo: [[...doors[0]]]
 	})
@@ -4004,7 +4011,7 @@ function drawing_mouseup(e) {
 				 window.wallTop];
 			window.DRAWINGS.push(line4);
 
-			window.wallUndo.push({
+			pushWallUndo({
 				undo: [[...line1], [...line2], [...line3], [...line4]]
 			});
 		}
@@ -4033,12 +4040,12 @@ function drawing_mouseup(e) {
 						window.wallBottom,
 				 		window.wallTop];
 					window.DRAWINGS.push(data);
-					window.wallUndo.push({
+					pushWallUndo({
 						undo: [[...data]]
 					});
 			}
 			if(undoArray.length > 0){
-				window.wallUndo.push({
+				pushWallUndo({
 					undo: [...undoArray]
 				});
 			}
@@ -4446,7 +4453,7 @@ function drawing_mouseup(e) {
 				undoArray.push([...data]);
 			}					
 		}
- 		window.wallUndo.push({
+ 		pushWallUndo({
 			undo: [...undoArray],
 			redo: [...redoArray]
 		});
@@ -4574,7 +4581,7 @@ function drawing_mouseup(e) {
 				undoArray.push([...window.DRAWINGS[index]])
 				window.selectedWalls[i].wall = [...window.DRAWINGS[index]];	
 			}	
-			window.wallUndo.push({undo: [...undoArray], redo:[...redoArray], selectedWalls: originalSelected});
+			pushWallUndo({undo: [...undoArray], redo:[...redoArray], selectedWalls: originalSelected});
 		}
 
       	redraw_light_walls();
@@ -5553,10 +5560,10 @@ function save3PointRect(e){
 			undoArray.push([...data]);
 		}
 
-		window.wallUndo.push({
+		pushWallUndo({
 			undo: [...undoArray]
 		});
-			
+
 
 		window.MOUSEDOWN = false;
 		redraw_light_walls();
@@ -5629,7 +5636,7 @@ function save3PointRound(e){  //only used for wall currently
 		window.DRAWINGS.push(l);
 		undoArray.push(l);
 	}
-	window.wallUndo.push({
+	pushWallUndo({
 		undo: [...undoArray]
 	});
 	window.MOUSEDOWN = false;

--- a/Token.js
+++ b/Token.js
@@ -5153,7 +5153,7 @@ function paste_selected_walls(x, y) {
 		window.selectedWalls.push({pt1: pt1, pt2: pt2, wall: wall, tokenId: doorTokenId, drawIndex: drawIndex})
 	}
 
-	window.wallUndo.push({undo: [...undoArray], selectedWalls: originalSelected});
+	pushWallUndo({undo: [...undoArray], selectedWalls: originalSelected});
 	
 	redraw_light_walls();
 	redraw_drawn_light();
@@ -5292,7 +5292,7 @@ function delete_selected_walls() {
 				window.TOKEN_OBJECTS[tokenId].delete();
 			}
 		}
-		window.wallUndo.push({redo: [...redoArray], selectedWalls: originalSelected});
+		pushWallUndo({redo: [...redoArray], selectedWalls: originalSelected});
 		window.selectedWalls =[];
 		redraw_light_walls();
 		redraw_drawn_light();

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -243,7 +243,7 @@ function token_context_menu_expanded(tokenIds, e) {
 					 			 (doors[0][11] != undefined ? doors[0][11] : "")
 					];	
 					window.DRAWINGS.push(data);
-					window.wallUndo.push({
+					pushWallUndo({
 						undo: [data],
 						redo: [doors[0]]
 					})
@@ -411,7 +411,7 @@ function token_context_menu_expanded(tokenIds, e) {
 					 			 (doors[0][11] != undefined ? doors[0][11] : "")
 					 	]
 					 	window.DRAWINGS.push(data);
-					 	window.wallUndo.push({
+					 	pushWallUndo({
 							undo: [[...data]],
 						})
 						let clonePortalId = `${mouseX-5}${mouseY}${mouseX+5}${mouseY}${window.CURRENT_SCENE_DATA.id}`.replaceAll('.','') 
@@ -567,7 +567,7 @@ function token_context_menu_expanded(tokenIds, e) {
 					 			 (doors[0][11] != undefined ? doors[0][11] : "")
 					];	
 					window.DRAWINGS.push(data);
-					window.wallUndo.push({
+					pushWallUndo({
 						undo: [data],
 						redo: [doors[0]]
 					})
@@ -614,7 +614,7 @@ function token_context_menu_expanded(tokenIds, e) {
 				 			 (doors[0][11] != undefined ? doors[0][11] : "")
 				];	
 				window.DRAWINGS.push(data);
-				window.wallUndo.push({
+				pushWallUndo({
 					undo: [data],
 					redo: [doors[0]]
 				})
@@ -654,7 +654,7 @@ function token_context_menu_expanded(tokenIds, e) {
 				 			 (doors[0][11] != undefined ? doors[0][11] : "")
 				];	
 				window.DRAWINGS.push(data);
-				window.wallUndo.push({
+				pushWallUndo({
 					undo: [data],
 					redo: [doors[0]]
 				})


### PR DESCRIPTION
## Problem

`window.wallUndo` and `window.playerDrawUndo` are undo stacks with no size limit. `wallUndo` is only reset when new scene data arrives; in a long DM session with heavy wall editing it accumulates every operation indefinitely.

## Changes

**`Fog.js`**
- Added `const WALL_UNDO_MAX = 100` constant
- Added `pushWallUndo(entry)` helper that wraps `window.wallUndo.push` with a cap (drops oldest entry via `shift()` when over limit) and an undefined guard for calls before scene load
- Replaced all `window.wallUndo.push(` call sites in `Fog.js` with `pushWallUndo(`
- Capped `playerDrawUndo` at `WALL_UNDO_MAX` entries inline

**`Token.js`, `TokenMenu.js`**
- Replaced all remaining `window.wallUndo.push(` call sites with `pushWallUndo(` to ensure the cap is applied regardless of which code path triggers the undo entry

100 steps covers any realistic undo need while preventing unbounded growth.

## Test plan
- [ ] Perform more than 100 wall edits in a single scene and confirm undo still works (oldest steps drop off, no crash)
- [ ] Confirm undo/redo behaves normally for typical editing sessions (under 100 steps)
- [ ] Verify player draw undo is similarly capped and functions correctly