### PR TITLE
QoL - Allow users to adjust sidebar width

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -2182,7 +2182,7 @@ function set_campaign_secret(campaignSecret) {
 function projector_scroll_event(event){
       event.stopImmediatePropagation();
       if($('#projector_toggle.enabled > [class*="is-active"]').length>0){
-            let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
+            let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? get_sidebar_width() : 0);
             let center = center_of_view(); 
 
 

--- a/Main.js
+++ b/Main.js
@@ -177,7 +177,7 @@ function change_zoom(newZoom, x, y, reset = false) {
 		let scrollX = Math.max(0, sceneMapCenterX - Math.round(window.innerWidth / 2));
 		const scrollY = Math.max(0, sceneMapCenterY - Math.round(window.innerHeight / 2));
 		if ($('#hide_rightpanel').hasClass('point-right') && $('.ct-sidebar.ct-sidebar--hidden').length == 0)
-			scrollX += 170 // 170 half of game log		
+			scrollX += get_sidebar_width() / 2 // offset by half the sidebar width so the scene centers in the visible area
 		window.scrollTo({ left: scrollX, top: scrollY, behavior: 'auto' });			
 	}
 
@@ -2004,8 +2004,14 @@ function apply_sidebar_width(newWidth) {
 	const widthStr = is_sidebar_visible() ? newWidth + 'px' : '0px';
 	$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', widthStr);
 	$('canvas.streamer-canvas').css('--sidebar-width', widthStr);
-	const sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
-	sidebar.css("width", newWidth + "px");
+	if (is_characters_page()) {
+		// On the characters page, .ct-sidebar__portal must stay at width:100% (see abovevtt.css ~6464)
+		// so popovers/menus position correctly. The visible sidebar inside it is sized via the
+		// --sidebar-width CSS var on .ct-sidebar[class*='styles_sidebar'] [class*='styles_content'].
+		$(".ct-sidebar__portal").css("width", "");
+	} else {
+		$(".sidebar--right").css("width", newWidth + "px");
+	}
 	$(".sidebar__controls").width(newWidth);
 	const zoomOffset = $("#zoom_buttons").data("zoom-offset");
 	if (zoomOffset !== undefined) {
@@ -2035,8 +2041,9 @@ function init_sidebar_resize_handle() {
 			const delta = startX - e.clientX;
 			const newWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, startWidth + delta));
 			document.documentElement.style.setProperty('--sidebar-width', newWidth + 'px');
-			const sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
-			sidebar.css("width", newWidth + "px");
+			if (!is_characters_page()) {
+				$(".sidebar--right").css("width", newWidth + "px");
+			}
 			$(".sidebar__controls").width(newWidth);
 			$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', newWidth + 'px');
 			$('canvas.streamer-canvas').css('--sidebar-width', newWidth + 'px');
@@ -2061,8 +2068,8 @@ function init_sidebar_resize_handle() {
 
 		$(window).one('blur.sidebarResize', function() {
 			cleanupSidebarDrag();
-			const sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
-			const currentWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, parseInt(sidebar.css('width')) || SIDEBAR_MIN_WIDTH));
+			const cssVarWidth = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width'));
+			const currentWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, cssVarWidth || SIDEBAR_MIN_WIDTH));
 			set_avtt_setting_value('sidebarWidth', currentWidth);
 		});
 	});

