### PR TITLE
Add devilsight and truesight as seperate options so you no longer need 2 tokens if a pc has 2 types of vision

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -7471,7 +7471,7 @@ function particleLook(ctx, walls, lightRadius=100000, fog=false, fogStyle, fogTy
 	let movePolygon = [];
 	let noDarknessPolygon = [];
 
-	let canSeeDarkness = (auraId !== undefined && (window.TOKEN_OBJECTS[auraId].options.sight == 'devilsight' || window.TOKEN_OBJECTS[auraId].options.sight =='truesight'));
+	let canSeeDarkness = (auraId !== undefined && (window.TOKEN_OBJECTS[auraId].options.devilsight?.feet > 0 || window.TOKEN_OBJECTS[auraId].options.truesight?.feet > 0));
 	let tokenElev = 0;
 	if(auraId !== undefined && window.TOKEN_OBJECTS[auraId].options.elev !== undefined && window.TOKEN_OBJECTS[auraId].options.elev !== '') 
 		tokenElev = parseInt(window.TOKEN_OBJECTS[auraId].options.elev)
@@ -7994,11 +7994,12 @@ function redraw_light(darknessMoved = false, limitActiveRays = 0) {
 		if (window.lineOfSightPolygons === undefined) {
 			window.lineOfSightPolygons = {};
 		}
+		const hasDevilOrTruesight = (window.TOKEN_OBJECTS[auraId].options.truesight.feet > 0 || window.TOKEN_OBJECTS[auraId].options.devilsight.feet > 0);
 		if (window.lineOfSightPolygons[auraId] !== undefined &&
 			window.lineOfSightPolygons[auraId].x === tokenPos.x &&
 			window.lineOfSightPolygons[auraId].y === tokenPos.y &&
 			window.lineOfSightPolygons[auraId].numberofwalls === allWalls.length &&
-			window.lineOfSightPolygons[auraId].visionType === window.TOKEN_OBJECTS[auraId].options.sight &&
+			window.lineOfSightPolygons[auraId].visionType === hasDevilOrTruesight &&
 			window.lineOfSightPolygons[auraId].scaleCreated === window.TOKEN_OBJECTS[auraId].options.scaleCreated &&
 			window.lineOfSightPolygons[auraId].elev === window.TOKEN_OBJECTS[auraId].options.elev &&
 			darknessMoved !== true) {
@@ -8029,19 +8030,19 @@ function redraw_light(darknessMoved = false, limitActiveRays = 0) {
 				y: tokenPos.y,
 				numberofwalls: allWalls.length,
 				clippath: pts,
-				visionType: window.TOKEN_OBJECTS[auraId].options.sight,
+				visionType: hasDevilOrTruesight,
 				scaleCreated: window.TOKEN_OBJECTS[auraId].options.scaleCreated,
 				elev: window.TOKEN_OBJECTS[auraId].options.elev
 			}
 
-			$(`.aura-element-container-clip[id='${auraId}']:not(.vision)`).css('clip-path', `polygon(${pts})`)
+			$(`.aura-element-container-clip[id='${auraId}']:is(.light, .darkvision)`).css('clip-path', `polygon(${pts})`)
 
-			if (window.lineOfSightPolygons[auraId] !== undefined && (window.TOKEN_OBJECTS[auraId].options.sight === 'devilsight' || window.TOKEN_OBJECTS[auraId].options.sight === 'truesight')) {
+			if (window.lineOfSightPolygons[auraId] !== undefined && (window.TOKEN_OBJECTS[auraId].options.devilsight?.feet > 0 || window.TOKEN_OBJECTS[auraId].options.truesight?.feet > 0)) {
 				let pts = window.noDarknessPolygon
 					.map(p => `${p.x / adjustScale}px ${p.y / adjustScale}px`)
 					.join(', ');
 				window.lineOfSightPolygons[auraId].devilsightClip = pts;
-				$(`.aura-element-container-clip[id='${auraId}'].vision`).css('clip-path', `polygon(${pts})`)
+				$(`.aura-element-container-clip[id='${auraId}'].vision:is(.devilsight, .truesight)`).css('clip-path', `polygon(${pts})`)
 
 			}
 
@@ -8051,8 +8052,11 @@ function redraw_light(darknessMoved = false, limitActiveRays = 0) {
 			clipped_light(auraId, window.lightPolygon, playerTokenId, canvasWidth, canvasHeight, darknessBoundarys, selectedIds.length);
 
 		}
-
-		let drawDarkVision = false;
+		lightInLosContext.globalCompositeOperation='lighten';
+		if (window.lightAuraClipPolygon[auraId]?.light !== undefined) {
+			clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].light2.range, window.lightAuraClipPolygon[auraId].light2.color, window.lightPolygon);
+			clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].light1.range, window.lightAuraClipPolygon[auraId].light1.color, window.lightPolygon);
+		}
 		if (selectedIds.length === 0 || found || (window.SelectedTokenVision !== true && !window.DM)) {
 
 			let hideVisionWhenNoPlayerToken = (playerTokenId === undefined && !window.TOKEN_OBJECTS[auraId].options.share_vision && !window.DM && window.TOKEN_OBJECTS[auraId].options.itemType !== 'pc')
@@ -8063,36 +8067,36 @@ function redraw_light(darknessMoved = false, limitActiveRays = 0) {
 				//when player token does not exist show vision for all pc tokens and shared vision for other tokens. Mostly used by DM's, streams and tabletop tv games.
 				//when player token does exist show your own vision and shared vision.
 				
-				if (window.noDarknessPolygon?.length>1 && (window.DM !== true || window.SelectedTokenVision === true) && (window.TOKEN_OBJECTS[auraId].options.sight === 'truesight' || window.TOKEN_OBJECTS[auraId].options.sight === 'devilsight')) {					
-					clip_circle_with_polygon(devilsightCanvasContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].darkvision, '#fff', window.noDarknessPolygon)
-					if (window.TOKEN_OBJECTS[auraId].options.sight === 'truesight') {
-						clip_circle_with_polygon(truesightCanvasContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].darkvision, '#fff', window.noDarknessPolygon)
-					}
-				}
 
-				if (window.lightAuraClipPolygon[auraId]?.darkvision !== undefined) {
-					drawDarkVision = true;
+
+				if (window.lightAuraClipPolygon[auraId]?.darkvision?.feet > 0) {
+					clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].darkvision, window.lightAuraClipPolygon[auraId].vision.color, window.lightPolygon);
 				}
 
 				$(`.aura-element-container-clip[id='${auraId}'] [id*='vision_']`).toggleClass('notVisible', false);
 			
 				drawPolygon(offscreenContext, window.lightPolygon, 'rgba(255, 255, 255, 1)', true, 2, undefined, undefined, undefined, true, true); //draw to offscreen canvas so we don't have to render every draw and use this for a mask	
 				drawPolygon(moveOffscreenCanvasMaskContext, window.movePolygon, 'rgba(255, 255, 255, 1)', true, 0, undefined, undefined, undefined, true, true); //draw to offscreen canvas so we don't have to render every draw and use this for a mask
+				if (window.noDarknessPolygon?.length>1 && (window.DM !== true || window.SelectedTokenVision === true)) {	
+					devilsightCanvasContext.globalCompositeOperation = "lighten";				
+					if (window.lightAuraClipPolygon[auraId].devilsight > 0) {
+						clip_circle_with_polygon(devilsightCanvasContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].devilsight, '#fff', window.noDarknessPolygon)
+						clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].devilsight, '#fff', window.noDarknessPolygon);
+						clip_circle_with_polygon(offscreenContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].devilsight, '#fff', window.noDarknessPolygon);
+					}
+					if (window.lightAuraClipPolygon[auraId].truesight > 0) {
+						truesightCanvasContext.globalCompositeOperation = "lighten";
+						clip_circle_with_polygon(devilsightCanvasContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].truesight, '#fff', window.noDarknessPolygon)
+						clip_circle_with_polygon(truesightCanvasContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].truesight, '#fff', window.noDarknessPolygon)
+						clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].truesight, '#fff', window.noDarknessPolygon);
+						clip_circle_with_polygon(offscreenContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].truesight, '#fff', window.noDarknessPolygon);
+					}
+				}
 			}
 		}
-		if (drawDarkVision || window.lightAuraClipPolygon[auraId]?.light !== undefined) {
-			lightInLosContext.globalCompositeOperation='lighten';
-			if (window.lightAuraClipPolygon[auraId]?.light !== undefined) {
-				clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].light2.range, window.lightAuraClipPolygon[auraId].light2.color, window.lightPolygon);
-				clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].light1.range, window.lightAuraClipPolygon[auraId].light1.color, window.lightPolygon);
-			}
-			if(drawDarkVision){
-				clip_circle_with_polygon(lightInLosContext, window.lightAuraClipPolygon[auraId].middle.x, window.lightAuraClipPolygon[auraId].middle.y, window.lightAuraClipPolygon[auraId].darkvision, window.lightAuraClipPolygon[auraId].vision.color, window.lightPolygon);
-			}
-		}
+
 	}
-	offscreenContext.globalCompositeOperation = "source-over";
-	offscreenContext.drawImage(devilsightCanvas, 0, 0);
+
 
 	const tokenObjectValues = Object.values(window.TOKEN_OBJECTS);
 	const aPlayerTokenExists = tokenObjectValues.some(d => d.options.id.startsWith('/profile'))
@@ -8122,7 +8126,7 @@ function redraw_light(darknessMoved = false, limitActiveRays = 0) {
 			lightInLosContext.drawImage(devilsightCanvas, 0, 0);		
 		}
 	}
