### PR TITLE
QoL - scroll wheel to adjust HP and max HP in combat tracker

### DIFF
--- a/CombatTracker.js
+++ b/CombatTracker.js
@@ -1352,6 +1352,20 @@ function ct_add_token(token,persist=true,disablerolling=false, adv=false, dis=fa
 		maxhp_input.click(function(e) {
 			$(e.target).select();
 		});
+		hp_input.on('wheel', function(e) {
+			e.preventDefault();
+			const delta = e.originalEvent.deltaY < 0 ? 1 : -1;
+			const current = parseInt(token.hp) || 0;
+			$(this).val(Math.max(0, current + delta));
+			$(this).trigger('change');
+		});
+		maxhp_input.on('wheel', function(e) {
+			e.preventDefault();
+			const delta = e.originalEvent.deltaY < 0 ? 1 : -1;
+			const current = parseInt(token.maxHp) || 0;
+			$(this).val(Math.max(1, current + delta));
+			$(this).trigger('change');
+		});
 	}
 	else {
 		hp.off('click.message').on('click.message', function(){


### PR DESCRIPTION
Closes #2026

## What

Adds scroll-wheel increment/decrement to the HP and max HP inputs in the combat tracker.

- Scroll up → +1
- Scroll down → −1
- HP clamps at 0; max HP clamps at 1
- Prevents the tracker list from scrolling while the cursor is over an input (via `e.preventDefault()`)

## How

Adds two `wheel` event listeners inside the existing `!token.isPlayer()` block (lines 1355–1368), alongside the existing `change`/`click`/`keydown` handlers. Uses `token.hp` / `token.maxHp` as the source of truth so a partially-typed `+5` expression in the input field doesn't cause an off-by-one, and triggers the existing `change` event so token sync, broadcast, and HP-bar updates all fire unchanged.

Player tokens are excluded — their inputs are already `disabled` and the listeners live in the `!isPlayer()` branch, so no regression there.

No reformatting, no new dependencies, backward compatible.