### PR TITLE
Fix - issue with vision failing to reveal tokens on linux machines running chromium browsers

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -2194,6 +2194,7 @@ function redraw_drawn_light(darknessMoved = false){
 function setVisionLightOffscreenCanvas(){
 	//To Do: look at zeroing these out when no bucket fills, vision are present in scene to save memory
 	const {sceneWidth, sceneHeight} = getSceneMapSize()
+	const isLinuxBlink = /Linux/.test(navigator.userAgent) && (Boolean(window.chrome) || /Chrome|Chromium/.test(navigator.userAgent));
 	function create_or_set_offscreen_canvas(name, ctx = true, readFrequently = false){
 		if(name==undefined)
 			return;
@@ -2208,11 +2209,11 @@ function setVisionLightOffscreenCanvas(){
 	}
 
 	create_or_set_offscreen_canvas('offScreenCombine'); // general purpose offscreen canvas used for repetative short term things like combining vision circles, line of sight, fog, applying blurs etc. Each usage is contained and clears or fills a rect the size of the canvas
-	create_or_set_offscreen_canvas('lightInLos'); // used to store token and drawn light thats in line of sight, checked against to reveal/hide tokens
+	create_or_set_offscreen_canvas('lightInLos', true, isLinuxBlink); // used to store token and drawn light thats in line of sight, checked against to reveal/hide tokens
 	create_or_set_offscreen_canvas('offscreenCanvasMask'); // used to combine line of sights and drawn to raycastingCanvas after
 	create_or_set_offscreen_canvas('moveOffscreenCanvasMask', true, true); // used to store moveable area that's checked against while moving tokens
 	create_or_set_offscreen_canvas('devilsightCanvas'); //devilsight canvas is used to combine with darkness aoe (or other magical darkness sources if implemented)
-	create_or_set_offscreen_canvas('truesightCanvas'); //this is stored and checked against in vision checks for invisible creatures (also works like devilsight for magical darkness)
+	create_or_set_offscreen_canvas('truesightCanvas', true, isLinuxBlink); //this is stored and checked against in vision checks for invisible creatures (also works like devilsight for magical darkness)
 }
 function open_portal_config(){
 


### PR DESCRIPTION
set readFrequently true for linux/blink, leave the rest at defaults. fixes Skia GPU bug where tokens that should be visible are not

[[Bug]: Darkvision & Truesight fail to reveal tokens on Linux Chromium](https://github.com/cyruzzo/AboveVTT/issues/4839)