--- a/Main.js
+++ b/Main.js
@@ -2007,6 +2007,10 @@ function apply_sidebar_width(newWidth) {
 	const sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
 	sidebar.css("width", newWidth + "px");
 	$(".sidebar__controls").width(newWidth);
+	const zoomOffset = $("#zoom_buttons").data("zoom-offset");
+	if (zoomOffset !== undefined) {
+		$("#zoom_buttons").css("right", (newWidth + zoomOffset) + "px");
+	}
 	if (is_characters_page()) {
 		reposition_player_sheet();
 	}
@@ -2036,6 +2040,10 @@ function init_sidebar_resize_handle() {
 			$(".sidebar__controls").width(newWidth);
 			$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', newWidth + 'px');
 			$('canvas.streamer-canvas').css('--sidebar-width', newWidth + 'px');
+			const zoomOffset = $("#zoom_buttons").data("zoom-offset");
+			if (zoomOffset !== undefined) {
+				$("#zoom_buttons").css("right", (newWidth + zoomOffset) + "px");
+			}
 		});
 
 		function cleanupSidebarDrag() {
@@ -2983,11 +2991,9 @@ function init_zoom_buttons() {
 	zoom_section.append(hide_interface);
 
 	$(".avtt-sidebar-controls").append(zoom_section);
-	if (window.DM || is_spectator_page()) {
-		zoom_section.css("right","371px");
-	} else {
-		zoom_section.css("right","420px");
-	}
+	const zoomOffset = (window.DM || is_spectator_page()) ? 31 : 80;
+	zoom_section.css("right", (get_sidebar_width() + zoomOffset) + "px");
+	zoom_section.data("zoom-offset", zoomOffset);
 }
 
 /**

--- a/Main.js
+++ b/Main.js
@@ -201,7 +201,7 @@ function add_zoom_to_storage() {
 		const zooms = JSON.parse(localStorage.getItem('zoom')) || [];
 		const zoomIndex = zooms.findIndex(zoom => zoom.title === window.CURRENT_SCENE_DATA.title);
 		const centerView = center_of_view(); 
-		const sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
+		const sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? get_sidebar_width() : 0);
 		if (zoomIndex !== -1) {
 			zooms[zoomIndex].zoom = window.ZOOM;
 			zooms[zoomIndex].leftOffset = window.scrollX + window.innerWidth/2 - sidebarSize/2;
@@ -256,7 +256,7 @@ function remove_zoom_from_storage() {
 */
 function apply_zoom_from_storage() {
 	console.group("apply_zoom_from_storage");
-	const sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
+	const sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? get_sidebar_width() : 0);
 	let initial_x = isNaN(parseInt(window.CURRENT_SCENE_DATA.initial_x)) ? undefined : window.CURRENT_SCENE_DATA.initial_x - window.innerWidth/2 + sidebarSize/2;
 	let initial_y =  isNaN(parseInt(window.CURRENT_SCENE_DATA.initial_y)) ? undefined : window.CURRENT_SCENE_DATA.initial_y - window.innerHeight/2;
 	let initial_zoom =  isNaN(parseInt(window.CURRENT_SCENE_DATA.initial_zoom)) ? undefined : window.CURRENT_SCENE_DATA.initial_zoom;
@@ -381,7 +381,7 @@ function get_reset_zoom() {
 	const w = $(window);
 	const scene_map = $("#scene_map");
 	const sf = window.CURRENT_SCENE_DATA.scale_factor;
-	const sidebar_open = ($('#hide_rightpanel').hasClass('point-right') && $('.ct-sidebar.ct-sidebar--hidden').length == 0) ? 340 : 0;
+	const sidebar_open = ($('#hide_rightpanel').hasClass('point-right') && $('.ct-sidebar.ct-sidebar--hidden').length == 0) ? get_sidebar_width() : 0;
 	const wH = w.height();
 	const mH = scene_map.height()*sf;
 	const wW = w.width()-sidebar_open;
@@ -668,7 +668,7 @@ function set_pointer(data, dontscroll = false) {
 	if(!dontscroll){
 		let pageX = Math.round(data.x * window.ZOOM - (w.width() / 2));
 		let pageY = Math.round(data.y * window.ZOOM - (w.height() / 2));
-		let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
+		let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? get_sidebar_width() : 0);
 		$("html,body").animate({
 			scrollTop: pageY + window.VTTMargin,
 			scrollLeft: pageX + window.VTTMargin + sidebarSize/2,
@@ -1989,6 +1989,77 @@ function monitor_character_sidebar_changes() {
 
 
 
+const SIDEBAR_MIN_WIDTH = 340;
+const SIDEBAR_MAX_WIDTH = 600;
+
+function get_sidebar_width() {
+	const stored = get_avtt_setting_value('sidebarWidth');
+	const n = parseInt(stored, 10);
+	return (!isNaN(n) && n >= SIDEBAR_MIN_WIDTH && n <= SIDEBAR_MAX_WIDTH) ? n : SIDEBAR_MIN_WIDTH;
+}
+
+function apply_sidebar_width(newWidth) {
+	newWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, parseInt(newWidth, 10) || SIDEBAR_MIN_WIDTH));
+	document.documentElement.style.setProperty('--sidebar-width', newWidth + 'px');
+	const widthStr = is_sidebar_visible() ? newWidth + 'px' : '0px';
+	$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', widthStr);
+	$('canvas.streamer-canvas').css('--sidebar-width', widthStr);
+	const sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
+	sidebar.css("width", newWidth + "px");
+	$(".sidebar__controls").width(newWidth);
+	if (is_characters_page()) {
+		reposition_player_sheet();
+	}
+	window.dispatchEvent(new Event('resize'));
+}
+
+function init_sidebar_resize_handle() {
+	$('#avtt-sidebar-resize-handle').remove();
+	const handle = $('<div id="avtt-sidebar-resize-handle"></div>');
+	$('body').append(handle);
+
+	let startX, startWidth;
+
+	handle.on('mousedown', function(e) {
+		e.preventDefault();
+		startX = e.clientX;
+		startWidth = get_sidebar_width();
+		$("#resizeDragMon, .note:has(iframe) form .mce-container-body, #sheet")
+			.append($('<div class="iframeResizeCover"></div>'));
+
+		$(document).on('mousemove.sidebarResize', function(e) {
+			const delta = startX - e.clientX;
+			const newWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, startWidth + delta));
+			document.documentElement.style.setProperty('--sidebar-width', newWidth + 'px');
+			const sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
+			sidebar.css("width", newWidth + "px");
+			$(".sidebar__controls").width(newWidth);
+			$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', newWidth + 'px');
+			$('canvas.streamer-canvas').css('--sidebar-width', newWidth + 'px');
+		});
+
+		function cleanupSidebarDrag() {
+			$(document).off('mousemove.sidebarResize');
+			$(window).off('mouseup.sidebarResize blur.sidebarResize');
+			$('.iframeResizeCover').remove();
+		}
+
+		$(window).one('mouseup.sidebarResize', function(e) {
+			cleanupSidebarDrag();
+			const delta = startX - e.clientX;
+			const newWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, startWidth + delta));
+			set_avtt_setting_value('sidebarWidth', newWidth);
+		});
+
+		$(window).one('blur.sidebarResize', function() {
+			cleanupSidebarDrag();
+			const sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
+			const currentWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(SIDEBAR_MAX_WIDTH, parseInt(sidebar.css('width')) || SIDEBAR_MIN_WIDTH));
+			set_avtt_setting_value('sidebarWidth', currentWidth);
+		});
+	});
+}
+
 /**
  * Initializes the user interface.
  */
