### PR TITLE
Fix: stop scene loading in reset_canvas when scene map has 0 dimensions

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1426,6 +1426,16 @@ function reset_canvas(apply_zoom=true) {
 	const sceneMapWidth = $("#scene_map").width();
 	const sceneMapHeight = $("#scene_map").height();
 
+	if (sceneMapWidth === 0 || sceneMapHeight === 0) {
+		showErrorMessage('No scene map link found. Please check your scene settings');
+		set_default_vttwrapper_size();
+		$('#loadingStyles').remove();
+		$('.import-loading-indicator').remove();
+		remove_loading_overlay();
+		delete window.LOADING;
+		return;
+	}
+
 	$('#darkness_layer').css({"width": sceneMapWidth, "height": sceneMapHeight});
 	$("#scene_map_container").css({"width": sceneMapWidth, "height": sceneMapHeight});
 	// grid overlay css tiling needs a container to fill that matches map

--- a/Fog.js
+++ b/Fog.js
@@ -1426,14 +1426,14 @@ function reset_canvas(apply_zoom=true) {
 	const sceneMapWidth = $("#scene_map").width();
 	const sceneMapHeight = $("#scene_map").height();
 
-	if (sceneMapWidth === 0 || sceneMapHeight === 0) {
-		showErrorMessage('No scene map link found. Please check your scene settings');
+	if (!sceneMapWidth || !sceneMapHeight) {
+		showErrorMessage("Error loading scene.", `<p>Possible issues:</p>• The scene map link may be blank<br>• If using a video map ensure the "video map" toggle is enabled<br>• The file may not be publicly accessible (check share settings on host)<br>• The host may have rate limits on file access`);
 		set_default_vttwrapper_size();
 		$('#loadingStyles').remove();
 		$('.import-loading-indicator').remove();
 		remove_loading_overlay();
 		delete window.LOADING;
-		return;
+		return false;
 	}
 
 	$('#darkness_layer').css({"width": sceneMapWidth, "height": sceneMapHeight});
@@ -1464,7 +1464,7 @@ function reset_canvas(apply_zoom=true) {
 	if (!window.FOG_OF_WAR) {
 		const canvas = document.getElementById("fog_overlay");
 		canvas.getContext("2d").clearRect(0, 0, canvas.width, canvas.height);
-		return;
+		return true;
 	}
 
 	setVisionLightOffscreenCanvas(); //adding this here as it was previously being done every fill causing webgl issues
@@ -1501,7 +1501,7 @@ function reset_canvas(apply_zoom=true) {
 	if(apply_zoom)
 		apply_zoom_from_storage();
 	redraw_text();
-	return;
+	return true;
 }
 function check_darkness_value(){
 	

--- a/MessageBroker.js
+++ b/MessageBroker.js
@@ -1716,7 +1716,8 @@ class MessageBroker {
 				$("#VTT").css("--scene-scale", scaleFactor)
 				window.CURRENT_SCENE_DATA.width = mapWidth;
 				window.CURRENT_SCENE_DATA.height = mapHeight;
-				await reset_canvas(false);
+				const continueLoading = await reset_canvas(false);
+				if(!continueLoading) return;
 
 				if(!isSameTokenLight){
 					for(let i in window.TOKEN_OBJECTS){
@@ -1907,7 +1908,12 @@ class MessageBroker {
 						}
 
 
-						await reset_canvas();
+						const continueLoading = await reset_canvas();
+						if(!continueLoading){
+							console.groupEnd();
+							window.MB.loadNextScene();
+							return;
+						}
         				await set_default_vttwrapper_size();
 						$('.import-loading-indicator .percentageLoaded').css('width', `20%`);	
 						remove_loading_overlay();

--- a/ScenesHandler.js
+++ b/ScenesHandler.js
@@ -440,7 +440,8 @@ class ScenesHandler { // ONLY THE DM USES THIS OBJECT
 		load_scenemap(map_url, map_is_video, window.CURRENT_SCENE_DATA.width, window.CURRENT_SCENE_DATA.height, window.CURRENT_SCENE_DATA.UVTTFile, async function() {
 			$("#scene_map").off("load");
 			delete window.LOADING;
-			await reset_canvas();
+			const continueLoading = await reset_canvas();
+			if(!continueLoading) return;
 			await set_default_vttwrapper_size()
 			align_grid(false, false, copiedSceneData);
 			window.WeatherOverlay.stop();


### PR DESCRIPTION
Fixes #4264

## The Bug

When a scene has no image (empty map URL), `reset_canvas` receives 0x0 dimensions from `#scene_map`. This cascades into `redraw_drawn_light()` → `new OffscreenCanvas(0, 0)` → `drawImage` crash:

```
InvalidStateError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D':
The image argument is an OffscreenCanvas element with a width or height of 0.
```

The crash path: DM creates/switches to empty scene → edits settings (e.g. enables Fog of War) → `handleScene` takes the `isSameScaleAndMaps` fast path → `reset_canvas(false)` → crash.

PR #4272 (merged) guards the crash site in `redraw_drawn_light`, but as noted, that leaves the scene in a broken state where drawn light never renders.

## The Fix

Early return in `reset_canvas` when `sceneMapWidth` or `sceneMapHeight` is 0:
- Shows `showErrorMessage('No scene map link found. Please check your scene settings')`
- Cleans up loading state (`set_default_vttwrapper_size`, loading overlays, `window.LOADING`)
- Returns before any canvas operations

## Why This Works

Catching at `reset_canvas` prevents all downstream draw functions (`redraw_light_walls`, `redraw_drawings`, `redraw_drawn_light`, `redraw_fog`, `redraw_elev`) from operating on 0-dimension canvases. The loading cleanup prevents the UI from getting stuck if this triggers during initial scene load.

Follows Azmoria's guidance in #4264: catch in `reset_canvas`, show error, stop loading to prevent downstream vision check errors.

## Chrome Verified

1. Created empty scene (no image), enabled Fog of War, saved → error banner with friendly message, no crash
2. Switched to scene with image → loaded normally, no errors
3. Console: zero `drawImage` errors, only our `showErrorMessage` logged

## Files Changed

- `Fog.js` — 10-line guard in `reset_canvas`