### PR TITLE
Add warning and download export button to reset link confirmation box

### DIFF
--- a/CampaignPage.mjs
+++ b/CampaignPage.mjs
@@ -1,5 +1,5 @@
 /** CampaignPage.js - functions that only execute on the campaign page */
-
+import { init_audio_mixer } from './audio/index.mjs'
 $(function() {
   if (is_campaign_page()) {
     window.gameIndexedDb = undefined;
@@ -197,7 +197,7 @@ function inject_dm_join_button() {
   if ($(".ddb-campaigns-detail-body-dm-notes-private").length === 0) return; // The owner of the campaign (the DM) is the only one with private notes on the campaign page
   // The owner of the campaign (the DM) is the only one with private notes on the campaign page
   console.log("inject_dm_join_button");
-
+  
   $(".ddb-campaigns-invite-container").append(`
     <div class="above-vtt-warning-div" style="display: flex;flex-direction: column; align-items: center;justify-content: center; text-align: center;padding: 5px;border: 2px solid #c53131; border-radius: 4px;">
       <div class="above-vtt-warning-secondary-div">
@@ -238,6 +238,33 @@ function inject_dm_join_button() {
     $(e.currentTarget).removeClass("button-loading");
   });
 
+  const resetObserver = new MutationObserver(async (mutationList, observer) => {
+     if($('.t-reset-campaign-modal').length>0 && $('.t-reset-campaign-modal #takeAbovevttExport').length == 0){
+        const avttExportContainer = $(`<div id="avttExportContainer" style="margin: 15px;
+              border: 1px solid #ddd;
+              display: flex;
+              flex-wrap: wrap;
+              max-width: 270px;
+              justify-content: center;
+              text-align: center;
+              padding: 5px;
+          ">
+          <span style="color:#F00; margin:3px;">WARNING: You will lose your AboveVTT cloud data if you continue without having an export.</span>
+          <button class='button' id='takeAbovevttExport'>Download AboveVTT Export</button>
+        </div>`);
+
+        avttExportContainer.find('button').on('click.takeExport', (e)=> {export_file('#avttExportContainer')});
+        $('.ddb-modal-reset-invite-code').before(avttExportContainer);
+        const aboveApi = await new AboveApi();
+        window.JOURNAL = await new JournalManager(window.gameId);
+        window.ScenesHandler = new ScenesHandler();
+        window.ScenesHandler.scenes = await AboveApi.getSceneList();
+        await init_audio_mixer();
+        fetch_token_customizations();
+      
+     }
+  })
+  resetObserver.observe(document.querySelector("body"), { childList: true, subtree: true });
 }
 
 function inject_player_join_buttons() {

--- a/Journal.js
+++ b/Journal.js
@@ -266,7 +266,7 @@ class JournalManager{
 			if(is_abovevtt_page()){
 				this.build_journal();
 			}
-			if(window.DM && !is_gamelog_popout()){
+			if(window.DM && !is_gamelog_popout() && is_abovevtt_page()){
 				// also sync the journal
 				window.JOURNAL?.sync();
 			}

--- a/Load.js
+++ b/Load.js
@@ -208,13 +208,19 @@
                   "ChatObserver.js",
                   "MonsterStatBlock.js",
                   "MonsterDice.js",
-                  "CampaignPage.js"
-              ] : pgType === "campaign" ? [      
+                  "CampaignPage.mjs"
+              ] : pgType === "campaign" ? [    
+                  "jquery-3.6.0.min.js",  
                   "environment.js",
                   "CoreFunctions.js", 		
-                  "DDBApi.js", 
+                  "DDBApi.js",
+                  "AboveApi.js",
+                  "audio/index.mjs",
+                  "Journal.js",
+                  "TokenCustomization.js",
+                  "ScenesHandler.js",
                   "Settings.js",
-                  "CampaignPage.js"
+                  "CampaignPage.mjs"
               ] : [
                     "Load.js",//load Loader on VTT full pages (for iframe inject - see below)
                     ...avttScripts,

--- a/Settings.js
+++ b/Settings.js
@@ -1072,7 +1072,7 @@ function b64DecodeUnicode(str) {
 
 
 
-function download(data, filename, type) {
+function download(data, filename, type, appendTo = document.body) {
     let file = new Blob([data], {type: type});
     if (window.navigator.msSaveOrOpenBlob) // IE10+
         window.navigator.msSaveOrOpenBlob(file, filename);
@@ -1081,10 +1081,11 @@ function download(data, filename, type) {
                 url = URL.createObjectURL(file);
         a.href = url;
         a.download = filename;
-        document.body.appendChild(a);
+		a.id = 'downloadAvttExportLink'
+        $(appendTo).append(a);
         a.click();
         setTimeout(function() {
-            document.body.removeChild(a);
+            $('#downloadAvttExportLink').remove();
             window.URL.revokeObjectURL(url);
         }, 0);
     }
@@ -1947,7 +1948,7 @@ function export_audio_csv() {
 
 
 
-function export_file() {
+function export_file(downloadAppendTo) {
 	build_import_loading_indicator('Preparing Export File');
 	let DataFile = {
 		version: 2,
@@ -1969,7 +1970,7 @@ function export_file() {
 			DataFile.soundpads = window.SOUNDPADS;
 			DataFile.mixerstate = window.MIXER.state();
 			DataFile.tracklibrary = Array.from(window.TRACK_LIBRARY.map().entries());
-			download(b64EncodeUnicode(JSON.stringify(DataFile,null,"\t")),`${window.CAMPAIGN_INFO.name}-${datetime}.abovevtt`,"text/plain");
+			download(b64EncodeUnicode(JSON.stringify(DataFile,null,"\t")),`${window.CAMPAIGN_INFO.name}-${datetime}.abovevtt`,"text/plain", downloadAppendTo);
 		})
 		.catch(error => {	
 			firstError = true;	//data is probably too large to get from https - fallback on individually grabbing scenes.

--- a/audio/mixer.js
+++ b/audio/mixer.js
@@ -152,7 +152,8 @@ class Mixer extends EventTarget {
     constructor() {
         super();
         this._localStorageKey = `audio.mixer.${window.gameId}.${playerID()}`;
-        this.syncPlayers(false);
+        if(is_abovevtt_page())
+            this.syncPlayers(false);
     }
 
     /**

--- a/manifest.json
+++ b/manifest.json
@@ -60,7 +60,7 @@
 			"DDBApi.js",
 			"AjaxQueueModule.js",
 			"CoreFunctions.js",
-			"CampaignPage.js",
+			"CampaignPage.mjs",
 			"Startup.mjs",
 			"CharactersPage.js",
 			"EncounterHandler.js",


### PR DESCRIPTION
I had to adjust the download section a bit as adding the download link button to just the body made it's event not fire. I assume DDB has click events outside that container blocked while it's open.

Also had to setup loading of some data on detecting that window to include local data in the export. I'm not 100% we need to include this datga but it's not obvious it's only scene data otherwise and it's nice to have.