### PR TITLE
Fix: replace blocking confirm() in map_load_error_cb with non-blocking banner

### DIFF
--- a/CoreFunctions.js
+++ b/CoreFunctions.js
@@ -1498,30 +1498,22 @@ function showErrorMessage(error, ...extraInfo) {
   
   const extraStrings = extraInfo.map(ei => {
     if (typeof ei === "object") {
-      if(JSON.stringify(ei).length>300)
-        return JSON.stringify(ei).substr(0, 300) + "...";
-      else
-        return JSON.stringify(ei)
+      return JSON.stringify(ei)
     } else {
-      if(ei?.toString().length>300)
-        return ei?.toString().substr(0, 300) + "...";
-      else
-        return ei?.toString()
+      return ei?.toString()
     }
   }).join('<br />');
   if(typeof error.message == 'object'){
     error.message = JSON.strigify(error.message);
   }
   let container = $("#above-vtt-error-message");
-  if(error.message.length > 300)
-    error.message = error.message.substr(0, 300) + "...";
   if ($('#error-message-stack').length == 0) {
     $("#above-vtt-error-message").remove();
     const container = $(`
       <div id="above-vtt-error-message">
         <h2>An unexpected error occurred!</h2>
         <h3 id="error-message">${error.message}</h3>
-        <div id="error-message-details">${extraStrings}</div>
+        <div id="error-message-details" style="max-height: 200px; overflow-y: auto;">${extraStrings}</div>
         <pre id="error-message-stack" style='max-height: 200px;'>${error.message}<br/>${extraStrings}</pre>
         <div id="error-github-issue"></div>
         <div class="error-message-buttons">

--- a/Main.js
+++ b/Main.js
@@ -437,14 +437,14 @@ function map_load_error_cb(e) {
 	$('#loadingStyles').remove();
 	console.error("map_load_error_cb src", src, e);
 	if (typeof src === "string") {
-		let specificMessage = `Please make sure the image is accessible to anyone on the internet.`;
 		if (src.includes("drive.google") || window.CURRENT_SCENE_DATA.map.includes("drive.google")) {
 			showGoogleDriveWarning();
 		}
-		else if (confirm(`Map could not be loaded!\n${specificMessage}\nYou may also need to disable ad blockers.\nWould you like to try loading the image in a separate tab to verify that it's accessible? If you are currently logged in to google, you will need to log out or open the image in a different browser or an incognito window to truly test it.`)) {
-			if (window.DM || confirm(`SPOILER ALERT!!!\nIf you click OK, you might see the entire map without fog of war. However, the map isn't loading at all so you will probably see a broken link. Are you sure you want to test this image?`)) {
-				window.open(window.CURRENT_SCENE_DATA.map, '_blank');
-			}
+		else {
+			let mapUrl = window.CURRENT_SCENE_DATA?.map || '';
+			let spoilerWarning = !window.DM ? '<br><b>Spoiler warning:</b> clicking this link may reveal the scene image if it is only failing to load in AboveVTT.<br>' : '';
+			let openLink = mapUrl ? `${spoilerWarning}<br><a target="_blank" href="${mapUrl}">Open map image in new tab</a>` : '';
+			showErrorMessage("Map could not be loaded.", `<p>Possible issues:</p>• The map URL may be blank or invalid<br>• If using a video map ensure the "video map" toggle is enabled<br>• The file may not be publicly accessible (check share settings on the host)<br>• The host may have rate limits or has removed the file<br>• An adblocker, VPN, or content filter may be blocking the image host${openLink}`);
 		}
 	}
 	delete window.LOADING;


### PR DESCRIPTION
Fixes #4288

## The Bug

`map_load_error_cb` in `Main.js` (line 444) fires two nested native `confirm()` dialogs when a non-Google-Drive map URL fails to load. Native `confirm()` blocks the entire JS event loop — the renderer freezes, WebSocket processing pauses, queued scenes can't drain, and CDP/automation sessions hang.

Triggering scenarios: pasted link with a typo, revoked share link, host returns 404/500/rate-limited, ad/content blocker on the host, imported scene with a dead URL, blank map field.

## The Fix

**Main.js** — Replace the nested `confirm()` block with `showErrorMessage()`:
- Lists 5 realistic failure modes (blank URL, video map toggle, share settings, rate limits, adblocker/VPN/content filter)
- Adds an "Open map image in new tab" link so DMs can still debug broken URLs (matches the old `window.open()` affordance)
- Players/spectators see a spoiler warning before the link (`!window.DM` gate)
- Link is hidden when the map URL is empty (no point linking to nothing)
- Google Drive path still routes to `showGoogleDriveWarning()` — untouched
- Cleanup block (`delete window.LOADING` / `remove_loading_overlay` / `loadNextScene` / `console.groupEnd`) — untouched

**CoreFunctions.js** — Remove the 300-character truncation in `showErrorMessage()`:
- Removed 3 truncation blocks that were cutting off `extraInfo` strings, `extraInfo` objects, and `error.message` at 300 chars
- Added `max-height: 200px; overflow-y: auto` to `#error-message-details` so longer messages scroll instead of being cut off
- Per Azmoria's feedback on #4288: the current message was already being truncated in the banner (screenshot in issue)

## Why This Works

- `showErrorMessage()` is the standard non-blocking error banner used elsewhere in the codebase (Fog.js, Token.js, CharactersPage.js, TokensPanel.js)
- The scrollable container only activates when content overflows — short messages from other callers look identical
- The spoiler warning / link logic uses the same `window.DM` gate pattern used throughout AboveVTT

## Chrome-verified

Tested on unpacked fork against a test campaign with 4 simultaneous tabs:

| Tab | Banner | Spoiler Warning | Open Link | VPN | No confirm() |
|---|---|---|---|---|---|
| DM | ✅ | Hidden (correct) | ✅ href correct | ✅ | ✅ |
| Player 1 | ✅ | Shown (correct) | ✅ | ✅ | ✅ |
| Spectator | ✅ | Shown (correct) | ✅ | ✅ | ✅ |
| Player 2 | ✅ | Shown (correct) | ✅ | ✅ | ✅ |

Also tested with blank map URL — link correctly hidden, banner still shows all bullets.

## Files changed

- `Main.js` — `map_load_error_cb` (−6/+5 lines)
- `CoreFunctions.js` — `showErrorMessage` (−10/+3 lines)