@@ -2008,12 +2079,11 @@ function init_ui() {
 	// ATTIVA GAMELOG
 	$(".glc-game-log").addClass("sidepanel-content");
 	$(".sidebar").css("z-index", 9999);
-	if (is_characters_page()) {
-		reposition_player_sheet();
-	}
-	$(".sidebar__controls").width(340);
 	// $(".ct-sidebar__control").width(340);
 	$("body").css("overflow", "scroll");
+
+	apply_sidebar_width(get_sidebar_width());
+	init_sidebar_resize_handle();
 
 	inject_chat_buttons();
 
@@ -3468,7 +3538,7 @@ function toggle_player_sheet_size() {
  */
 function reposition_player_sheet() {
 
-	let sidebarWidth = is_sidebar_visible() ? 340 : 0;
+	let sidebarWidth = is_sidebar_visible() ? get_sidebar_width() : 0;
 	let playableSpace = window.innerWidth - sidebarWidth;
 	let forceLayout = "none";
 
@@ -3698,8 +3768,8 @@ function show_sidebar(dispatchResize = true) {
 	} else {
 		$("#sheet").removeClass("sidebar_hidden");
 	}
-	$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', '340px');
-	$('canvas.streamer-canvas').css('--sidebar-width', '340px');
+	$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', get_sidebar_width() + 'px');
+	$('canvas.streamer-canvas').css('--sidebar-width', get_sidebar_width() + 'px');
 	if(dispatchResize)
 		window.dispatchEvent(new Event('resize'));
 	addGamelogPopoutButton()
@@ -3855,7 +3925,7 @@ function hide_sidebar(triggerResize = true) {
 		
 	} else {
 		let sidebar = is_characters_page() ? $(".ct-sidebar__portal") : $(".sidebar--right");
-		sidebar.css("transform", "translateX(340px)");
+		sidebar.css("transform", `translateX(${get_sidebar_width()}px)`);
 		$('#combat_carousel_container.tracker-list').toggleClass('sidebarClosed', true)
 	}
 
@@ -3882,7 +3952,7 @@ function adjust_site_bar() {
 	let fullWidth = "100%";
 	if (!is_player_sheet_full_width()) {
 		let sheetWidth =  window.innerWidth < 1200 ? 550 : 620;
-		let sidebarWidth = is_sidebar_visible() ? 340 : 0;
+		let sidebarWidth = is_sidebar_visible() ? get_sidebar_width() : 0;
 		fullWidth = `${sheetWidth + sidebarWidth}px`;
 	}
 

--- a/Main.js
+++ b/Main.js
@@ -2011,6 +2011,7 @@ function apply_sidebar_width(newWidth) {
 		$(".ct-sidebar__portal").css("width", "");
 	} else {
 		$(".sidebar--right").css("width", newWidth + "px");
+		$(".ct-sidebar__pane-content").css("width", newWidth + "px");
 	}
 	$(".sidebar__controls").width(newWidth);
 	const zoomOffset = $("#zoom_buttons").data("zoom-offset");
@@ -2043,6 +2044,7 @@ function init_sidebar_resize_handle() {
 			document.documentElement.style.setProperty('--sidebar-width', newWidth + 'px');
 			if (!is_characters_page()) {
 				$(".sidebar--right").css("width", newWidth + "px");
+				$(".ct-sidebar__pane-content").css("width", newWidth + "px");
 			}
 			$(".sidebar__controls").width(newWidth);
 			$('canvas.dice-rolling-panel__container, .roll-mod-container').css('--sidebar-width', newWidth + 'px');

--- a/ScenesPanel.js
+++ b/ScenesPanel.js
@@ -396,7 +396,7 @@ function open_grid_wizard_controls(scene_id, aligner1, aligner2, regrid = functi
 	scene_properties = $('<div id="scene_properties"/>');
 	dialog.append(scene_properties);
 
-	adjust_create_import_edit_container(dialog, undefined, undefined, window.innerWidth-340, 340);
+	adjust_create_import_edit_container(dialog, undefined, undefined, window.innerWidth-get_sidebar_width(), get_sidebar_width());
 
 	let container = scene_properties;
 
@@ -1453,7 +1453,7 @@ Tbh I feel like these overcomplicate things
 		)
 	initialPosition.find('button#initialPosition').off('click.setPos').on('click.setPos', function(e){
 		initialPosition.find(`input[name='initial_zoom']`).val(parseFloat(window.ZOOM));
-		const sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
+		const sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? get_sidebar_width() : 0);
 		initialPosition.find(`input[name='initial_x']`).val(parseFloat(window.scrollX)+window.innerWidth/2-sidebarSize/2);
 		initialPosition.find(`input[name='initial_y']`).val(parseFloat(window.scrollY)+window.innerHeight/2);
 	})

--- a/Settings.js
+++ b/Settings.js
@@ -668,6 +668,17 @@ function avtt_settings() {
 		class: 'ui',
 		global: 1
 	})
+	settings.push({
+		name: 'sidebarWidth',
+		label: 'Sidebar Width',
+		type: 'rangeInput',
+		options: [
+			{ min: 340, max: 600, step: 10, description: "Width of the sidebar panel in pixels" },
+		],
+		defaultValue: 340,
+		class: 'ui',
+		global: 1
+	})
 	settings.push(
 	{
 		name: "monsterCritType",
@@ -990,6 +1001,9 @@ function set_avtt_setting_value(name, newValue) {
 		case "projector":
 			$('#projector_toggle, #projector_zoom_lock').toggleClass('enabled', newValue);
 			break;
+		case "sidebarWidth":
+			apply_sidebar_width(newValue);
+			break;
 		case "receiveCursorFromPeers":
 		case "receiveRulerFromPeers":
 			local_peer_setting_changed(name, newValue);
@@ -1215,6 +1229,11 @@ function init_settings() {
 				break;
 			case "customButton":
 				inputWrapper = build_custom_button_input(setting);
+				break;
+			case "rangeInput":
+				inputWrapper = build_rangeInput_input(setting.options[0], currentValue, function(_name, newValue){
+					set_avtt_setting_value(setting.name, newValue);
+				})
 				break;
 		}
 		if (inputWrapper) {

--- a/Settings.js
+++ b/Settings.js
@@ -1231,7 +1231,7 @@ function init_settings() {
 				inputWrapper = build_custom_button_input(setting);
 				break;
 			case "rangeInput":
-				inputWrapper = build_rangeInput_input(setting.options[0], currentValue, function(_name, newValue){
+				inputWrapper = build_rangeInput_input(setting, currentValue, function(_name, newValue){
 					set_avtt_setting_value(setting.name, newValue);
 				})
 				break;

--- a/SidebarPanel.js
+++ b/SidebarPanel.js
@@ -2165,7 +2165,7 @@ function did_click_row(clickEvent) {
               : clickedItem.image;
             flyout.append(`<img class='list-item-image-flyout' src="${src}" alt="scene map preview" />`);
           }
-          flyout.css("right", "340px");
+          flyout.css("right", get_sidebar_width() + "px");
         });
         clickedRow.off("mouseleave").on("mouseleave", function (mouseleaveEvent) {
           $(mouseleaveEvent.currentTarget).off("mouseleave");

--- a/Startup.mjs
+++ b/Startup.mjs
@@ -271,7 +271,7 @@ $(function() {
               });
             }
             else if(event.data.msgType == 'projectionScroll' && event.data.sceneId == window.CURRENT_SCENE_DATA.id){
-              let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? 340 : 0);
+              let sidebarSize = ($('#hide_rightpanel.point-right').length>0 ? get_sidebar_width() : 0);
               let windowRatio = window.innerHeight / event.data.innerHeight;
 
               if(windowRatio == 1 && window.ZOOM == event.data.zoom){

--- a/Token.js
+++ b/Token.js
@@ -891,7 +891,7 @@ class Token {
 			
 			if(!dontscroll){
 				if($("#hide_rightpanel").hasClass("point-right")) {
-   					pageX += 190; // 190 = half gamelog + scrollbar
+   					pageX += (get_sidebar_width() / 2 + 20); // half sidebar + scrollbar offset
    				}
 				$("html,body").animate({
 					scrollTop: pageY + window.VTTMargin,
@@ -3664,7 +3664,7 @@ function default_options() {
 function center_of_view() {
 	let centerX = (window.innerWidth/2) + window.scrollX 
 	if($("#hide_rightpanel").hasClass("point-right")) {
-    centerX = centerX - 190; // 190 = half gamelog + scrollbar
+    centerX = centerX - (get_sidebar_width() / 2 + 20); // half sidebar + scrollbar offset
   }
 	let centerY = (window.innerHeight/2) + window.scrollY - 20 // 20 = scrollbar
 	return { x: centerX, y: centerY };

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -750,7 +750,7 @@ span.button-text{
 
 #sheet {
     left: auto;
-    right: 340px;
+    right: var(--sidebar-width, 340px);
     display: none;
     position: fixed !important;
     border-radius: 5px; 
@@ -912,6 +912,23 @@ select#doorTypeSelectUVTT{
     position: relative;
     display:inline-block;
 }
+#avtt-sidebar-resize-handle {
+    position: fixed;
+    top: 30px;
+    right: var(--sidebar-width, 340px);
+    width: 6px;
+    height: calc(100vh - 30px);
+    cursor: ew-resize;
+    z-index: 99999;
+    background: transparent;
+}
+#avtt-sidebar-resize-handle:hover {
+    background: rgba(100, 149, 237, 0.4);
+}
+body:has(#hide_rightpanel[data-visible="0"]) #avtt-sidebar-resize-handle {
+    display: none;
+}
+
 .iframeResizeCover {
     z-index:9999999;
     position:absolute;
@@ -4353,12 +4370,12 @@ div.token-image {
 }
 
 .ct-sidebar[class*='styles_sidebar'] {
-    min-width: 340px !important;
+    min-width: var(--sidebar-width, 340px) !important;
 }
 
 .ct-sidebar[class*='styles_sidebar'] [class*='styles_content'] {
-    min-width: 340px !important;
-    max-width: 340px !important;
+    min-width: var(--sidebar-width, 340px) !important;
+    max-width: var(--sidebar-width, 340px) !important;
 }
 
 .token:before{
@@ -4892,7 +4909,7 @@ body {
     padding: 10px;
     overflow-y: auto;
     background-color: rgb(235, 241, 245);
-    width: 340px;
+    width: var(--sidebar-width, 340px);
     top: 30px;
     right: 0px;
     left: auto;
@@ -4912,7 +4929,7 @@ body {
     position: fixed;
     top: 30px;
     right: 0px;
-    width: 340px;
+    width: var(--sidebar-width, 340px);
     z-index: -1;
     height: calc(-45px + 100vh);
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2773,7 +2773,8 @@ body:not(.encounter-builder-page) .sidebar__pane-content {
     right: 0;
     top: 28px;
     height: calc(100vh - 30px) !important;
-    width: var(--sidebar-width, 340px);
+    width: var(--sidebar-width, 340px) !important;
+    max-width: 600px !important;
 }
 body .gamelogcontainer .sidebar__pane-content {
     top: 0px !important;
@@ -2848,7 +2849,7 @@ body .gamelogcontainer .sidebar__pane-content {
 .sidebar__controls .tab-btn .sidebar-tab-image > div {
     width: 100%;
     height: 80%;
-    margin: 5% 0 0 0;
+    margin: 2px 0 0 0;
     background-color: #838383;
 }
 .avtt-sidebar-controls .tab-btn.selected-tab .sidebar-tab-image > div,
@@ -2861,7 +2862,7 @@ body .gamelogcontainer .sidebar__pane-content {
 .sidebar__controls .tab-btn .sidebar-tab-image > svg {
     width: 100%;
     height: 80%;
-    margin: 5% 0 0 0;
+    margin: 2px 0 0 0;
     color: #838383;
 }
 .avtt-sidebar-controls .tab-btn.selected-tab .sidebar-tab-image > svg,
@@ -7078,6 +7079,12 @@ button.avtt-roll-formula-button {
 }
 .ct-sidebar__inner .glc-game-log .abovevtt-sidebar-injected *{
     color: rgb(92, 112, 128);
+}
+.glc-game-log {
+    max-width: 600px !important;
+}
+[class*="GameLogEntry-Other-Flex"] {
+    height: fit-content !important;
 }
 .glc-game-log .popout-button{
     position: relative;
@@ -14783,7 +14790,7 @@ button#displayedDiceFormulaExit:hover {
 .mobileAVTTUI #zoom_buttons{
     display: flex;
     flex-direction: column-reverse !important;
-    right: 342px !important;
+    right: calc(var(--sidebar-width, 340px) + 2px) !important;
     top:26px;
     left:unset !important;
 }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2773,6 +2773,7 @@ body:not(.encounter-builder-page) .sidebar__pane-content {
     right: 0;
     top: 28px;
     height: calc(100vh - 30px) !important;
+    width: var(--sidebar-width, 340px);
 }
 body .gamelogcontainer .sidebar__pane-content {
     top: 0px !important;

--- a/peerDice.js
+++ b/peerDice.js
@@ -26,7 +26,7 @@ function setDiceRemoteStream(stream, peerId) {
     let dicecanvas=$(`<canvas width='${video[0].videoWidth}' height='${video[0].videoHeight}' class='streamer-canvas' />`);
     dicecanvas.attr("id","streamer-canvas-"+peerId);
     //dicecanvas.css("opacity",0.5);
-    let sidebarWidth = $("#hide_rightpanel").hasClass("point-left") ? 0 : 340;
+    let sidebarWidth = $("#hide_rightpanel").hasClass("point-left") ? 0 : get_sidebar_width();
  
     dicecanvas.css({
         "position": "fixed",
@@ -56,7 +56,7 @@ function setDiceRemoteStream(stream, peerId) {
     
     video.off('resize.dice').on("resize.dice", function(){
         let videoAspectRatio = video[0].videoWidth / video[0].videoHeight
-        sidebarWidth = $("#hide_rightpanel").hasClass("point-left") ? 0 : 340;
+        sidebarWidth = $("#hide_rightpanel").hasClass("point-left") ? 0 : get_sidebar_width();
 
         if (video[0].videoWidth > video[0].videoHeight)
         {


### PR DESCRIPTION
## Summary
- Sidebar width was hardcoded at 340px across 21 locations in 6 files
- Adds a drag handle on the left edge of the sidebar so DMs and players can resize it between 340px and 600px
- Width persists globally across sessions via the existing settings system (also exposed as a slider in the Settings panel under UI)

## Changes
- `Main.js` — `get_sidebar_width()` / `apply_sidebar_width()` / `init_sidebar_resize_handle()` helpers; all hardcoded `340` literals replaced
- `Settings.js` — new `sidebarWidth` rangeInput setting (340–600px, global)
- `abovevtt.css` — `#avtt-sidebar-resize-handle` drag handle styles; all hardcoded `width: 340px` replaced with `var(--sidebar-width, 340px)` including `#sheet`
- `CoreFunctions.js`, `ScenesPanel.js`, `Startup.mjs`, `peerDice.js` — mechanical substitutions

## Backward compatibility
- Default is 340px — sessions without the setting stored behave identically to before
- Minimum enforced at 340px, maximum at 600px

## Test plan
- [ ] Drag the left edge of the sidebar — confirm it resizes smoothly between 340px and 600px
- [ ] Reload the page — confirm the width is restored from the previous session
- [ ] Check Settings panel (UI section) — confirm the Sidebar Width slider appears and works
- [ ] Hide and re-show the sidebar — confirm the hide/show animation matches the current width
- [ ] Open a stat block or character sheet as DM — confirm `#sheet` spawns flush against the sidebar, not overlapping it
- [ ] Test on characters page — confirm character sheet layout adjusts correctly at wider sidebar widths
- [ ] Test dice rolling — confirm dice canvas stays correctly positioned and sized

Resolves #988