### PR TITLE
Fix - PeerManager stale connection interval not cleared on teardown

### DIFF
--- a/PeerManager.js
+++ b/PeerManager.js
@@ -92,6 +92,8 @@ class PeerManager {
   }
 
   tearDown() {
+    clearInterval(this.staleConnectionTimerId);
+    this.staleConnectionTimerId = undefined;
     this.disconnectAllPeers();
     this.peer.disconnect();
     this.peer.destroy();
@@ -381,6 +383,7 @@ class PeerManager {
 
   /** Checks for and cleans up stale connections */
   checkForStaleConnections() {
+    if (!this.peer || this.peer.destroyed) return;
     try {
       let attemptReconnect = false;
       // first let's clean up everything that we actually know about


### PR DESCRIPTION
## Summary
- `setInterval` registered in `startMonitoringStaleConnections()` was never cleared when `tearDown()` was called
- `rebuild_peerManager()` can call `tearDown()` up to 3 times per session on peer errors, each leaving an orphaned interval firing every 10 seconds indefinitely
- Orphaned intervals leaked CPU and could call `checkForStaleConnections()` on an already-destroyed peer

## Changes
- `tearDown()`: clear and unset `staleConnectionTimerId` on cleanup
- `checkForStaleConnections()`: early-return guard if peer is destroyed or absent

## Test plan
- [ ] Join a campaign as DM and trigger a peer reconnect (e.g. disable/re-enable network briefly) — confirm no runaway intervals accumulate
- [ ] Verify players still reconnect normally after a peer error
- [ ] Confirm stale connection detection still works during an active session