-	if(window.CURRENT_SCENE_DATA.darkness_filter != 0){
+	else {
 		lightInLosContext.globalCompositeOperation='lighten';	
 		lightInLosContext.drawImage($('#light_overlay')[0], 0, 0);
 		
@@ -8245,7 +8249,7 @@ function getTokenVision(tokenId, darknessMoved){
 		visionType: window.TOKEN_OBJECTS[tokenId].options.sight,
 		scaleCreated: window.TOKEN_OBJECTS[tokenId].options.scaleCreated
 	}
-	if(window.lineOfSightPolygons[tokenId] !== undefined &&(window.TOKEN_OBJECTS[tokenId].options.sight === 'devilsight' || window.TOKEN_OBJECTS[tokenId].options.sight === 'truesight')){
+	if(window.lineOfSightPolygons[tokenId] !== undefined &&(window.TOKEN_OBJECTS[tokenId].options.devilsight?.feet > 0 || window.TOKEN_OBJECTS[tokenId].options.truesight?.feet > 0)){
 		let path = "";
 		for (let i = 0; i < window.noDarknessPolygon.length; i++){
 			path += (i && "L" || "M") + window.noDarknessPolygon[i].x / adjustScale + ',' + window.noDarknessPolygon[i].y/adjustScale
@@ -8437,6 +8441,10 @@ function clipped_light(auraId, maskPolygon, playerTokenId, canvasWidth = getScen
 	
 	let visionColor = `rgba(0,0,0,0)`;
 	let visionRange = 0;
+	let devilsightColor = `rgba(0,0,0,0)`;
+	let devilsightRange = 0;
+	let truesightColor = `rgba(0,0,0,0)`;
+	let truesightRange = 0;
 	let light1Color = `rgba(0,0,0,0)`;
 	let light2Color = `rgba(0,0,0,0)`;
 	let light1Range = 0;
@@ -8444,6 +8452,8 @@ function clipped_light(auraId, maskPolygon, playerTokenId, canvasWidth = getScen
 	let blackLight1 = 1;
 	let blackLight2 = 1;
 	let blackVision = 1;
+	let blackDevilsight = 1;
+	let blackTruesight = 1;
 
 	if(window.TOKEN_OBJECTS[auraId] !== undefined){
 		if(window.TOKEN_OBJECTS[auraId].options.vision !== undefined){
@@ -8452,6 +8462,20 @@ function clipped_light(auraId, maskPolygon, playerTokenId, canvasWidth = getScen
 
 			if(window.TOKEN_OBJECTS[auraId].options.vision.feet !== undefined)
 				visionRange = window.TOKEN_OBJECTS[auraId].options.vision.feet;
+		}
+		if(window.TOKEN_OBJECTS[auraId].options.devilsight !== undefined){
+			if(window.TOKEN_OBJECTS[auraId].options.devilsight.color !== undefined)
+				devilsightColor =  window.TOKEN_OBJECTS[auraId].options.devilsight.color;
+
+			if(window.TOKEN_OBJECTS[auraId].options.devilsight.feet !== undefined)
+				devilsightRange = window.TOKEN_OBJECTS[auraId].options.devilsight.feet;
+		}
+		if(window.TOKEN_OBJECTS[auraId].options.truesight !== undefined){
+			if(window.TOKEN_OBJECTS[auraId].options.truesight.color !== undefined)
+				truesightColor =  window.TOKEN_OBJECTS[auraId].options.truesight.color;
+
+			if(window.TOKEN_OBJECTS[auraId].options.truesight.feet !== undefined)
+				truesightRange = window.TOKEN_OBJECTS[auraId].options.truesight.feet;
 		}
 		if(window.TOKEN_OBJECTS[auraId].options.light1 !== undefined){
 			if(window.TOKEN_OBJECTS[auraId].options.light1.color !== undefined)
@@ -8477,22 +8501,31 @@ function clipped_light(auraId, maskPolygon, playerTokenId, canvasWidth = getScen
 	if(visionColor.match(/rgba\(0, 0, 0.*/g) !== null)
 		blackVision = 0;
 
+	if(devilsightColor.match(/rgba\(0, 0, 0.*/g) !== null)
+		blackDevilsight = 0;
 
-	let lightRadius = ((parseFloat(light1Range) * blackLight1) + (parseFloat(light2Range)*blackLight2))*window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.fpsq 
+	if(truesightColor.match(/rgba\(0, 0, 0.*/g) !== null)
+		blackTruesight = 0;
+
+
+	const lightRadius = ((parseFloat(light1Range) * blackLight1) + (parseFloat(light2Range)*blackLight2))*window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.fpsq 
 	let darkvisionRadius = parseFloat(visionRange)*window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.fpsq*blackVision;
-	
+	let devilsightRadius = parseFloat(devilsightRange)*window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.fpsq*blackDevilsight;
+	let truesightRadius = parseFloat(truesightRange)*window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.fpsq*blackTruesight;
+
+
 	const selectedTokenCheck = numberOfSharedVisionTokens == 0 || (window.SelectedTokenVision !== true || window.CURRENTLY_SELECTED_TOKENS.includes(auraId) || window.CURRENTLY_SELECTED_TOKENS.length===0)
 
 	let circleRadius = 0
-
-	if(lightRadius > darkvisionRadius)
-		circleRadius = lightRadius;
-	else if (selectedTokenCheck === true && (window.DM === true || window.TOKEN_OBJECTS[auraId].options.share_vision === true || window.TOKEN_OBJECTS[auraId].options.share_vision == window.myUser || (window.TOKEN_OBJECTS[auraId].options.share_vision && is_spectator_page()) || auraId.includes(window.PLAYER_ID) || (window.TOKEN_OBJECTS[auraId].options.itemType === 'pc' && playerTokenId === undefined)))
-		circleRadius = darkvisionRadius;
-	else if(lightRadius > 0)
+	const largest = Math.max(lightRadius, darkvisionRadius, devilsightRadius, truesightRadius);
+	if (selectedTokenCheck === true && (window.DM === true || window.TOKEN_OBJECTS[auraId].options.share_vision === true || window.TOKEN_OBJECTS[auraId].options.share_vision == window.myUser || (window.TOKEN_OBJECTS[auraId].options.share_vision && is_spectator_page()) || auraId.includes(window.PLAYER_ID) || (window.TOKEN_OBJECTS[auraId].options.itemType === 'pc' && playerTokenId === undefined)))
+		circleRadius = largest;
+	else if(lightRadius >= 0)
 		circleRadius = lightRadius;
 	
 	darkvisionRadius += (window.TOKEN_OBJECTS[auraId].options.size / 2);
+	devilsightRadius += (window.TOKEN_OBJECTS[auraId].options.size / 2);
+	truesightRadius += (window.TOKEN_OBJECTS[auraId].options.size / 2);
 	let horizontalTokenMiddle = (parseInt(window.TOKEN_OBJECTS[auraId].options.left) + (window.TOKEN_OBJECTS[auraId].options.size / 2));
 	let verticalTokenMiddle = (parseInt(window.TOKEN_OBJECTS[auraId].options.top) + (window.TOKEN_OBJECTS[auraId].options.size / 2));
 	if(window.TOKEN_OBJECTS[auraId].options.type == 'door' && window.TOKEN_OBJECTS[auraId].options.scaleCreated){
@@ -8504,7 +8537,7 @@ function clipped_light(auraId, maskPolygon, playerTokenId, canvasWidth = getScen
 			delete window.lightAuraClipPolygon[auraId];
 			return; // remove 0 range light and return
 		}
-		if(!window.SelectedTokenVision && window.lightAuraClipPolygon[auraId].numberOfWalls == walls.length+darknessBoundarys.length+tokenWalls.length && window.lightAuraClipPolygon[auraId].light == lightRadius && window.lightAuraClipPolygon[auraId].darkvision == darkvisionRadius && window.lightAuraClipPolygon[auraId].middle.x == horizontalTokenMiddle && window.lightAuraClipPolygon[auraId].middle.y == verticalTokenMiddle)
+		if(!window.SelectedTokenVision && window.lightAuraClipPolygon[auraId].numberOfWalls == walls.length+darknessBoundarys.length+tokenWalls.length && window.lightAuraClipPolygon[auraId].light == lightRadius && window.lightAuraClipPolygon[auraId].devilsight == devilsightRadius && window.lightAuraClipPolygon[auraId].truesight == truesightRadius && window.lightAuraClipPolygon[auraId].darkvision == darkvisionRadius && window.lightAuraClipPolygon[auraId].middle.x == horizontalTokenMiddle && window.lightAuraClipPolygon[auraId].middle.y == verticalTokenMiddle)
 			return; // token settings and position have not changed - a lot of light will be stationary do not redraw checker canvas
 	}
 	else if(circleRadius === 0){
@@ -8516,6 +8549,8 @@ function clipped_light(auraId, maskPolygon, playerTokenId, canvasWidth = getScen
 	window.lightAuraClipPolygon[auraId] = {
 		light: lightRadius,
 		darkvision: darkvisionRadius,
+		devilsight: devilsightRadius,
+		truesight: truesightRadius,
 		light1: {
 			range: light1Range > 0 ? light1Range * window.CURRENT_SCENE_DATA.hpps / window.CURRENT_SCENE_DATA.fpsq + (window.TOKEN_OBJECTS[auraId].options.size / 2) : 0,
 			color: light1Color
@@ -8527,6 +8562,14 @@ function clipped_light(auraId, maskPolygon, playerTokenId, canvasWidth = getScen
 		vision: {
 			range: darkvisionRadius,
 			color: visionColor
+		},
+		devilsightVision: {
+			range: devilsightRadius,
+			color: devilsightColor
+		},
+		truesightVision: {
+			range: darkvisionRadius,
+			color: truesightColor
 		},
 		middle: {
 			x: horizontalTokenMiddle,

--- a/KeypressHandler.js
+++ b/KeypressHandler.js
@@ -1,8 +1,6 @@
 var altHeld = false;
 var ctrlHeld = false;
 var shiftHeld = false;
-var cursor_x = -1;
-var cursor_y = -1;
 var arrowKeysHeld = [0, 0, 0, 0];
 
 const sb_scroll_style = "avtt-scroll-hidden"
@@ -602,11 +600,6 @@ Mousetrap.bind('mod+a', function (e) {
     }
 });
 
-document.onmousemove = function(event)
-{
- window.cursor_x = event.pageX;
- window.cursor_y = event.pageY;
-}
 
 Mousetrap.bind(['backspace', 'del'], function(e) {
     delete_selected_tokens();

--- a/Main.js
+++ b/Main.js
@@ -2461,23 +2461,32 @@ function init_ui() {
 			}
 		}
 	}
-
+	function set_paste_location(event){
+		window.cursor_x = event.pageX;
+		window.cursor_y = event.pageY;
+	}
+	function enable_paste_mouse_move(){
+		document.addEventListener('mousemove', set_paste_location, { passive: true });
+	}
+	function disable_paste_mouse_move(){
+		document.removeEventListener('mousemove', set_paste_location);
+	}
 	// Helper function to disable window mouse handlers, required when we
 	// do token dragging operations with measure paths
 	window.disable_window_mouse_handlers = function () {
-
 		$(window.document).off("mousemove.mouseHandler", mousemove);
 		$(window.document).off("mousedown.mouseHandler", mousedown);
 		$(window.document).off("mouseup.mouseHandler", mouseup);
+		disable_paste_mouse_move();
 	}
 
 	// Helper function to enable mouse handlers, required when we
 	// do token dragging operations with measure paths
 	window.enable_window_mouse_handlers = function () {
-
 		$(window.document).on("mousemove.mouseHandler", mousemove);
 		$(window.document).on("mousedown.mouseHandler", mousedown);
 		$(window.document).on("mouseup.mouseHandler", mouseup);
+		enable_paste_mouse_move();
 	}
 
 	window.enable_window_mouse_handlers();

--- a/MonsterStatBlock.js
+++ b/MonsterStatBlock.js
@@ -1763,6 +1763,39 @@ class MonsterStatBlock {
     }
 }
 
+function get_monster_senses(senses, vision = {darkvision: 0, devilsight: 0, truesight: 0}){
+    if(senses.length > 0){
+      const monsterSenseIds = {
+        1 : 'truesight', //blind sight
+        2 : 'darkvision',
+        4 : 'truesight'
+      }	
+      for(let i=0; i < senses.length; i++){
+        const senseKey = senses[i].senseId;
+    
+        const ftPosition = senses[i].notes.indexOf('ft.')
+        
+        const range = parseInt(senses[i].notes.slice(0, ftPosition));
+        if(monsterSenseIds[senseKey] == undefined && range>darkvision){
+          vision.darkvision = range;
+        } else{
+          if(monsterSenseIds[senseKey] == 'darkvision'){
+            const isDevilsight = senses[i].notes.match(/magical darkness|devil'?\s?s?sight/gi);
+            if(isDevilsight){
+              vision.devilsight = range;
+              continue;
+            }
+              
+          }
+          vision[monsterSenseIds[senseKey]] = range;
+        }
+          
+      }
+    }
+    return vision;
+  
+}
+
 const hidemeHack = "<span class='hideme'></span>";
 
 // not sure where to find these, but I've reversed engineered it by looking at this.data.damageAdjustments and window.ddbConfigJson.damageAdjustments

--- a/Settings.js
+++ b/Settings.js
@@ -496,10 +496,14 @@ function avtt_settings() {
 								delete window.TOKEN_SETTINGS[name];
 							}
 						}, function() {
-							let visionInput = $("input[name='visionColor']").spectrum("get");
-			   				let light1Input = $("input[name='light1Color']").spectrum("get");
-			    			let light2Input = $("input[name='light2Color']").spectrum("get");
-			        		
+							const devilsightInput = $("input[name='devilsightColor']").spectrum("get");
+							const truesightInput = $("input[name='truesightColor']").spectrum("get");
+							const visionInput = $("input[name='visionColor']").spectrum("get");
+			   				const light1Input = $("input[name='light1Color']").spectrum("get");
+			    			const light2Input = $("input[name='light2Color']").spectrum("get");
+
+			        		window.TOKEN_SETTINGS.devilsight.color= `rgba(${devilsightInput._r}, ${devilsightInput._g}, ${devilsightInput._b}, ${devilsightInput._a})`;
+							window.TOKEN_SETTINGS.truesight.color= `rgba(${truesightInput._r}, ${truesightInput._g}, ${truesightInput._b}, ${truesightInput._a})`;
 			        		window.TOKEN_SETTINGS.vision.color= `rgba(${visionInput._r}, ${visionInput._g}, ${visionInput._b}, ${visionInput._a})`;
 			   				window.TOKEN_SETTINGS.light1.color = `rgba(${light1Input._r}, ${light1Input._g}, ${light1Input._b}, ${light1Input._a})`;
 			    			window.TOKEN_SETTINGS.light2.color = `rgba(${light2Input._r}, ${light2Input._g}, ${light2Input._b}, ${light2Input._a})`;
@@ -1438,18 +1442,33 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 
 
 	if(showExtraOptions){
-		
+		window.TOKEN_SETTINGS.truesight = (window.TOKEN_SETTINGS?.truesight) ? window.TOKEN_SETTINGS.truesight : {color: 'rgba(142, 142, 142, 1)'};
+		window.TOKEN_SETTINGS.devilsight = (window.TOKEN_SETTINGS?.devilsight) ? window.TOKEN_SETTINGS.devilsight : {color: 'rgba(142, 142, 142, 1)'};
 	    window.TOKEN_SETTINGS.vision = (window.TOKEN_SETTINGS?.vision) ? window.TOKEN_SETTINGS.vision : {color: 'rgba(142, 142, 142, 1)'};
 	    window.TOKEN_SETTINGS.light1 = (window.TOKEN_SETTINGS?.light1) ? window.TOKEN_SETTINGS.light1 : {color: 'rgba(255, 255, 255, 1)'};
 	   	window.TOKEN_SETTINGS.light2 = (window.TOKEN_SETTINGS?.light2) ? window.TOKEN_SETTINGS.light2 : {color: 'rgba(142, 142, 142, 1)'};
 	
 
 	    let lightInputs = `<div class="token-image-modal-footer-select-wrapper">
-	                    <div class="token-image-modal-footer-title">Darkvision Color</div>
+					<div class="token-image-modal-footer-title">Darkvision Color</div>
 	                    <div style="padding-left: 2px">
 	                        <input class="spectrum" name="visionColor" value="${window.TOKEN_SETTINGS.vision.color}" >
 	                    </div>
 	                </div>
+					<div class="token-image-modal-footer-select-wrapper">
+						<div class="token-image-modal-footer-title">Devilsight Color</div>
+							<div style="padding-left: 2px">
+								<input class="spectrum" name="devilsightColor" value="${window.TOKEN_SETTINGS.devilsight.color}" >
+							</div>
+						</div>
+					</div>
+					<div class="token-image-modal-footer-select-wrapper">
+						<div class="token-image-modal-footer-title">True Color</div>
+							<div style="padding-left: 2px">
+								<input class="spectrum" name="truesightColor" value="${window.TOKEN_SETTINGS.truesight.color}" >
+							</div>
+						</div>
+					</div>
 	                <div class="token-image-modal-footer-select-wrapper">
 	                    <div class="token-image-modal-footer-title">Inner Light Color</div>
 	                    <div style="padding-left: 2px">
@@ -1473,6 +1492,8 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 	        clickoutFiresChange: true,
 	        appendTo: "parent"
 	    });
+		container.find("input[name='devilsightColor']").spectrum("set", window.TOKEN_SETTINGS.devilsight.color);
+		container.find("input[name='truesightColor']").spectrum("set", window.TOKEN_SETTINGS.truesight.color);
 		container.find("input[name='visionColor']").spectrum("set", window.TOKEN_SETTINGS.vision.color);
 	    container.find("input[name='light1Color']").spectrum("set", window.TOKEN_SETTINGS.light1.color);
 	    container.find("input[name='light2Color']").spectrum("set", window.TOKEN_SETTINGS.light2.color);
@@ -1532,15 +1553,17 @@ function build_sidebar_token_options_flyout(availableOptions, setValues, updateV
 
 			let defaultTokenOptions = default_options();
 
-			if(showExtraOptions == true){
-				$("input[name='visionColor']").spectrum("set", defaultTokenOptions.light2.color);
+			if(showExtraOptions == true){	
 			    $("input[name='light1Color']").spectrum("set", defaultTokenOptions.light1.color);
-			    $("input[name='light2Color']").spectrum("set", defaultTokenOptions.light2.color);
+			    $("input[name='light2Color'], input[name='visionColor'], input[name='devilsightColor'], input[name='truesightColor']").spectrum("set", defaultTokenOptions.light2.color);
 			}
 			else{
+				$("input[name='devilsightColor']").spectrum("set", ((window.TOKEN_SETTINGS?.devilsight?.color) ? window.TOKEN_SETTINGS.devilsight.color : defaultTokenOptions.light2.color));
+				$("input[name='truesightColor']").spectrum("set", ((window.TOKEN_SETTINGS?.truesight?.color) ? window.TOKEN_SETTINGS.truesight.color : defaultTokenOptions.light2.color));
 				$("input[name='visionColor']").spectrum("set", ((window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : defaultTokenOptions.light2.color));
 			    $("input[name='light1Color']").spectrum("set", ((window.TOKEN_SETTINGS?.light1?.color) ? window.TOKEN_SETTINGS.light1.color : defaultTokenOptions.light1.color));
 			    $("input[name='light2Color']").spectrum("set", ((window.TOKEN_SETTINGS?.light2?.color) ? window.TOKEN_SETTINGS.light2.color : defaultTokenOptions.light2.color));
+				
 			}
 
 

--- a/Token.js
+++ b/Token.js
@@ -2146,27 +2146,32 @@ class Token {
 				color: (window.TOKEN_SETTINGS?.light2?.color) ? window.TOKEN_SETTINGS.light2.color : 'rgba(142, 142, 142, 1)'
 			}
 		}
-		if(this.options.vision?.feet == undefined){
-			//TO DO VISION UPDATE: get each vision type seperately from darkvision
-			if(this.isPlayer()){
-				
-				let pcData = find_pc_by_player_id(this.options.id, false);
-				let darkvision = 0;
-				if(pcData && pcData.senses.length > 0) {
-						for(let i=0; i < pcData.senses.length; i++){
-							const ftPosition = pcData.senses[i].distance.indexOf('ft.');
-							const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
-							if(range > darkvision)
-								darkvision = range;
-						}
-				}
-				this.options.vision = {
-					feet: darkvision.toString(),
-					color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
-				}
+
+
+		let vision = {
+			darkvision: 0,
+			devilsight: 0,
+			truesight: 0
+		}
+
+		if(this.isPlayer()){		
+			let pcData = find_pc_by_player_id(this.options.id, false);
+			if(pcData && pcData.senses.length > 0) {
+					const pcSenses = {
+						darkvision: "darkvision",
+						tremorsense: "darkvision",
+						blindsight: "truesight",
+						truesight: "truesight"
+					}
+					for(let i=0; i < pcData.senses.length; i++){
+						const name = pcData.senses[i].name?.toLowerCase();
+						const ftPosition = pcData.senses[i].distance.indexOf('ft.');
+						const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
+						if(range > vision[pcSenses[name]])
+							vision[pcSenses[name]] = range;
+					}
 			}
 			else if(this.isMonster()){
-				let darkvision = 0;
 				if(window.monsterListItems){
 					let monsterSidebarListItem = this.options.monster == "open5e" ? window.open5eListItems.filter((d) => this.options.itemId == d.id)[0] : window.monsterListItems.filter((d) => this.options.monster == d.id)[0] ;	
 					if(!monsterSidebarListItem){
@@ -2177,46 +2182,33 @@ class Token {
 							}
 						}
 					}
-						
+					
 					if(monsterSidebarListItem){
-						if(monsterSidebarListItem.monsterData.senses.length > 0){
-							for(let i=0; i < monsterSidebarListItem.monsterData.senses.length; i++){
-								const ftPosition = monsterSidebarListItem.monsterData.senses[i].notes.indexOf('ft.')
-								const range = parseInt(monsterSidebarListItem.monsterData.senses[i].notes.slice(0, ftPosition));
-								if(range > darkvision)
-									darkvision = range;
-							}
-						}
+						vision = get_monster_senses(monsterSidebarListItem.monsterData.senses)
 					}
 				} 
+			}
+
+			if(this.options.vision?.feet == undefined){
 				this.options.vision = {
-					feet: darkvision.toString(),
+					feet: vision.darkvision.toString(),
 					color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
 				}
 			}
-			else{
-				this.options.vision = {
-					feet: 60,
-					color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+			if(this.options.truesight?.feet == undefined){
+				this.options.truesight = {
+					feet: vision.truesight.toString(),
+					color: (window.TOKEN_SETTINGS?.truesight?.color) ? window.TOKEN_SETTINGS.truesight.color : 'rgba(142, 142, 142, 1)'
 				}
-			
+			}
+			if(this.options.devilsight?.feet == undefined){
+				this.options.devilsight = {
+					feet: vision.devilsight.toString(),
+					color: (window.TOKEN_SETTINGS?.devilsight?.color) ? window.TOKEN_SETTINGS.devilsight.color : 'rgba(142, 142, 142, 1)'
+				}
 			}
 		}
 
-		if(this.options.devilsight?.feet == undefined){
-		//TO DO VISION UPDATE: get each vision type seperately from darkvision above, update color with TOKEN_SETTINGS
-			this.options.devilsight = {
-				feet: 0,
-				color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
-			}
-		}
-		if(this.options.truesight?.feet == undefined){
-			//TO DO VISION UPDATE: get each vision type seperately from darkvision above, update color with TOKEN_SETTINGS
-			this.options.truesight = {
-				feet: 0,
-				color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
-			}
-		}
 	}
 	place(animationDuration) {
 		try{

--- a/Token.js
+++ b/Token.js
@@ -2105,7 +2105,7 @@ class Token {
 			const tokMidLeft = Math.round(tokenX) + parseFloat(token.sizeWidth())/2
 			const tokMidTop = Math.round(tokenY) + parseFloat(token.sizeHeight())/2
 			const idReplaced = token.options.id.replaceAll("/", "");
-			let selEl = $(`#aura_${idReplaced}, #light_${idReplaced}, #vision_${idReplaced}, [data-darkness='darkness_${idReplaced}']`);
+			let selEl = $(`#aura_${idReplaced}, #light_${idReplaced}, #vision_${idReplaced}, #vision_devilsight_${idReplaced}, #vision_truesight_${idReplaced}, [data-darkness='darkness_${idReplaced}']`);
 			selEl.each((i, el) => {
 				const $el = $(el);
 				const selElWidth = parseFloat($el.css('width')) / 2;
@@ -2130,6 +2130,91 @@ class Token {
 			return false;
 		}			
 	}	
+	assignLightVisionOptions(){
+		if(this.options.light1?.feet == undefined){
+			this.options.light1 ={
+				feet: 0,
+				color: (window.TOKEN_SETTINGS?.light1?.color) ? window.TOKEN_SETTINGS.light1.color : 'rgba(255, 255, 255, 1)'
+			}
+		}
+		if(this.options.light2?.feet == undefined){
+			this.options.light2 = {
+				feet: 0,
+				color: (window.TOKEN_SETTINGS?.light2?.color) ? window.TOKEN_SETTINGS.light2.color : 'rgba(142, 142, 142, 1)'
+			}
+		}
+		if(this.options.vision?.feet == undefined){
+			//TO DO VISION UPDATE: get each vision type seperately from darkvision
+			if(this.isPlayer()){
+				
+				let pcData = find_pc_by_player_id(this.options.id, false);
+				let darkvision = 0;
+				if(pcData && pcData.senses.length > 0) {
+						for(let i=0; i < pcData.senses.length; i++){
+							const ftPosition = pcData.senses[i].distance.indexOf('ft.');
+							const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
+							if(range > darkvision)
+								darkvision = range;
+						}
+				}
+				this.options.vision = {
+					feet: darkvision.toString(),
+					color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+				}
+			}
+			else if(this.isMonster()){
+				let darkvision = 0;
+				if(window.monsterListItems){
+					let monsterSidebarListItem = this.options.monster == "open5e" ? window.open5eListItems.filter((d) => this.options.itemId == d.id)[0] : window.monsterListItems.filter((d) => this.options.monster == d.id)[0] ;	
+					if(!monsterSidebarListItem){
+						for(let i in encounter_monster_items){
+							if(encounter_monster_items[i].some((d) => this.options.monster == d.id)){
+								monsterSidebarListItem = encounter_monster_items[i].filter((d) => this.options.monster == d.id)[0]
+								break;
+							}
+						}
+					}
+						
+					if(monsterSidebarListItem){
+						if(monsterSidebarListItem.monsterData.senses.length > 0){
+							for(let i=0; i < monsterSidebarListItem.monsterData.senses.length; i++){
+								const ftPosition = monsterSidebarListItem.monsterData.senses[i].notes.indexOf('ft.')
+								const range = parseInt(monsterSidebarListItem.monsterData.senses[i].notes.slice(0, ftPosition));
+								if(range > darkvision)
+									darkvision = range;
+							}
+						}
+					}
+				} 
+				this.options.vision = {
+					feet: darkvision.toString(),
+					color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+				}
+			}
+			else{
+				this.options.vision = {
+					feet: 60,
+					color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+				}
+			
+			}
+		}
+
+		if(this.options.devilsight?.feet == undefined){
+		//TO DO VISION UPDATE: get each vision type seperately from darkvision above, update color with TOKEN_SETTINGS
+			this.options.devilsight = {
+				feet: 0,
+				color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+			}
+		}
+		if(this.options.truesight?.feet == undefined){
+			//TO DO VISION UPDATE: get each vision type seperately from darkvision above, update color with TOKEN_SETTINGS
+			this.options.truesight = {
+				feet: 0,
+				color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+			}
+		}
+	}
 	place(animationDuration) {
 		try{
 			if(!this.options.id.includes('exampleToken') && (isNaN(parseFloat(this.options.left)) || isNaN(parseInt(this.options.top)))){// prevent errors with NaN positioned tokens - delete them as catch all. 
@@ -2176,12 +2261,13 @@ class Token {
 			else{
 				old.removeAttr('data-group-id')
 			}		
-
+			this.assignLightVisionOptions();
 			if (old.length > 0) {
 				const hasDraggable = old.hasClass('ui-draggable');
 				
 				if(this.options.type == 'door'){
 					this.options.size = 50;
+					
 					setTokenLight(old, this.options);
 					redraw_light();
 					door_note_icon(this.options.id);
@@ -2560,24 +2646,7 @@ class Token {
 						this.options.restrictPlayerMove = false;
 					}
 				}
-				if(this.options.light1 == undefined){
-					this.options.light1 ={
-						feet: 0,
-						color: 'rgba(255, 255, 255, 1)'
-					}
-				}
-				if(this.options.light2 == undefined){
-					this.options.light2 = {
-						feet: 0,
-						color: 'rgba(142, 142, 142, 1)'
-					}
-				}
-				if(this.options.vision == undefined){
-					this.options.vision = {
-						feet: 60,
-						color: 'rgba(142, 142, 142, 1)'
-					}
-				}
+
 				if((!window.DM && this.options.restrictPlayerMove && !this.isCurrentPlayer() && this.options.share_vision != true &&  this.options.share_vision != window.myUser) || this.options.locked){
 					if(!window.DM || (window.DM && !$('#select_locked>div.ddbc-tab-options__header-heading').hasClass('ddbc-tab-options__header-heading--is-active'))){
 						if (hasDraggable) old.draggable("disable");
@@ -2757,7 +2826,7 @@ class Token {
 				let fs = Math.floor(bar_height / 1.3) + "px";
 				tok.css("font-size",fs);
 				let tokenMultiplierAdjustment = (window.CURRENT_SCENE_DATA?.scaleAdjustment?.x > window.CURRENT_SCENE_DATA?.scaleAdjustment?.y) ? window.CURRENT_SCENE_DATA.scaleAdjustment.x : (window.CURRENT_SCENE_DATA?.scaleAdjustment?.y) ? window.CURRENT_SCENE_DATA.scaleAdjustment.y : 1;
-				
+
 				if(this.options.type == 'door'){
 					this.options.size = 50;
 					setTokenLight(tok, this.options);
@@ -2773,72 +2842,6 @@ class Token {
 				}
 				if(this.options.groupId != undefined)
 					tok.attr('data-group-id', this.options.groupId)
-				if(this.options.light1?.feet == undefined){
-					this.options.light1 ={
-						feet: 0,
-						color: (window.TOKEN_SETTINGS?.light1?.color) ? window.TOKEN_SETTINGS.light1.color : 'rgba(255, 255, 255, 1)'
-					}
-				}
-				if(this.options.light2?.feet == undefined){
-					this.options.light2 = {
-						feet: 0,
-						color: (window.TOKEN_SETTINGS?.light2?.color) ? window.TOKEN_SETTINGS.light2.color : 'rgba(142, 142, 142, 1)'
-					}
-				}
-				if(this.options.vision?.feet == undefined){
-					if(this.isPlayer()){
-			            let pcData = find_pc_by_player_id(this.options.id, false);
-			            let darkvision = 0;
-			            if(pcData && pcData.senses.length > 0) {
-				                for(let i=0; i < pcData.senses.length; i++){
-				                    const ftPosition = pcData.senses[i].distance.indexOf('ft.');
-				                    const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
-				                    if(range > darkvision)
-				                        darkvision = range;
-				                }
-				        }
-			            this.options.vision = {
-			                feet: darkvision.toString(),
-			                color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
-			            }
-			        }
-			        else if(this.isMonster()){
-			            let darkvision = 0;
-			            if(window.monsterListItems){
-			            	let monsterSidebarListItem = this.options.monster == "open5e" ? window.open5eListItems.filter((d) => this.options.itemId == d.id)[0] : window.monsterListItems.filter((d) => this.options.monster == d.id)[0] ;	
-			            	if(!monsterSidebarListItem){
-								for(let i in encounter_monster_items){
-								    if(encounter_monster_items[i].some((d) => this.options.monster == d.id)){
-								        monsterSidebarListItem = encounter_monster_items[i].filter((d) => this.options.monster == d.id)[0]
-								        break;
-								    }
-								}
-							}
-			                   
-							if(monsterSidebarListItem){
-					            if(monsterSidebarListItem.monsterData.senses.length > 0){
-					                for(let i=0; i < monsterSidebarListItem.monsterData.senses.length; i++){
-					                    const ftPosition = monsterSidebarListItem.monsterData.senses[i].notes.indexOf('ft.')
-					                    const range = parseInt(monsterSidebarListItem.monsterData.senses[i].notes.slice(0, ftPosition));
-					                    if(range > darkvision)
-					                        darkvision = range;
-					                }
-					            }
-				       		}
-			       		} 
-			            this.options.vision = {
-			                feet: darkvision.toString(),
-			                color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
-			            }
-			        }
-					else{
-						this.options.vision = {
-							feet: 60,
-							color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
-						}
-					
-					}
-				}
 
 				if(this.options.reveal_light != undefined){
 					if(this.options.reveal_light == 'always' || this.options.reveal_light == true){
@@ -3182,7 +3185,7 @@ class Token {
 							
 							const setDataPos = (id) =>{
 								const idReplaced = id.replaceAll("/", "");
-								let selEl = $(`#aura_${idReplaced}, #light_${idReplaced}, #vision_${idReplaced}, [data-darkness='darkness_${idReplaced}']`);
+								let selEl = $(`#aura_${idReplaced}, #light_${idReplaced}, #vision_${idReplaced}, #vision_devilsight_${idReplaced}, #vision_truesight_${idReplaced}, [data-darkness='darkness_${idReplaced}']`);
 								selEl.each((i, el) => {
 									const $el = $(el);
 									$el.attr({
@@ -4305,19 +4308,23 @@ function setTokenLight (token, options) {
 	const playerNoVision = options.id != playerTokenId && options.share_vision != true && options.share_vision != window.myUser && !(options.share_vision && is_spectator_page())
 	const playerNoTokenIsPc = playerTokenId == undefined && options.itemType == 'pc'
 	const zeroLight = (options.light1?.feet == 0 && options.light2?.feet == 0) || (!options.light1?.feet && !options.light2?.feet)
-	const zeroVision = options.vision?.feet == 0 || !options.vision?.feet;
-
+	const zeroVision = (options.vision?.feet == 0 || !options.vision?.feet) && (options.devilsight?.feet == 0 || !options.devilsight?.feet)&& (options.truesight?.feet == 0 || !options.truesight?.feet);
+	const tokenGrandparent = token.parent().parent();
 	if ((window.DM && zeroLight && zeroVision) || 
 			(!window.DM && playerNoVision && !playerNoTokenIsPc && zeroLight) || 
 			window.CURRENT_SCENE_DATA.disableSceneVision == true || 
 			options.id.includes('exampleToken')) {
-		token.parent().parent().find(`.aura-element-container-clip[id='${options.id}']`).parent().remove();
+		tokenGrandparent.find(`.aura-element-container-clip[id='${options.id}']`).parent().remove();
 		return;
 	} 
 	const innerlightSize = options.light1.feet != undefined ? (options.light1.feet / parseFloat(window.CURRENT_SCENE_DATA.fpsq)) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
 	const outerlightSize = options.light2.feet != undefined ? (options.light2.feet / parseFloat(window.CURRENT_SCENE_DATA.fpsq)) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
 	const visionSize = options.vision.feet != undefined ? (options.vision.feet / parseFloat(window.CURRENT_SCENE_DATA.fpsq)) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor  : 0;
+	const devilsightSize = options.devilsight?.feet != undefined ? (options.devilsight.feet / parseFloat(window.CURRENT_SCENE_DATA.fpsq)) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor : 0;
+	const truesightSize = options.truesight?.feet != undefined ? (options.truesight.feet / parseFloat(window.CURRENT_SCENE_DATA.fpsq)) * window.CURRENT_SCENE_DATA.hpps/window.CURRENT_SCENE_DATA.scale_factor : 0;
+	
 	const tokenId = options.id.replaceAll("/", "").replaceAll('.', '');
+	let tokenVisionLightContainer = tokenGrandparent.find(".aura-element-container-clip[id='" + options.id +"']");
 	if (options.auraislight) {
 
 		const isDoor = options.type == 'door';
@@ -4397,13 +4404,72 @@ function setTokenLight (token, options) {
 							--rotation: ${options.rotation}deg;
 							`;
 		
-
+		const devilsightRadius = devilsightSize ? (devilsightSize + (optionsSize / 2)) : 0;
+	
+		const devilsightBg = `radial-gradient(${options.devilsight.color ? options.devilsight.color : `rgba(142, 142, 142, 1)`} ${devilsightRadius}px, #00000000 ${devilsightRadius}px)`;
+		const totalDevilsightSize = optionsSize + (2 * devilsightSize);
+		const devilsightAbsPosOffset = (optionsSize - totalDevilsightSize) / 2;
+		const devilsightStyles = `width:${totalDevilsightSize }px;
+							height:${totalDevilsightSize}px;
+							left:${devilsightAbsPosOffset}px;
+							top:${devilsightAbsPosOffset}px;
+							background-image:${devilsightBg};
+							left:${optionsLeft + devilsightAbsPosOffset}px;
+							top:${optionsTop + devilsightAbsPosOffset}px;
+							--vision-radius: ${devilsightRadius}px;
+							--vision-color: ${options.devilsight.color};
+							--rotation: ${options.rotation}deg;
+							`;
 		
+		const truesightRadius = truesightSize ? (truesightSize + (optionsSize / 2)) : 0;
+		const truesightBg = `radial-gradient(${options.truesight.color ? options.truesight.color : `rgba(142, 142, 142, 1)`} ${truesightRadius}px, #00000000 ${truesightRadius}px)`;
+		const totaltruesightSize = optionsSize + (2 * truesightSize);
+		const truesightAbsPosOffset = (optionsSize - totaltruesightSize) / 2;
+		const truesightStyles = `width:${totaltruesightSize }px;
+							height:${totaltruesightSize }px;
+							left:${truesightAbsPosOffset}px;
+							top:${truesightAbsPosOffset}px;
+							background-image:${truesightBg};
+							left:${optionsLeft + truesightAbsPosOffset}px;
+							top:${optionsTop + truesightAbsPosOffset}px;
+							--vision-radius: ${truesightRadius}px;
+							--vision-color: ${options.truesight.color};
+							--rotation: ${options.rotation}deg;
+							`;
 
-		token.parent().parent().find(".aura-element-container-clip[id='" + options.id+"']").parent().remove();
+	
+
+		tokenGrandparent.find(".aura-element-container-clip[id='" + options.id+"']").parent().remove();
 
 
-		const lightElement = options.sight == 'devilsight' || options.sight == 'truesight' ? $(`<div class='aura-clip-container'><div class='aura-element-container-clip light' style='clip-path: ${clippath};' id='${options.id}'><div class='aura-element' id="light_${tokenId}" data-id='${options.id}' style='${lightStyles}'></div></div></div><div class='aura-clip-container vision'><div class='aura-element-container-clip vision' style='clip-path: ${devilsightClip};' id='${options.id}'><div class='aura-element darkvision' id="vision_${tokenId}" data-id='${options.id}' style='${visionStyles}'></div></div></div>`) : $(`<div class='aura-clip-container'><div class='aura-element-container-clip light' style='clip-path: ${clippath};' id='${options.id}'><div class='aura-element' id="light_${tokenId}" data-id='${options.id}' style='${lightStyles}'></div><div class='aura-element darkvision' id="vision_${tokenId}" data-id='${options.id}' style='${visionStyles}'></div></div></div>`) 
+		const lightElement = $(`
+			<div class='aura-clip-container'>
+				<div class='aura-element-container-clip light' style='clip-path: ${clippath};' id='${options.id}'>
+					<div class='aura-element' id="light_${tokenId}" data-id='${options.id}' style='${lightStyles}'></div>
+				</div>
+				
+
+			</div>
+			<div class='aura-clip-container vision'>
+				<div class='aura-element-container-clip vision darkvision' style='clip-path: ${clippath};' id='${options.id}'>
+					<div class='aura-element darkvision' id="vision_${tokenId}" data-id='${options.id}' style='${visionStyles}'></div>
+				</div>
+			</div>
+			<div class='aura-clip-container devilsight vision'>
+				${parseInt(options.devilsight.feet) > 0 ? `
+					<div class='aura-element-container-clip vision devilsight' style='clip-path: ${devilsightClip};' id='${options.id}'>
+						<div class='aura-element devilsight' id="vision_devilsight_${tokenId}" data-id='${options.id}' style='${devilsightStyles}'></div>
+					</div>` : ""
+				}
+			</div>
+			<div class='aura-clip-container truesight vision'>
+				${parseInt(options.truesight.feet) > 0 ? `
+					<div class='aura-element-container-clip vision truesight' style='clip-path: ${devilsightClip};' id='${options.id}'>
+						<div class='aura-element truesight' id="vision_truesight_${tokenId}" data-id='${options.id}' style='${truesightStyles}'></div>
+					</div>` : ""
+				}
+			</div>`) 
+		
 
 		lightElement.contextmenu(function(){return false;});
 		$("#light_container").prepend(lightElement);
@@ -4411,85 +4477,86 @@ function setTokenLight (token, options) {
 			debounceLightChecks();
 		}
 		
-		
-
+	
+		tokenVisionLightContainer = tokenGrandparent.find(".aura-element-container-clip[id='" + options.id +"']");
 		if(options.animation?.light && options.animation?.light != 'none'){
 
 			if(options.animation.customLightMask != undefined){
 				if(options.animation.customLightRotate == true){
-					token.parent().parent().find(".aura-element-container-clip[id='" + options.id +"']").attr('data-animation', 'aurafx-rotate')
+					tokenVisionLightContainer.attr('data-animation', 'aurafx-rotate')
 					if(options.animation.customLightRpm){
-						token.parent().parent().find(".aura-element-container-clip[id='" + options.id + "']").css('--custom-rotate-rpm', `${60/options.animation.customLightRpm}s`)
+						tokenVisionLightContainer.css('--custom-rotate-rpm', `${60/options.animation.customLightRpm}s`)
 					}
 				}
 				else{
-					token.parent().parent().find(".aura-element-container-clip[id='" + options.id +"']").attr('data-animation', '')
+					tokenVisionLightContainer.attr('data-animation', '')
 				}
 				if(options.animation.customLightDarkvision != undefined){
-					token.parent().parent().find(".aura-element-container-clip[id='" + options.id +"']").toggleClass('darkvision-animation', options.animation.customLightDarkvision)
+					tokenVisionLightContainer.toggleClass('darkvision-animation', options.animation.customLightDarkvision)
 				}
-				token.parent().parent().find(".aura-element-container-clip[id='" + options.id +"']").attr('data-custom-animation', 'true')
-				token.parent().parent().find(".aura-element-container-clip[id='" + options.id +"']").css('--custom-mask-image', `url('${parse_img(options.animation.customLightMask)}')`)
+				tokenVisionLightContainer.attr('data-custom-animation', 'true')
+				tokenVisionLightContainer.css('--custom-mask-image', `url('${parse_img(options.animation.customLightMask)}')`)
 				if(options.animation.customLightMask?.includes('above-bucket-not-a-url')){
 					setAvttFilePickerCssVar({
 						var: '--custom-mask-image',
-						target: token.parent().parent().find(".aura-element-container-clip[id='" + options.id + "']"),
+						target: tokenVisionLightContainer,
 						url: options.animation.customLightMask
 					})
 				}
 			}
 			else{
-				token.parent().parent().find(".aura-element-container-clip[id='" + options.id +"']").attr('data-animation', options.animation.light)
+				tokenVisionLightContainer.attr('data-animation', options.animation.light)
 			}
 			
 		}
 		else{
-			token.parent().parent().find(".aura-element-container-clip[id='" + options.id +"']").removeAttr('data-animation')
+			tokenVisionLightContainer.removeAttr('data-animation')
 		}
 		if(window.DM){
-			(options.hidden && options.reveal_light == 'never') ? token.parent().parent().find("#vision_" + tokenId).css("opacity", 0.5)
-			: token.parent().parent().find("#vision_" + tokenId).css("opacity", 1)
+			(options.hidden && options.reveal_light == 'never') ? tokenVisionLightContainer.find('[id^="vision_"]').css("opacity", 0.5)
+			: tokenVisionLightContainer.find('[id^="vision_"]').css("opacity", 1)
 		}
 		else{
-			options.hidden ? token.parent().parent().find("#vision_" + tokenId).hide()
-						: token.parent().parent().find("#vision_" + tokenId).show()
+			options.hidden ? tokenVisionLightContainer.find('[id^="vision_"]').hide()
+						: tokenVisionLightContainer.find('[id^="vision_"]').show()
 		}
 		if(totalSize > 0){
-			token.parent().parent().find("#light_" + tokenId).show()		
+			tokenGrandparent.find("#light_" + tokenId).show()		
 		}
 		else{
-			token.parent().parent().find("#light_" + tokenId).hide()
+			tokenGrandparent.find("#light_" + tokenId).hide()
 		}
-		token.parent().parent().find("#light_" + tokenId).toggleClass("islight", true);
+		tokenGrandparent.find("#light_" + tokenId).toggleClass("islight", true);
 	} else {
-		token.parent().parent().find(`.aura-element-container-clip[id='${options.id}']`).parent().remove();
+		tokenVisionLightContainer.parent().remove();
 	}
 	
 
-		
+	tokenVisionLightContainer = tokenGrandparent.find(".aura-element-container-clip[id='" + options.id +"']");
 		
 	if (!window.DM && playerNoVision){
-		token.parent().parent().find("#vision_" + tokenId).toggleClass("notVisible", true);
+		tokenVisionLightContainer.find('[id^="vision_"]').toggleClass("notVisible", true);
 	}		
 	if (!window.DM && playerNoTokenIsPc){
-		token.parent().parent().find("#vision_" + tokenId).toggleClass("notVisible", false);
+		tokenVisionLightContainer.find('[id^="vision_"]').toggleClass("notVisible", false);
 	}	
 		
 
 
 	if(options.type == 'door' && $(`.door-button[data-id='${options.id}']`).hasClass('closed') && $(`.door-button[data-id='${options.id}'] :is(.door, .curtain)`).length > 0){
-		$(".aura-element-container-clip[id='" + options.id +"']").css("display", "none")
+		tokenVisionLightContainer.css("display", "none")
 	}
 	else if(options.type == 'door'){
-		$(".aura-element-container-clip[id='" + options.id +"']").css("display", "")
+		tokenVisionLightContainer.css("display", "")
 	}
+	/*
 	if ((options.sight == 'devilsight' || options.sight == 'truesight') && (options.share_vision == true || options.share_vision == window.myUser || (options.share_vision && is_spectator_page()) || options.id.includes(window.PLAYER_ID) || window.DM || (is_player_id(options.id) && playerTokenId == undefined))){
-		token.parent().parent().find(`.aura-element-container-clip[id='${options.id}']`).toggleClass('devilsight', true);	
-		token.parent().parent().find(`.aura-element-container-clip[id='${options.id}']`).toggleClass('truesight', options.sight=='truesight');
+		tokenGrandparent.find(`.aura-element-container-clip[id='${options.id}']`).toggleClass('devilsight', true);	
+		tokenGrandparent.find(`.aura-element-container-clip[id='${options.id}']`).toggleClass('truesight', options.sight=='truesight');
 	}
 	else{
-		token.parent().parent().find(`.aura-element-container-clip[id='${options.id}']`).toggleClass(['devilsight', 'truesight'], false);
-	}
+		tokenGrandparent.find(`.aura-element-container-clip[id='${options.id}']`).toggleClass(['devilsight', 'truesight'], false);
+	}*/
 
 }
 

--- a/TokenMenu.js
+++ b/TokenMenu.js
@@ -2102,31 +2102,43 @@ function build_token_light_inputs(tokenIds, door=false) {
 		auraRevealVisionEnabled = uniqueAuraRevealVisionValues[0];
 	}
 
-	let aura1Feet = tokens.map(t => t.options.light1.feet);
-	let uniqueAura1Feet = aura1Feet.length === 1 ? aura1Feet[0] : "";
-	let aura2Feet = tokens.map(t => t.options.light2.feet);
-	let uniqueAura2Feet = aura2Feet.length === 1 ? aura2Feet[0] : "";
-	let aura1Color = tokens.map(t => t.options.light1.color);
-	let uniqueAura1Color = aura1Color.length === 1 ? aura1Color[0] : window.TOKEN_SETTINGS?.light1?.color ? window.TOKEN_SETTINGS.light1.color : "";
-	let aura2Color = tokens.map(t => t.options.light2.color);
-	let uniqueAura2Color = aura2Color.length === 1 ? aura2Color[0] : window.TOKEN_SETTINGS?.light2?.color ? window.TOKEN_SETTINGS.light2.color : "";
-	let visionFeet = tokens.map(t => t.options.vision.feet);
-	let uniqueVisionFeet = visionFeet.length === 1 ? visionFeet[0] : "";
-	let visionColor = tokens.map(t => t.options.vision.color);
-	let uniqueVisionColor = visionColor.length === 1 ? visionColor[0] : window.TOKEN_SETTINGS?.vision?.color ? window.TOKEN_SETTINGS.vision.color : "";
+	const aura1Feet = tokens.map(t => t.options.light1.feet);
+	const uniqueAura1Feet = aura1Feet.length === 1 ? aura1Feet[0] : "";
+	const aura2Feet = tokens.map(t => t.options.light2.feet);
+	const uniqueAura2Feet = aura2Feet.length === 1 ? aura2Feet[0] : "";
+	const aura1Color = tokens.map(t => t.options.light1.color);
+	const uniqueAura1Color = aura1Color.length === 1 ? aura1Color[0] : window.TOKEN_SETTINGS?.light1?.color ? window.TOKEN_SETTINGS.light1.color : "";
+	const aura2Color = tokens.map(t => t.options.light2.color);
+	const uniqueAura2Color = aura2Color.length === 1 ? aura2Color[0] : window.TOKEN_SETTINGS?.light2?.color ? window.TOKEN_SETTINGS.light2.color : "";
+	const visionFeet = tokens.map(t => t.options.vision.feet);
+	const uniqueVisionFeet = visionFeet.length === 1 ? visionFeet[0] : "";
+	const visionColor = tokens.map(t => t.options.vision.color);
+	const uniqueVisionColor = visionColor.length === 1 ? visionColor[0] : window.TOKEN_SETTINGS?.vision?.color ? window.TOKEN_SETTINGS.vision.color : "";
+	
+	
+	const devilsightFeet = tokens.map(t => t.options.devilsight.feet);
+	const uniqueDevilsightFeet = devilsightFeet.length === 1 ? devilsightFeet[0] : "";
+	const devilsightColor = tokens.map(t => t.options.devilsight.color);
+	const uniqueDevilsightColor = devilsightColor.length === 1 ? devilsightColor[0] : window.TOKEN_SETTINGS?.devilsight?.color ? window.TOKEN_SETTINGS.devilsight.color : "";
 
-	let light1DaylightColor = tokens.map(t => t.options.light1.daylight);
-	let uniquelight1DaylightColor = light1DaylightColor.length === 1 ? light1DaylightColor[0] == true ? 'active-daylight' : '' : '';
+	const truesightFeet = tokens.map(t => t.options.truesight.feet);
+	const uniqueTruesightFeet = truesightFeet.length === 1 ? truesightFeet[0] : "";
+	const truesightColor = tokens.map(t => t.options.truesight.color);
+	const uniqueTruesightColor = truesightColor.length === 1 ? truesightColor[0] : window.TOKEN_SETTINGS?.truesight?.color ? window.TOKEN_SETTINGS.truesight.color : "";
 
-	let light2DaylightColor = tokens.map(t => t.options.light2.daylight);
-	let uniquelight2DaylightColor = light2DaylightColor.length === 1 ? light2DaylightColor[0] == true ? 'active-daylight' : '' : '';
+
+	const light1DaylightColor = tokens.map(t => t.options.light1.daylight);
+	const uniquelight1DaylightColor = light1DaylightColor.length === 1 ? light1DaylightColor[0] == true ? 'active-daylight' : '' : '';
+
+	const light2DaylightColor = tokens.map(t => t.options.light2.daylight);
+	const uniquelight2DaylightColor = light2DaylightColor.length === 1 ? light2DaylightColor[0] == true ? 'active-daylight' : '' : '';
 
 
 	let upsq = 'ft';
 	if (window.CURRENT_SCENE_DATA.upsq !== undefined && window.CURRENT_SCENE_DATA.upsq.length > 0) {
 		upsq = window.CURRENT_SCENE_DATA.upsq;
 	}
-	let wrapper = $(`
+	const wrapper = $(`
 		<div class="token-config-aura-input">
 
 			<div class="token-config-aura-wrapper">			
@@ -2137,12 +2149,6 @@ function build_token_light_inputs(tokenIds, door=false) {
 						<option value=""></option>
 					</select>
 				</div>
-				<div class="token-image-modal-footer-select-wrapper">
-					<div class="token-image-modal-footer-title">Darkvision Type</div>
-					<select class="token-config-visiontype-preset">
-						<option value=""></option>
-					</select>
-				</div>
 				<div class="token-image-modal-footer-select-wrapper">		
 					<div class="token-image-modal-footer-title">Preset</div>
 					<div class="token-image-modal-footer-title"><button id='editPresets'>Edit</button></div>
@@ -2150,6 +2156,7 @@ function build_token_light_inputs(tokenIds, door=false) {
 						<option value=""></option>
 					</select>
 				</div>
+				<h3 style="margin: 10px 5px 4px 0px;border-bottom: 1px solid #ddd;font-size: 12px;">Vision</h3>
 				<div class="menu-vision-aura">
 					<h3 style="margin-bottom:0px;">Darkvision</h3>
 					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
@@ -2161,6 +2168,29 @@ function build_token_light_inputs(tokenIds, door=false) {
 						<input class="spectrum" name="visionColor" value="${uniqueVisionColor}" >
 					</div>
 				</div>
+				<div class="menu-vision-aura">
+					<h3 style="margin-bottom:0px;">Devilsight</h3>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Radius (${upsq})</div>
+						<input class="vision-radius" name="devilsight" type="text" value="${uniqueDevilsightFeet}" style="width: 3rem" />
+					</div>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Color</div>
+						<input class="spectrum" name="devilsightColor" value="${uniqueDevilsightColor}" >
+					</div>
+				</div>
+				<div class="menu-vision-aura">
+					<h3 style="margin-bottom:0px;">Truesight</h3>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Radius (${upsq})</div>
+						<input class="vision-radius" name="truesight" type="text" value="${uniqueTruesightFeet}" style="width: 3rem" />
+					</div>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Color</div>
+						<input class="spectrum" name="truesightColor" value="${uniqueTruesightColor}" >
+					</div>
+				</div>
+				<h3 style="margin: 10px 5px 4px 0px;border-bottom: 1px solid #ddd;font-size: 12px;">Light</h3>
 				<div class="menu-inner-aura">
 					<h3 style="margin-bottom:0px;">Inner Light</h3>
 					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
@@ -2475,6 +2505,13 @@ function build_token_light_inputs(tokenIds, door=false) {
 		if(selectedPreset.vision.feet){
 			wrapper.find("input[name='vision']").val(selectedPreset.vision.feet);
 		}
+		if(selectedPreset.devilsight?.feet){
+			wrapper.find("input[name='devilsight']").val(selectedPreset.devilsight.feet);
+		}
+		if(selectedPreset.truesight?.feet){
+			wrapper.find("input[name='truesight']").val(selectedPreset.truesight.feet);
+		}
+
 
 		if(selectedPreset.light1.feet){
 			wrapper.find("input[name='light1']").val(selectedPreset.light1.feet);
@@ -2486,7 +2523,12 @@ function build_token_light_inputs(tokenIds, door=false) {
 		if(selectedPreset.vision.color){
 			wrapper.find("input[name='visionColor']").spectrum("set", selectedPreset.vision.color);
 		}
-
+		if(selectedPreset.devilsight?.feet){
+			wrapper.find("input[name='devilsight']").val(selectedPreset.devilsight.feet);
+		}
+		if(selectedPreset.truesight?.feet){
+			wrapper.find("input[name='truesight']").val(selectedPreset.truesight.feet);
+		}
 		if(selectedPreset.light1.color){
 			wrapper.find("input[name='light1Color']").spectrum("set", selectedPreset.light1.color);
 		}
@@ -2501,6 +2543,10 @@ function build_token_light_inputs(tokenIds, door=false) {
 		tokens.forEach(token => {
 			token.options.vision.feet = (selectedPreset.vision.feet) ? selectedPreset.vision.feet : token.options.vision.feet;
 			token.options.vision.color = (selectedPreset.vision.color) ? selectedPreset.vision.color : token.options.vision.color;
+			token.options.devilsight.feet = (selectedPreset.devilsight.feet) ? selectedPreset.devilsight?.feet : token.options.devilsight?.feet;
+			token.options.devilsight.color = (selectedPreset.devilsight.color) ? selectedPreset.devilsight?.color : token.options.devilsight?.color;
+			token.options.truesight.feet = (selectedPreset.truesight.feet) ? selectedPreset.truesight?.feet : token.options.truesight?.feet;
+			token.options.truesight.color = (selectedPreset.truesight.color) ? selectedPreset.truesight?.color : token.options.truesight?.color;
 			token.options.light1.feet = (selectedPreset.light1.feet) ? selectedPreset.light1.feet : token.options.light1.feet;
 			token.options.light2.feet = (selectedPreset.light2.feet) ? selectedPreset.light2.feet : token.options.light2.feet;
 			token.options.light1.color = (selectedPreset.light1.color) ? selectedPreset.light1.color : token.options.light1.color;
@@ -2703,6 +2749,12 @@ function create_light_presets_edit(){
 					Darkvision		
 				</th>
 				<th>
+					Devilsight		
+				</th>
+				<th>
+					Truesight		
+				</th>
+				<th>
 					Inner Light			
 				</th>
 				<th>
@@ -2727,6 +2779,26 @@ function create_light_presets_edit(){
 					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
 						<div class="token-image-modal-footer-title">Color</div>
 						<input class="spectrum" name="visionColor" value="${(window.LIGHT_PRESETS[i].vision?.color) ? window.LIGHT_PRESETS[i].vision.color : `rgba(0, 0, 0, 0)`}" >
+					</div>
+				</td>
+				<td class="menu-devilsight-aura">
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Radius (${upsq})</div>
+						<input class="devilsight-radius" name="devilsight" type="text" value="${(window.LIGHT_PRESETS[i].devilsight?.feet) ? window.LIGHT_PRESETS[i].devilsight.feet : ``}" style="width: 3rem" />
+					</div>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Color</div>
+						<input class="spectrum" name="devilsightColor" value="${(window.LIGHT_PRESETS[i].devilsight?.color) ? window.LIGHT_PRESETS[i].devilsight.color : `rgba(0, 0, 0, 0)`}" >
+					</div>
+				</td>
+				<td class="menu-truesight-aura">
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Radius (${upsq})</div>
+						<input class="truesight-radius" name="truesight" type="text" value="${(window.LIGHT_PRESETS[i].truesight?.feet) ? window.LIGHT_PRESETS[i].truesight.feet : ``}" style="width: 3rem" />
+					</div>
+					<div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+						<div class="token-image-modal-footer-title">Color</div>
+						<input class="spectrum" name="truesightColor" value="${(window.LIGHT_PRESETS[i].truesight?.color) ? window.LIGHT_PRESETS[i].truesight.color : `rgba(0, 0, 0, 0)`}" >
 					</div>
 				</td>
 				<td class="menu-inner-aura">
@@ -2798,6 +2870,10 @@ function create_light_presets_edit(){
 			name: 'New Preset',
 			vision: {
 			},
+			devilsight: {
+			},
+			truesight: {
+			},
 			light1: {
 			},
 			light2: {
@@ -2840,7 +2916,7 @@ function create_animation_presets_edit(isVision = false){
 					RPM
 				</th>
 				${isVision ? `<th>
-					Apply to Darkvision			
+					Apply to Vision			
 				</th>` : ``}
 			</tr>
 			`)

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1352,18 +1352,26 @@ async function create_and_place_token(listItem, hidden = undefined, specificImag
                     }
                     break;
             }
-            if(listItem.monsterData.senses.length > 0 && foundOptions.vision == undefined){
-                //TO DO VISION UPDATE: Get other monster vision types
-                let darkvision = 0;
-                for(let i=0; i < listItem.monsterData.senses.length; i++){
-                    const ftPosition = listItem.monsterData.senses[i].notes.indexOf('ft.')
-                    const range = parseInt(listItem.monsterData.senses[i].notes.slice(0, ftPosition));
-                    if(range > darkvision)
-                        darkvision = range;
+            if(listItem.monsterData.senses.length > 0){
+               
+                const vision = get_monster_senses(listItem.monsterData.senses);
+                if(foundOptions.vision == undefined){
+                    options.vision = {
+                        feet: vision.darkvision.toString(),
+                        color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+                    }
                 }
-                options.vision = {
-                    feet: darkvision.toString(),
-                    color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+                if(foundOptions.truesight == undefined){
+                    options.truesight = {
+                        feet: vision.truesight.toString(),
+                        color: (window.TOKEN_SETTINGS?.truesight?.color) ? window.TOKEN_SETTINGS.truesight.color : 'rgba(142, 142, 142, 1)'
+                    }
+                }
+                if(foundOptions.devilsight == undefined){
+                    options.devilsight = {
+                        feet: vision.devilsight.toString(),
+                        color: (window.TOKEN_SETTINGS?.devilsight?.color) ? window.TOKEN_SETTINGS.devilsight.color : 'rgba(142, 142, 142, 1)'
+                    }
                 }
             }
             break;
@@ -3063,46 +3071,67 @@ function display_aoe_token_configuration_modal(listItem, placedToken = undefined
             color: window.TOKEN_SETTINGS?.truesight?.color ? window.TOKEN_SETTINGS?.truesight?.color : 'rgba(142, 142, 142, 1)'
         }
     }
+    let vision = {
+        darkvision: 0,
+        devilsight: 0,
+        truesight: 0
+    }
+    if(listItem.isTypePC()){
+        let pcData = find_pc_by_player_id(listItem.id);
+        let vision = {
+            darkvision: 0,
+            devilsight: 0,
+            truesight: 0
+        }
+        if(pcData.senses.length > 0)
+        {
+            const pcSenses = {
+                darkvision: "darkvision",
+                tremorsense: "darkvision",
+                blindsight: "truesight",
+                truesight: "truesight"
+            }
+            for(let i=0; i < pcData.senses.length; i++){
+                const name = pcData.senses[i].name?.toLowerCase();
+                const ftPosition = pcData.senses[i].distance.indexOf('ft.');
+                const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
+                if(range > vision[pcSenses[name]])
+                    vision[pcSenses[name]] = range;
+            }
+        }
+        customization.tokenOptions.vision = {
+            feet: vision.darkvision.toString(),
+            color: window.TOKEN_SETTINGS?.vision?.color ? window.TOKEN_SETTINGS?.vision?.color : 'rgba(142, 142, 142, 1)'
+        }
+        customization.tokenOptions.truesight = {
+            feet: vision.truesight.toString(),
+            color: (window.TOKEN_SETTINGS?.truesight?.color) ? window.TOKEN_SETTINGS.truesight.color : 'rgba(142, 142, 142, 1)'
+        }
+        customization.tokenOptions.devilsight = {
+            feet: vision.devilsight.toString(),
+            color: (window.TOKEN_SETTINGS?.devilsight?.color) ? window.TOKEN_SETTINGS.devilsight.color : 'rgba(142, 142, 142, 1)'
+        }
+    }
+    else if(listItem.isTypeMonster() || listItem.isTypeOpen5eMonster()){
+        vision = get_monster_senses(listItem.monsterData.senses);
+    }
     if(customization.tokenOptions.vision?.feet == undefined){
-        if(listItem.isTypePC()){
-            let pcData = find_pc_by_player_id(listItem.id);
-            let darkvision = 0;
-            if(pcData.senses.length > 0)
-            {
-                for(let i=0; i < pcData.senses.length; i++){
-                    const ftPosition = pcData.senses[i].distance.indexOf('ft.');
-                    const range = parseInt(pcData.senses[i].distance.slice(0, ftPosition));
-                    if(range > darkvision)
-                        darkvision = range;
-                }
-            }
-            customization.tokenOptions.vision = {
-                feet: darkvision.toString(),
-                color: window.TOKEN_SETTINGS?.vision?.color ? window.TOKEN_SETTINGS?.vision?.color : 'rgba(142, 142, 142, 1)'
-            }
+        customization.tokenOptions.vision = {
+            feet: vision.darkvision.toString(),
+            color: window.TOKEN_SETTINGS?.vision?.color ? window.TOKEN_SETTINGS?.vision?.color : 'rgba(142, 142, 142, 1)'
         }
-        else if(listItem.isTypeMonster() || listItem.isTypeOpen5eMonster()){
-            let darkvision = 0;
-            if(listItem.monsterData.senses.length > 0)
-            {
-                for(let i=0; i < listItem.monsterData.senses.length; i++){
-                    const ftPosition = listItem.monsterData.senses[i].notes.indexOf('ft.')
-                    const range = parseInt(listItem.monsterData.senses[i].notes.slice(0, ftPosition));
-                    if(range > darkvision)
-                        darkvision = range;
-                }
-            }
+    }
+    if(customization.tokenOptions.truesight?.feet == undefined){
+        customization.tokenOptions.truesight = {
+            feet: vision.truesight.toString(),
+            color: (window.TOKEN_SETTINGS?.truesight?.color) ? window.TOKEN_SETTINGS.truesight.color : 'rgba(142, 142, 142, 1)'
+        }
+    }
+    if(customization.tokenOptions.devilsight?.feet == undefined){
 
-            customization.tokenOptions.vision = {
-                feet: darkvision.toString(),
-                color: window.TOKEN_SETTINGS?.vision?.color ? window.TOKEN_SETTINGS?.vision?.color : 'rgba(142, 142, 142, 1)'
-            }
-        }
-        else{
-            customization.tokenOptions.vision = {
-                feet: '60',
-                color: window.TOKEN_SETTINGS?.vision?.color ? window.TOKEN_SETTINGS?.vision?.color : 'rgba(142, 142, 142, 1)'
-            }
+        customization.tokenOptions.devilsight = {
+            feet: vision.devilsight.toString(),
+            color: (window.TOKEN_SETTINGS?.devilsight?.color) ? window.TOKEN_SETTINGS.devilsight.color : 'rgba(142, 142, 142, 1)'
         }
     }
     if(customization.tokenOptions.light1?.feet == undefined){
@@ -4497,8 +4526,12 @@ function create_token_copy_inside(listItem, open5e = false){
         options.sizeId = listItem.monsterData.sizeId;
         // TODO: handle custom sizes
     }
-    //TO DO VISION UPDATE: other senses for vision
-    let darkvision = 0;
+    
+    let vision = {
+        darkvision: 0,
+        devilsight: 0,
+        truesight: 0
+    }
     if(window.monsterListItems){
         let monsterSidebarListItem = open5e ? window.open5eListItems.filter((d) => listItem.id == d.id)[0] : window.monsterListItems.filter((d) => listItem.id == d.id)[0]; 
         if(!monsterSidebarListItem){
@@ -4512,18 +4545,44 @@ function create_token_copy_inside(listItem, open5e = false){
            
         if(monsterSidebarListItem){
             if(monsterSidebarListItem.monsterData.senses.length > 0){
+       
+                const monsterSenseIds = {
+                    1 : 'truesight', //blind sightw
+                    2 : 'darkvision',
+                    4 : 'truesight'
+                }	
                 for(let i=0; i < monsterSidebarListItem.monsterData.senses.length; i++){
+                    const senseKey = i+1;
+            
                     const ftPosition = monsterSidebarListItem.monsterData.senses[i].notes.indexOf('ft.')
+                    
                     const range = parseInt(monsterSidebarListItem.monsterData.senses[i].notes.slice(0, ftPosition));
-                    if(range > darkvision)
-                        darkvision = range;
+                    if(monsterSenseIds[senseKey] == undefined && range>darkvision){
+                        vision.darkvision = range;
+                    } else{
+                        if(monsterSenseIds[senseKey] == 'darkvision'){
+                            const isDevilsight = monsterSidebarListItem.monsterData.senses[i].notes.includes(/magical darkness|devilsight|devil sight|devil's sight/gi);
+                            vision.devilsight = range;
+                            continue;
+                        }
+                        vision[monsterSenseIds[senseKey]] = range;
+                    }
+                        
                 }
             }
         }
     } 
     options.vision = {
-        feet: darkvision.toString(),
+        feet: vision.darkvision.toString(),
         color: (window.TOKEN_SETTINGS?.vision?.color) ? window.TOKEN_SETTINGS.vision.color : 'rgba(142, 142, 142, 1)'
+    }
+    options.truesight = {
+        feet: vision.truesight.toString(),
+        color: (window.TOKEN_SETTINGS?.truesight?.color) ? window.TOKEN_SETTINGS.truesight.color : 'rgba(142, 142, 142, 1)'
+    }
+    options.devilsight = {
+        feet: vision.devilsight.toString(),
+        color: (window.TOKEN_SETTINGS?.devilsight?.color) ? window.TOKEN_SETTINGS.devilsight.color : 'rgba(142, 142, 142, 1)'
     }
     
     options.monster = 'customStat'

--- a/TokensPanel.js
+++ b/TokensPanel.js
@@ -1188,6 +1188,8 @@ async function create_and_place_token(listItem, hidden = undefined, specificImag
 
     if(options.alternativeImagesCustomizations != undefined && options.alternativeImagesCustomizations[options.imgsrc] != undefined){
         const visionOptions = {
+            'devilsight': {...options.devilsight},
+            'truesight': {...options.truesight},
             'vision': {...options.vision},
             'light1': {...options.light1},
             'light2': {...options.light2}
@@ -1199,6 +1201,12 @@ async function create_and_place_token(listItem, hidden = undefined, specificImag
         }
         if(options.vision != undefined && options.vision?.feet == undefined && visionOptions?.vision?.feet != undefined){
             options.vision.feet = visionOptions.vision.feet;
+        }
+        if(options.devilsight != undefined && options.devilsight?.feet == undefined && devilsightOptions?.devilsight?.feet != undefined){
+            options.devilsight.feet = devilsightOptions.devilsight.feet;
+        }
+        if(options.truesight != undefined && options.truesight?.feet == undefined && truesightOptions?.truesight?.feet != undefined){
+            options.truesight.feet = truesightOptions.truesight.feet;
         }
          if(options.light1 != undefined && options.light1?.feet == undefined && visionOptions?.light1?.feet != undefined){
             options.light1.feet = visionOptions.light1.feet;
@@ -1345,6 +1353,7 @@ async function create_and_place_token(listItem, hidden = undefined, specificImag
                     break;
             }
             if(listItem.monsterData.senses.length > 0 && foundOptions.vision == undefined){
+                //TO DO VISION UPDATE: Get other monster vision types
                 let darkvision = 0;
                 for(let i=0; i < listItem.monsterData.senses.length; i++){
                     const ftPosition = listItem.monsterData.senses[i].notes.indexOf('ft.')
@@ -3041,7 +3050,19 @@ function display_aoe_token_configuration_modal(listItem, placedToken = undefined
     if (!specificBorderColorValue || (listItem.isTypePC() && targetOptions.playerThemeBorder != false)) {
         borderColorWrapper.hide();
     }
-
+    //TO DO VISION UPDATE: add detection for pc/monsters
+    if(customization.tokenOptions.devilsight?.feet == undefined){
+        customization.tokenOptions.devilsight = {
+            feet: '0',
+            color: window.TOKEN_SETTINGS?.devilsight?.color ? window.TOKEN_SETTINGS?.devilsight?.color : 'rgba(142, 142, 142, 1)'
+        }
+    }
+    if(customization.tokenOptions.truesight?.feet == undefined){
+        customization.tokenOptions.truesight = {
+            feet: '0',
+            color: window.TOKEN_SETTINGS?.truesight?.color ? window.TOKEN_SETTINGS?.truesight?.color : 'rgba(142, 142, 142, 1)'
+        }
+    }
     if(customization.tokenOptions.vision?.feet == undefined){
         if(listItem.isTypePC()){
             let pcData = find_pc_by_player_id(listItem.id);
@@ -3097,13 +3118,16 @@ function display_aoe_token_configuration_modal(listItem, placedToken = undefined
         }
     }
 
-
-    let uniqueVisionFeet = customization.tokenOptions.vision.feet;
-    let uniqueVisionColor = customization.tokenOptions.vision.color;
-    let uniqueLight1Feet = customization.tokenOptions.light1.feet;
-    let uniqueLight2Feet = customization.tokenOptions.light2.feet;
-    let uniqueLight1Color = customization.tokenOptions.light1.color;
-    let uniqueLight2Color = customization.tokenOptions.light2.color;
+    const uniqueDevilsightFeet = customization.tokenOptions.devilsight.feet;
+    const uniqueDevilsightColor = customization.tokenOptions.devilsight.color;
+    const uniqueTruesightFeet = customization.tokenOptions.truesight.feet;
+    const uniqueTruesightColor = customization.tokenOptions.truesight.color;
+    const uniqueVisionFeet = customization.tokenOptions.vision.feet;
+    const uniqueVisionColor = customization.tokenOptions.vision.color;
+    const uniqueLight1Feet = customization.tokenOptions.light1.feet;
+    const uniqueLight2Feet = customization.tokenOptions.light2.feet;
+    const uniqueLight1Color = customization.tokenOptions.light1.color;
+    const uniqueLight2Color = customization.tokenOptions.light2.color;
 
     const lightOption = {
     name: "auraislight",
@@ -3139,6 +3163,28 @@ function display_aoe_token_configuration_modal(listItem, placedToken = undefined
                     <div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
                         <div class="token-image-modal-footer-title">Color</div>
                         <input class="spectrum" name="visionColor" value="${uniqueVisionColor}" >
+                    </div>
+                </div>
+                <div class="menu-vision-aura">
+                    <h3 style="margin-bottom:0px;">Devilsight</h3>
+                    <div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+                        <div class="token-image-modal-footer-title">Radius (${window.CURRENT_SCENE_DATA.upsq})</div>
+                        <input class="vision-radius" name="devilsight" type="text" value="${uniqueDevilsightFeet}" style="width: 3rem" />
+                    </div>
+                    <div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+                        <div class="token-image-modal-footer-title">Color</div>
+                        <input class="spectrum" name="devilsightColor" value="${uniqueDevilsightColor}" >
+                    </div>
+                </div>
+                <div class="menu-vision-aura">
+                    <h3 style="margin-bottom:0px;">Truesight</h3>
+                    <div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+                        <div class="token-image-modal-footer-title">Radius (${window.CURRENT_SCENE_DATA.upsq})</div>
+                        <input class="vision-radius" name="truesight" type="text" value="${uniqueTruesightFeet}" style="width: 3rem" />
+                    </div>
+                    <div class="token-image-modal-footer-select-wrapper" style="padding-left: 2px">
+                        <div class="token-image-modal-footer-title">Color</div>
+                        <input class="spectrum" name="truesightColor" value="${uniqueTruesightColor}" >
                     </div>
                 </div>
                 <div class="menu-inner-aura">
@@ -3346,9 +3392,13 @@ function display_aoe_token_configuration_modal(listItem, placedToken = undefined
     let tokenOptionsButton = build_override_token_options_button(sidebarPanel, listItem, placedToken, targetOptions, function(name, value) {
         customization.setTokenOption(name, value);
     }, function () {
+        let devilsightInput = $("input[name='devilsightColor']").spectrum("get");
+        let truesightInput = $("input[name='truesightColor']").spectrum("get");
         let visionInput = $("input[name='visionColor']").spectrum("get");
         let light1Input = $("input[name='light1Color']").spectrum("get");
         let light2Input = $("input[name='light2Color']").spectrum("get");
+        customization.setTokenOption('devilsight.color', `rgba(${devilsightInput._r}, ${devilsightInput._g}, ${devilsightInput._b}, ${devilsightInput._a})`);
+        customization.setTokenOption('truesight.color', `rgba(${truesightInput._r}, ${truesightInput._g}, ${truesightInput._b}, ${truesightInput._a})`);
         customization.setTokenOption('vision.color', `rgba(${visionInput._r}, ${visionInput._g}, ${visionInput._b}, ${visionInput._a})`);
         customization.setTokenOption(`light1.color`, `rgba(${light1Input._r}, ${light1Input._g}, ${light1Input._b}, ${light1Input._a})`);
         customization.setTokenOption(`light2.color`, `rgba(${light2Input._r}, ${light2Input._g}, ${light2Input._b}, ${light2Input._a})`);
@@ -4447,7 +4497,7 @@ function create_token_copy_inside(listItem, open5e = false){
         options.sizeId = listItem.monsterData.sizeId;
         // TODO: handle custom sizes
     }
-
+    //TO DO VISION UPDATE: other senses for vision
     let darkvision = 0;
     if(window.monsterListItems){
         let monsterSidebarListItem = open5e ? window.open5eListItems.filter((d) => listItem.id == d.id)[0] : window.monsterListItems.filter((d) => listItem.id == d.id)[0]; 
@@ -4932,7 +4982,7 @@ function convert_open5e_monsterData(monsterData){
 
 
         let convertedSenses = [];
-        
+        //TO DO VISION UPDATE: senseId's here to reference for fetching other senses
         if(monsterData.blindsight_range){
             convertedSenses.push({senseId: 1, notes: `${monsterData.blindsight_range} ft.`})
         }

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -2768,13 +2768,15 @@ body>[class*='styles_mobileNav']>button{
 }*/
 
 /* .ct-sidebar__pane-content, */
+body .sidebar__pane-content{
+    max-width: 600px !important;
+    width: var(--sidebar-width, 340px) !important;
+}
 body:not(.encounter-builder-page) .sidebar__pane-content {
     position: absolute;
     right: 0;
     top: 28px;
     height: calc(100vh - 30px) !important;
-    width: var(--sidebar-width, 340px) !important;
-    max-width: 600px !important;
 }
 body .gamelogcontainer .sidebar__pane-content {
     top: 0px !important;

--- a/abovevtt.css
+++ b/abovevtt.css
@@ -9253,7 +9253,7 @@ body:not(.body-rpgcampaign) .site-bar{
     z-index: 8;
     mix-blend-mode: lighten;
 }
-.aura-clip-container.vision:has(.devilsight){
+.aura-clip-container:is(.devilsight, .truesight){
     z-index: 20 !important;
 }
 [data-darkness]{
@@ -9349,7 +9349,7 @@ body.preventSelectDefinitelyNot .token.declutterToken[style*='opacity: 0.5']{
     mix-blend-mode: lighten;
 }
 
-.aura-element-container-clip.vision.devilsight{
+.aura-element-container-clip.vision:is(.devilsight, .truesight){
     z-index: 20 !important;
 }
 #map_items{
@@ -10863,19 +10863,19 @@ button.resistanceButton.qrm_buttons_bar span {
     background-image: radial-gradient(rgba(var(--color1), calc(var(--opacity1) * var(--opacity))) var(--light1-blur-size), rgba(var(--color2), calc(var(--opacity2) * var(--opacity))) calc(var(--light1-blur-size) * 1.3) var(--light2-blur-size), transparent var(--transparency-blur-size)) !important;
 }
 
-[data-animation='static-blur-fx'] .darkvision,
-[data-animation='flicker-fx'] .darkvision{
+[data-animation='static-blur-fx'] :is(.darkvision, .devilsight, .truesight),
+[data-animation='flicker-fx'] :is(.darkvision, .devilsight, .truesight){
     background-image: radial-gradient(var(--vision-color) calc(var(--vision-radius) * 0.9), #00000000 var(--vision-radius)) !important;
 }
 [data-custom-animation] .islight,
 .aura-element[data-custom-animation],
-[data-custom-animation].darkvision-animation .darkvision{
+[data-custom-animation].darkvision-animation :is(.darkvision, .devilsight, .truesight){
  -webkit-mask-image: var(--custom-mask-image);
  -webkit-mask-size: contain;
 }
 [data-animation='aurafx-rotate'] .islight,
 .aura-element[data-animation='aurafx-rotate'][id*='aura_'],
-[data-animation='aurafx-rotate'].darkvision-animation .darkvision {
+[data-animation='aurafx-rotate'].darkvision-animation :is(.darkvision, .devilsight, .truesight) {
     animation: aurafx-rotate var(--custom-rotate-rpm, 40s) infinite linear;
     transform: scale(var(--animation-scale)) rotate(calc(1deg * var(--animation-rotation, 0)));
 }
@@ -11643,8 +11643,12 @@ table#aura_presets_properties  {
     border-collapse: unset;
     border-spacing: 10px;    
 }
-
-
+table#light_presets_properties :is(td, th):has(.token-image-modal-footer-title) {
+    width: 120px;
+}
+table#light_presets_properties div.token-image-modal-footer-title{
+    font-size: 8px;
+}
 #light_presets_properties div.removePreset svg rect,
 #animation_presets_properties div.removePreset svg rect,
 #aura_presets_properties div.removePreset svg rect{

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "AboveVTT",
 	"description": "Integrated VTT for D&DBeyond",
-	"version": "1.53",
+	"version": "1.54",
 	"content_scripts": [
 		{
 			"matches": [


### PR DESCRIPTION
Adds truesight and devilsight to token vision options. This eliminates the need for a second token grouped with a pc if they have 2 vision types. 

<img width="1131" height="702" alt="image" src="https://github.com/user-attachments/assets/0884ae6d-f48f-4a1d-a772-8a5eb5186d47" />


I still need to: 

- [x] Add preset settings
- [x] Add token default options, global and per token
- [x] Add logic for picking up devilsight/truesight seperately from pc and monster statblocks